### PR TITLE
only animate tabs slider after first render

### DIFF
--- a/.changeset/shy-ladybugs-clap.md
+++ b/.changeset/shy-ladybugs-clap.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": patch
+---
+
+Only animate tabs slider after first render

--- a/packages/component-library/src/components/navigation/mt-tabs/mt-tabs.vue
+++ b/packages/component-library/src/components/navigation/mt-tabs/mt-tabs.vue
@@ -133,16 +133,13 @@ export default defineComponent({
     },
   },
 
-  data(): {
-    refreshKey: boolean;
-    activeItemName: string;
-    showMoreItems: boolean;
-  } {
+  data() {
     return {
       // refreshKey is for recalculating specific computed properties
       refreshKey: true,
       activeItemName: "",
       showMoreItems: false,
+      passedFirstRender: false,
     };
   },
 
@@ -234,6 +231,7 @@ export default defineComponent({
 
       return {
         "mt-tabs__slider--error": this.activeItem?.hasError ?? false,
+        "mt-tabs__slider--animated": this.passedFirstRender,
       };
     },
 
@@ -265,6 +263,8 @@ export default defineComponent({
 
     this.$nextTick(() => {
       this.handleResize();
+
+      this.passedFirstRender = true;
     });
 
     // @ts-expect-error $device helper is not registered in TS yet
@@ -408,7 +408,6 @@ export default defineComponent({
 
   .mt-tabs__slider {
     transform-origin: top left;
-    transition: 0.2s all ease-in-out;
     position: absolute;
     bottom: 0;
     left: 0;
@@ -418,6 +417,10 @@ export default defineComponent({
 
     &--error {
       background-color: var(--color-border-critical-default);
+    }
+
+    &--animated {
+      transition: 0.2s all ease-in-out;
     }
   }
 


### PR DESCRIPTION
## What?

This PR improves the UX for the tab component by only animating the tab slider after the initial render.

## Why?

Motion in design is used to convey meaning. The slider animation from one point to another helps the user understand from which tab we're coming from and to which one we're going. Adding this animation on the first render is confusing. Because it's not relevant from where we're coming.

## How?

After the component mounts the slider gets a CSS class that enables the animation.

## Testing?

You can check out the story in the deployment preview below.
