### PR TITLE
add "pull request" write permission to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   id-token: write
+  pull-requests: write
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 


### PR DESCRIPTION
## What?

This PR fixes the automatic release workflow. The action was able to create a new branch and push the changes to it. But it failed once it tried to create the PR.

## Why?

We need this in order to make our automatic release workflow work again.

## How?

The job now has the permission to create a new pull request.

## Testing?

We'll see if it works once we merge this PR.