### PR TITLE
add github workflow to update tokens

### DIFF
--- a/.github/workflows/update-tokens.yml
+++ b/.github/workflows/update-tokens.yml
@@ -1,0 +1,45 @@
+name: Update tokens
+
+on: workflow_dispatch
+
+env:
+  FIGMA_TOKEN: ${{ secrets.FIGMA_TOKEN }}
+  PRIMITIVE_TOKENS_FILE_KEY: ${{ secrets.TOKENS__PRIMITIVE_TOKENS_FILE_KEY }}
+  ADMIN_TOKENS_FILE_KEY: ${{ secrets.TOKENS__ADMIN_TOKENS_FILE_KEY }}
+
+jobs:
+  update:
+    name: Update icons
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+          cache-dependency-path: '**/pnpm-lock.yaml'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --prefer-offline
+
+      - name: Update tokens
+        run: pnpm --filter @shopware-ag/meteor-tokens run start
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: Update icons
+          committer: Dennis Mader <${{ secrets.ICON_KIT__COMMITTER }}>
+          author: Dennis Mader <${{ secrets.ICON_KIT__COMMITTER }}>
+          branch: update-icons
+          delete-branch: true
+          branch-suffix: timestamp
+          title: Update icons
+          assignees: Weltraumakustik


### PR DESCRIPTION
## What?

This PR introduces another GitHub workflow to further automate the process of generating the Design Tokens.

## Why?

This makes it easier for everyone to generate new tokens. Especially for designers as they lack the technical knowledge, but also for other developers as they just need to run that action. Otherwise they have to checkout the repository, install the dependencies, get and set the correct environment variables, running the script and creating a new PR.

## How?

I added a new GitHub workflow that one can trigger on the actions tab of the repository.

## Testing?

The only way to test it is by merging the changes and testing it manually.
