### PR TITLE
feat: add developer-portal workflows

### DIFF
--- a/.github/workflows/deploy-developer-portal.yml
+++ b/.github/workflows/deploy-developer-portal.yml
@@ -1,0 +1,23 @@
+# This workflow is triggered whenever the main branch is updated.
+name: Deploy to DevHub
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  trigger-deployment:
+    name: Trigger deployment
+    runs-on: ubuntu-latest
+    steps:
+      - uses: octokit/request-action@v2.x
+        name: Trigger deployment
+        with:
+          route: POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches
+          owner: shopware
+          repo: developer-portal
+          ref: main
+          workflow_id: checkout-test-build-deploy.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.DEV_HUB_PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/developer-portal-healthcheck.yml
+++ b/.github/workflows/developer-portal-healthcheck.yml
@@ -1,0 +1,19 @@
+# This workflow triggers a Healthcheck workflow in developer-portal for every PR targeting main branch.
+name: Healthcheck
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  create-healthcheck:
+    uses: shopware/developer-portal/.github/workflows/healthcheck.yml@main
+    with:
+      owner: ${{ github.repository_owner }}
+      repo: ${{ github.event.repository.name }}
+      branch: ${{ github.event.pull_request.head.ref }}
+      sha: ${{ github.event.pull_request.head.sha }}
+    secrets:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      PERSONAL_TOKEN: ${{ secrets.DEV_HUB_PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/update-healthcheck.yml
+++ b/.github/workflows/update-healthcheck.yml
@@ -1,0 +1,38 @@
+# This workflow is triggered from developer-portal and updates the healthcheck status in the PR.
+name: Update healthcheck
+
+on:
+  workflow_dispatch:
+    inputs:
+      owner:
+        description: "Owner to checkout"
+        required: true
+        type: string
+      repo:
+        description: "Repo to checkout"
+        required: true
+        type: string
+      check:
+        description: "Check ID"
+        required: true
+        type: string
+      conclusion:
+        description: "Healthcheck conclusion"
+        required: true
+        type: string
+      run_id:
+        description: "Workflow run ID"
+        required: true
+        type: string
+
+jobs:
+  update-healthcheck:
+    uses: shopware/developer-portal/.github/workflows/update-healthcheck.yml@main
+    with:
+      owner: ${{ inputs.owner }}
+      repo: ${{ inputs.repo }}
+      check: ${{ inputs.check }}
+      conclusion: ${{ inputs.conclusion }}
+      run_id: ${{ inputs.run_id }}
+    secrets:
+      TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What?
3 new workflows for communicating with the DevHub:
 - [X] `developer-portal-healthcheck` - triggers a new [preview build](https://github.com/shopware/developer-portal/blob/main/.github/workflows/external-healthcheck.yml) in `developer-portal` for every PR targeting `main` branch in this repo
 - [X] `update-healthcheck` - needed to update the PR status check from the previous workflow - will be replaced with a dedicated GitHub app to avoid usage of the PAT
 - [X] `deploy-developer-portal` - triggers a new [production build](https://github.com/shopware/developer-portal/blob/main/.github/workflows/checkout-test-build-deploy.yml) in `developer-portal` whenever the `main` branch has changed
 - [ ] `DEV_HUB_PERSONAL_ACCESS_TOKEN` - PAT, tmp

## Why?
So we can automate DevHub actions.

## How?
By adding a few workflows.

## Testing?
Already used by `shopware/docs`, `shopware/frontends`, `shopware/release-notes`.

## Screenshots (optional)

## Anything Else?