### PR TITLE
feat: generate docs, provide commands

### DIFF
--- a/.github/scripts/docs-after-clone.sh
+++ b/.github/scripts/docs-after-clone.sh
@@ -1,0 +1,106 @@
+#! /usr/bin/env bash
+set -e
+
+[[ -z "$1" ]] && echo "Missing working directory argument" && exit 1
+
+DIR=$1
+SRC=$1/..
+
+reverse() {
+    declare -n arr="$1" rev="$2"
+    for i in "${arr[@]}"
+    do
+        rev=("$i" "${rev[@]}")
+    done
+}
+
+echo "Creating Storybook docs dir"
+mkdir -p $DIR/docs/preview
+
+echo "Discovering Storybook stories"
+find $DIR -type f -name "*.stories.js" -print0 | while read -d $'\0' file
+do
+  if [[ $file == *".interactive."* ]]; then
+    # ./src/components/icons-media/sw-icon/sw-icon.interactive.stories.js
+    echo "$file is interactive"
+
+  # ./src/components/icons-media/sw-icon/sw-icon.stories.js
+  elif [[ $file == *"/components/"* ]]; then
+    # split to array
+    split=($(echo "$file" | tr '/' ' '))
+    reverse split reversed
+    component="${reversed[1]//.stories.js/''}"
+    identifier="${reversed[3]}-${reversed[2]}-${reversed[1]}--docs"
+
+    # create dir
+    if [[ ! -d "$SRC/docs/component" ]]; then
+      echo "Creating dir docs/component"
+      mkdir -p $SRC/docs/component
+
+      cat <<EOT > $SRC/docs/component/index.md
+---
+sidebar: true
+---
+
+# Components
+
+EOT
+    fi
+
+    # components-navigation-sw-tabs--default
+    # create file
+    echo "Creating file component/$component.md"
+    cat <<EOT > $SRC/docs/component/$component.md
+---
+sidebar: true
+aside: false
+nav:
+  title: $component
+---
+
+<SwagStorybookIframe component="$identifier" />
+EOT
+  # cat $SRC/docs/component/$component.md
+
+  # ./src/directives/tooltip.stories.js
+  elif [[ $file == *"/directives/"* ]]; then
+
+    # split to array
+    split=($(echo "$file" | tr '/' ' '))
+    reverse split reversed
+    component="${reversed[0]//.stories.js/''}"
+    identifier="${reversed[1]}-${component}--docs"
+
+    # create dir
+    if [[ ! -d "$SRC/docs/directive" ]]; then
+      echo "Creating dir docs/directive"
+      mkdir -p $SRC/docs/directive
+
+      cat <<EOT > $SRC/docs/directive/index.md
+---
+sidebar: true
+---
+
+# Directives
+
+EOT
+    fi
+
+    # create file
+    echo "Creating file directive/$component.md"
+    cat <<EOT > $SRC/docs/directive/$component.md
+---
+sidebar: true
+aside: false
+nav:
+  title: $component
+---
+
+<SwagStorybookIframe component="$identifier" />
+EOT
+  # cat $SRC/docs/directive/$component.md
+
+  else
+    echo "$file is unknown"
+  fi
+done

--- a/packages/component-library/docs/components/SwagStorybookIframe.vue
+++ b/packages/component-library/docs/components/SwagStorybookIframe.vue
@@ -1,0 +1,28 @@
+<template>
+  <iframe :src="src" class="SwagStorybookIframe"></iframe>
+</template>
+
+<script setup lang="ts">
+import {computed} from 'vue';
+
+const props = defineProps({
+  component: {
+    type: String,
+    required: true,
+  },
+  domain: {
+    type: String,
+    default: 'meteor-component-library.vercel.app',
+  }
+});
+
+const src = computed(() => `https://${props.domain}/iframe.html?id=${props.component}&viewMode=docs&shortcuts=false&singleStory=true`);
+</script>
+
+<style>
+.SwagStorybookIframe {
+  border: 0;
+  min-height: 50vh;
+  width: 100%;
+}
+</style>

--- a/packages/component-library/package.json
+++ b/packages/component-library/package.json
@@ -12,6 +12,9 @@
     "build:storybook": "storybook build",
     "start:storybook": "serve ./storybook-static -p 6006 --no-request-logging",
     "test:storybook": "test-storybook --url http://127.0.0.1:6006",
+    "docs:env": "[ -d \"../../../developer-portal\" ] && ../../../developer-portal/docs-cli.cjs pull || (git clone git@github.com:shopware/developer-portal.git ../../../developer-portal && pnpm i -C ../../../developer-portal)",
+    "docs:link": "../../../developer-portal/docs-cli.cjs link --src docs --dst resources/meteor-component-library --symlink --keep",
+    "docs:preview": "../../../developer-portal/docs-cli.cjs preview",
     "docker": "docker run -v $PWD/../../:/tests:delegated -w /tests -it --rm --ipc=host mcr.microsoft.com/playwright:v1.20.0-focal /bin/bash"
   },
   "main": "dist/common/index.js",


### PR DESCRIPTION
## What?
 - provides `docs:env`, `docs:link` and `docs:preview` shortcuts/commands
 - provides `docs-after-clone.sh` script to auto-generate markdown articles from the storybook
 - provides `SwagStorybookIframe` VueJS component

## Why?
So we can display Meteor component library docs in DevHub.

## How?
By generating markdown articles from storybook.

## Testing?
Why not :)

## Screenshots (optional)

## Anything Else?
