### PR TITLE
Fix UUID issue

### DIFF
--- a/.changeset/purple-geckos-count.md
+++ b/.changeset/purple-geckos-count.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": patch
+---
+
+Fix id generation for inputs when using SSR

--- a/packages/component-library/src/components/form/_internal/mt-base-field/mt-base-field.vue
+++ b/packages/component-library/src/components/form/_internal/mt-base-field/mt-base-field.vue
@@ -179,10 +179,14 @@ export default defineComponent({
     },
   },
 
-  data() {
+  data(): { id: string | undefined } {
     return {
-      id: createId(),
+      id: undefined,
     };
+  },
+
+  mounted() {
+    this.id = createId();
   },
 
   computed: {

--- a/packages/component-library/src/components/form/mt-checkbox/mt-checkbox.vue
+++ b/packages/component-library/src/components/form/mt-checkbox/mt-checkbox.vue
@@ -141,11 +141,15 @@ export default defineComponent({
     },
   },
 
-  data() {
+  data(): { id: string | undefined; currentValue: boolean | undefined } {
     return {
       currentValue: this.checked,
-      id: createId(),
+      id: undefined,
     };
+  },
+
+  mounted() {
+    this.id = createId();
   },
 
   computed: {

--- a/packages/component-library/src/components/form/mt-switch/mt-switch.vue
+++ b/packages/component-library/src/components/form/mt-switch/mt-switch.vue
@@ -132,11 +132,15 @@ export default defineComponent({
     },
   },
 
-  data() {
+  data(): { id: string | undefined; currentValue: boolean | undefined } {
     return {
       currentValue: this.checked,
-      id: createId(),
+      id: undefined,
     };
+  },
+
+  mounted() {
+    this.id = createId();
   },
 
   computed: {

--- a/packages/component-library/src/utils/uuid.ts
+++ b/packages/component-library/src/utils/uuid.ts
@@ -1,18 +1,11 @@
-function uuidv4() {
-  // @ts-expect-error
-  return ([1e7] + -1e3 + -4e3 + -8e3 + -1e11).replace(/[018]/g, (c) =>
-    (c ^ (window.crypto.getRandomValues(new Uint8Array(1))[0] & (15 >> (c / 4)))).toString(16),
-  );
+function isNode() {
+  return typeof process !== "undefined" && !!process.versions && !!process.versions.node;
 }
 
-/**
- * Returns a uuid string in hex format.
- *
- * @returns {String}
- */
 export function createId() {
-  // eslint-disable-next-line max-len
-  return uuidv4().replace(/-/g, "");
+  const crypto = isNode() ? require("crypto") : window.crypto;
+
+  return crypto.randomUUID();
 }
 
 export default {


### PR DESCRIPTION
## What?

Fixes the id generation for the input fields.

## Why?

This makes our app compatible with projects that use Nuxt or every other SSR framework.

## How?

We only set the id once the app hydrates the client. This prevents us from having a hydration miss-match. The only drawback with that is that the labels won't work when the user has Javascript disabled. As we currently don't practice progressive enhancement the whole app does not work without Javascript.

## Testing?

You can check out the nuxt example app and take a look at the console output.

## Anything Else?

I suggest that we use the [`useId`](https://github.com/vuejs/rfcs/issues/556) hook once Vue 3.5 is out.
