### PR TITLE
enable npm provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,3 +43,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
## What?

This PR enables [provenance](https://github.blog/2023-04-19-introducing-npm-package-provenance/) for our npm packages.

## Why?

This increases trust for our packages, because we can be sure that the packages indeed published by us and not by a malicious person.

## How?

I've added a `NPM_CONFIG_PROVENANCE` environment variable to the CI pipeline. 

## Testing?

The changes will only have effect once this PR gets merged and we do another release.

## Anything Else?

Closes #63