### PR TITLE
fix checkmark sizing in checkbox

### DIFF
--- a/.changeset/brave-bottles-build.md
+++ b/.changeset/brave-bottles-build.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": patch
+---
+
+resize checkmark in checkbox to correct dimensions

--- a/packages/component-library/src/components/form/mt-checkbox/mt-checkbox.vue
+++ b/packages/component-library/src/components/form/mt-checkbox/mt-checkbox.vue
@@ -13,7 +13,7 @@
             @change.stop="onChange"
           />
           <div class="mt-field__checkbox-state">
-            <mt-icon :name="iconName" size="16" />
+            <mt-icon :name="iconName" />
           </div>
         </div>
 


### PR DESCRIPTION
## What?

Makes the size of the checkmark in the checkbox smaller.

## Why?

Fixes a visual bug.

## How?

Removed the `size` property.

## Testing?

You can check it out in the deployment preview below.

## Screenshots (optional)

Before: ![Bildschirmfoto 2024-04-02 um 14 13 45](https://github.com/shopware/meteor/assets/35109813/e83206cc-fe5c-4951-bc05-2a0a830469f9)

After: ![Bildschirmfoto 2024-04-02 um 14 13 48](https://github.com/shopware/meteor/assets/35109813/86013704-88bc-4c35-a793-8e9d05da3cdd)

## Anything Else?
