### PR TITLE
NEXT-34273 - fix class inheritance in form fields

### DIFF
--- a/.changeset/warm-dolphins-talk.md
+++ b/.changeset/warm-dolphins-talk.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": minor
+---
+
+Allow attribute inheritance on every form field

--- a/packages/component-library/src/components/form/_internal/mt-select-base/mt-select-base.vue
+++ b/packages/component-library/src/components/form/_internal/mt-select-base/mt-select-base.vue
@@ -90,8 +90,6 @@ export default defineComponent({
     "mt-field-error": MtFieldError,
   },
 
-  inheritAttrs: false,
-
   props: {
     /**
      * The label for the select field itself.

--- a/packages/component-library/src/components/form/mt-text-field/mt-text-field.vue
+++ b/packages/component-library/src/components/form/mt-text-field/mt-text-field.vue
@@ -1,5 +1,6 @@
 <template>
   <mt-base-field
+    class="mt-text-field"
     :disabled="disabled"
     :required="required"
     :is-inherited="isInherited"
@@ -33,7 +34,7 @@
         :placeholder="placeholder"
         :maxlength="maxLength"
         @input="onInput"
-        @change="onChange"
+        @change.stop="onChange"
         @focus="setFocusClass"
         @blur="removeFocusClass"
       />
@@ -69,8 +70,6 @@ export default defineComponent({
     "mt-field-error": MtFieldError,
     "mt-base-field": MtBaseField,
   },
-
-  inheritAttrs: false,
 
   props: {
     /**

--- a/packages/component-library/src/components/form/mt-textarea/mt-textarea.vue
+++ b/packages/component-library/src/components/form/mt-textarea/mt-textarea.vue
@@ -63,8 +63,6 @@ export default defineComponent({
 
   mixins: [MtFormFieldMixin],
 
-  inheritAttrs: false,
-
   props: {
     modelValue: {
       type: String,

--- a/packages/component-library/src/components/form/mt-url-field/mt-url-field.stories.ts
+++ b/packages/component-library/src/components/form/mt-url-field/mt-url-field.stories.ts
@@ -27,7 +27,7 @@ export default {
           v-bind="args"
           :modelValue="currentValue"
           @change="onChange"
-          @update:modelValue="args.updateModelValue"
+          @update:modelValue="onUpdateModelValue"
           @inheritance-restore="inheritanceRestoreWrapper"
           @inheritance-remove="inheritanceRemoveWrapper">
           <template
@@ -73,6 +73,11 @@ export default {
 
       onChange(value: string) {
         args.change(value);
+        this.currentValue = value;
+      },
+
+      onUpdateModelValue(value: string) {
+        args.updateModelValue(value);
         this.currentValue = value;
       },
     },

--- a/packages/component-library/src/components/form/mt-url-field/mt-url-field.vue
+++ b/packages/component-library/src/components/form/mt-url-field/mt-url-field.vue
@@ -46,12 +46,12 @@
         :value="unicodeUri(currentValue)"
         :placeholder="placeholder"
         :disabled="disabled"
-        @input.stop="onInput"
         @focus="setFocusClass"
         @blur="
           onBlur($event);
           removeFocusClass();
         "
+        @change.stop="onChange"
       />
     </template>
 
@@ -86,8 +86,6 @@ export default defineComponent({
   },
 
   extends: MtTextField,
-
-  inheritAttrs: false,
 
   props: {
     /**
@@ -148,7 +146,7 @@ export default defineComponent({
   },
 
   watch: {
-    value() {
+    modelValue() {
       this.checkInput(this.modelValue || "");
     },
   },
@@ -169,6 +167,11 @@ export default defineComponent({
     onBlur(event: Event) {
       // @ts-expect-error - target is defined
       this.checkInput(event.target.value);
+    },
+
+    onChange(event: Event): void {
+      // @ts-expect-error - target is defined
+      this.$emit("change", event.target.value || "");
     },
 
     checkInput(inputValue: string) {


### PR DESCRIPTION
## What?

Classes on some form fields aren't rendered, e.g.  `<MtTextField class="foobar" v-model="username" />`

## Why?

`inheritAttrs` was set to false

## How?

Remove attrs. Classes working again