### PR TITLE
PS-178 - Allow toggling the admin menu

### DIFF
--- a/.changeset/violet-eyes-sniff.md
+++ b/.changeset/violet-eyes-sniff.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-admin-sdk": minor
+---
+
+Allow toggling the admin menu

--- a/packages/admin-sdk/src/message-types.ts
+++ b/packages/admin-sdk/src/message-types.ts
@@ -6,7 +6,7 @@ import type { uiTabsAddTabItem } from './ui/tabs';
 import type { uiModulePaymentOverviewCard } from './ui/module/payment/overview-card';
 import type { cmsRegisterElement, cmsRegisterBlock } from './ui/cms';
 import type { locationUpdateHeight, locationUpdateUrl } from './location/index';
-import type { menuItemAdd } from './ui/menu';
+import type { menuCollapse, menuExpand, menuItemAdd } from './ui/menu';
 import type { settingsItemAdd } from './ui/settings';
 import type { mainModuleAdd } from './ui/main-module';
 import type { smartBarButtonAdd } from './ui/main-module';
@@ -53,6 +53,8 @@ export interface ShopwareMessageTypes {
   cmsRegisterBlock: cmsRegisterBlock,
   locationUpdateHeight: locationUpdateHeight,
   locationUpdateUrl: locationUpdateUrl,
+  menuCollapse: menuCollapse,
+  menuExpand: menuExpand,
   menuItemAdd: menuItemAdd,
   settingsItemAdd: settingsItemAdd,
   mainModuleAdd: mainModuleAdd,

--- a/packages/admin-sdk/src/ui/menu/index.ts
+++ b/packages/admin-sdk/src/ui/menu/index.ts
@@ -1,6 +1,16 @@
 import { createSender } from '../../channel';
 
+export const collapseMenu = createSender('menuCollapse');
+export const expandMenu = createSender('menuExpand');
 export const addMenuItem = createSender('menuItemAdd');
+
+export type menuCollapse = {
+  responseType: void,
+}
+
+export type menuExpand = {
+  responseType: void,
+}
 
 export type menuItemAdd = {
   responseType: void,


### PR DESCRIPTION
## What?

I am adding the functionality to collapse the admin menu from an app.

## Why?

Some app modules need a more extensive view, like Shopping Experiences.

## How?

Send a signal to collapse the admin menu from an app.

## Testing?

N/A

## Screenshots (optional)

N/A

## Anything Else?

N/A
