### PR TITLE
update tokens workflow

### DIFF
--- a/.github/workflows/update-tokens.yml
+++ b/.github/workflows/update-tokens.yml
@@ -35,10 +35,10 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6
         with:
-          commit-message: Update icons
+          commit-message: Update tokens
           committer: Dennis Mader <${{ secrets.ICON_KIT__COMMITTER }}>
           author: Dennis Mader <${{ secrets.ICON_KIT__COMMITTER }}>
-          branch: update-icons
+          branch: update-tokens
           delete-branch: true
           branch-suffix: timestamp
           title: Update icons


### PR DESCRIPTION
## What?

The update tokens workflow creates branches with a wrong branch name and branch title. If fixed it so it now matches the actual result of that action.

## Why?

This separates the PRs created trough the update icon workflow from the ones created by the update tokens workflow.

## How?

I changed the configuration of the action that creates the PR.

## Testing?

Double check if the values are correct.
