### PR TITLE
Import popover component to use

### DIFF
--- a/.changeset/many-coins-play.md
+++ b/.changeset/many-coins-play.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": minor
+---
+
+Import overlay popover component to use.

--- a/packages/component-library/src/index.ts
+++ b/packages/component-library/src/index.ts
@@ -21,6 +21,9 @@ import MtDataTable from "./components/table-and-list/mt-data-table/mt-data-table
 import MtPagination from "./components/table-and-list/mt-pagination/mt-pagination.vue";
 import MtSkeletonBar from "./components/feedback-indicator/mt-skeleton-bar/mt-skeleton-bar.vue";
 import MtToast from "./components/feedback-indicator/mt-toast/mt-toast.vue";
+import MtPopover from "./components/overlay/mt-popover/mt-popover.vue";
+import MtPopoverItem from "./components/overlay/mt-popover-item/mt-popover-item.vue";
+import MtPopoverItemResult from "./components/overlay/mt-popover-item-result/mt-popover-item-result.vue";
 import TooltipDirective from "./directives/tooltip.directive";
 import DeviceHelperPlugin from "./plugin/device-helper.plugin";
 // Import SCSS for styling
@@ -50,6 +53,9 @@ export {
   MtPagination,
   MtSkeletonBar,
   MtToast,
+  MtPopover,
+  MtPopoverItem,
+  MtPopoverItemResult,
   TooltipDirective,
   DeviceHelperPlugin,
   // @deprecated


### PR DESCRIPTION
## What?
The Popover component is already implemented in [storybook](https://meteor-component-library.vercel.app/?path=/docs/components-overlay-mt-popover--docs) but it's not imported to use [here](https://github.com/shopware/meteor/blob/main/packages/component-library/src/index.ts)