### PR TITLE
set data-theme attribute depending on background of story

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 .env
 chrome/
 .idea/
+.DS_Store

--- a/packages/component-library/.storybook/ThemeProvider.ts
+++ b/packages/component-library/.storybook/ThemeProvider.ts
@@ -1,0 +1,34 @@
+import { useGlobals, useEffect } from "@storybook/preview-api";
+
+type BackgroundsGlobal = null | {
+  value: string;
+};
+
+export const LIGHT_THEME_BACKGROUND_VALUE = "#FFFFFF";
+export const DARK_THEME_BACKGROUND_VALUE = "#141418";
+
+export function ThemeProvider(Story) {
+  const [globals] = useGlobals();
+  const backgrounds: BackgroundsGlobal = globals.backgrounds;
+  const theme = useThemeStyle(backgrounds?.value);
+
+  useEffect(() => {
+    const rootStoryElement = document.querySelector("body");
+    if (!rootStoryElement) throw new Error("Failed to render story: Root element not found");
+
+    rootStoryElement.setAttribute("data-theme", theme);
+  }, [backgrounds]);
+
+  return Story();
+}
+
+function useThemeStyle(value: string | undefined): "dark" | "light" | "auto" {
+  switch (value) {
+    case DARK_THEME_BACKGROUND_VALUE:
+      return "dark";
+    case LIGHT_THEME_BACKGROUND_VALUE:
+      return "light";
+    default:
+      return "auto";
+  }
+}

--- a/packages/component-library/.storybook/preview.ts
+++ b/packages/component-library/.storybook/preview.ts
@@ -4,6 +4,7 @@ import { darkTheme, lightTheme } from "./shopwareTheme";
 import { setup } from "@storybook/vue3";
 import { createI18n } from "vue-i18n";
 import DeviceHelperPlugin from "./../src/plugin/device-helper.plugin";
+import { DARK_THEME_BACKGROUND_VALUE, LIGHT_THEME_BACKGROUND_VALUE, ThemeProvider } from "./ThemeProvider";
 
 const i18n = createI18n({
   // something vue-i18n options here ...
@@ -37,7 +38,15 @@ const preview: Preview = {
       dark: { ...darkTheme },
       light: { ...lightTheme },
     },
+    backgrounds: {
+      default: 'light',
+      values: [
+        { name: 'light', value: LIGHT_THEME_BACKGROUND_VALUE },
+        { name: 'dark', value: DARK_THEME_BACKGROUND_VALUE },
+      ],
+    },
   },
+  decorators: [ThemeProvider],
 };
 
 export default preview;

--- a/packages/component-library/.storybook/preview.ts
+++ b/packages/component-library/.storybook/preview.ts
@@ -4,7 +4,15 @@ import { darkTheme, lightTheme } from "./shopwareTheme";
 import { setup } from "@storybook/vue3";
 import { createI18n } from "vue-i18n";
 import DeviceHelperPlugin from "./../src/plugin/device-helper.plugin";
-import { DARK_THEME_BACKGROUND_VALUE, LIGHT_THEME_BACKGROUND_VALUE, ThemeProvider } from "./ThemeProvider";
+import {
+  DARK_THEME_BACKGROUND_VALUE,
+  LIGHT_THEME_BACKGROUND_VALUE,
+  ThemeProvider,
+} from "./ThemeProvider";
+
+// importing meteor tokens
+import "@shopware-ag/meteor-tokens/administration/light.css";
+import "@shopware-ag/meteor-tokens/administration/dark.css";
 
 const i18n = createI18n({
   // something vue-i18n options here ...
@@ -39,10 +47,10 @@ const preview: Preview = {
       light: { ...lightTheme },
     },
     backgrounds: {
-      default: 'light',
+      default: "light",
       values: [
-        { name: 'light', value: LIGHT_THEME_BACKGROUND_VALUE },
-        { name: 'dark', value: DARK_THEME_BACKGROUND_VALUE },
+        { name: "light", value: LIGHT_THEME_BACKGROUND_VALUE },
+        { name: "dark", value: DARK_THEME_BACKGROUND_VALUE },
       ],
     },
   },

--- a/packages/component-library/package.json
+++ b/packages/component-library/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@floating-ui/dom": "^1.4.3",
     "@shopware-ag/meteor-icon-kit": "^5.2.0",
+    "@shopware-ag/meteor-tokens": "workspace:*",
     "@vueuse/components": "^10.7.2",
     "@vueuse/core": "^10.7.2",
     "date-fns": "^2.30.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,6 +100,9 @@ importers:
       '@shopware-ag/meteor-icon-kit':
         specifier: ^5.2.0
         version: link:../icon-kit
+      '@shopware-ag/meteor-tokens':
+        specifier: workspace:*
+        version: link:../tokens
       '@vueuse/components':
         specifier: ^10.7.2
         version: 10.8.0(vue@3.3.8)


### PR DESCRIPTION
## What?

With this PR I enable the mechanisms to switch between dark and light mode components.

## Why?

This change allows us to see a component in a dark and light mode. That makes it much easier to develop, and debug components for each color mode.

## How?

I achieved this by creating global decorator, that adds a `data-theme` attribute to the root element of the story.

## Testing?

Checkout the project and change the background colour by clicking in the picture / image icon.

## Screenshots (optional)

https://github.com/shopware/meteor/assets/35109813/5e64e65b-4aa6-46fe-a6ff-9bf470edc25b

## Anything Else?

I also changed the colour of the backgrounds so they reflect the token values.
