### PR TITLE
NTR - Use ViteJS CSS preprocessor option

### DIFF
--- a/packages/component-library/src/components/_internal/mt-floating-ui/mt-floating-ui.vue
+++ b/packages/component-library/src/components/_internal/mt-floating-ui/mt-floating-ui.vue
@@ -218,8 +218,6 @@ export default defineComponent({
 </script>
 
 <style lang="scss">
-@import "../../assets/scss/variables.scss";
-
 .mt-floating-ui {
   display: inline-block;
   position: relative;

--- a/packages/component-library/src/components/_internal/mt-highlight-text.vue
+++ b/packages/component-library/src/components/_internal/mt-highlight-text.vue
@@ -52,8 +52,6 @@ export default defineComponent({
 </script>
 
 <style lang="scss">
-@import "../assets/scss/variables.scss";
-
 .mt-highlight-text {
   .mt-highlight-text__highlight {
     color: $color-shopware-brand-500;

--- a/packages/component-library/src/components/_internal/mt-label.vue
+++ b/packages/component-library/src/components/_internal/mt-label.vue
@@ -116,10 +116,6 @@ export default defineComponent({
 </script>
 
 <style lang="scss">
-@use "sass:math";
-@import "../assets/scss/variables.scss";
-@import "../assets/scss/mixins.scss";
-
 @mixin mt-label-variant($color-background, $color-text, $color-border, $color-border-normal) {
   background-color: $color-background;
   border-color: $color-border-normal;

--- a/packages/component-library/src/components/context-menu/mt-context-button/mt-context-button.vue
+++ b/packages/component-library/src/components/context-menu/mt-context-button/mt-context-button.vue
@@ -128,8 +128,6 @@ export default defineComponent({
 </script>
 
 <style lang="scss">
-@import "../../assets/scss/variables.scss";
-
 $mt-context-button-color-text: $color-darkgray-200;
 $mt-context-button-border-radius: $border-radius-default;
 $mt-context-button-color-border: $color-gray-300;

--- a/packages/component-library/src/components/context-menu/mt-context-menu-divider/mt-context-menu-divider.vue
+++ b/packages/component-library/src/components/context-menu/mt-context-menu-divider/mt-context-menu-divider.vue
@@ -11,8 +11,6 @@ export default defineComponent({
 </script>
 
 <style lang="scss">
-@import "../../assets/scss/variables.scss";
-
 $mt-context-menu-color-border: $color-gray-300;
 
 .mt_context_menu_divider {

--- a/packages/component-library/src/components/feedback-indicator/mt-banner/mt-banner.vue
+++ b/packages/component-library/src/components/feedback-indicator/mt-banner/mt-banner.vue
@@ -140,8 +140,6 @@ export default defineComponent({
 </script>
 
 <style lang="scss">
-@import "../../assets/scss/variables.scss";
-
 $mt-banner-size-close: 40px;
 
 .mt-banner {

--- a/packages/component-library/src/components/feedback-indicator/mt-color-badge/mt-color-badge.vue
+++ b/packages/component-library/src/components/feedback-indicator/mt-color-badge/mt-color-badge.vue
@@ -56,8 +56,6 @@ export default defineComponent({
 </script>
 
 <style lang="scss">
-@import "../../assets/scss/variables.scss";
-
 $mt-color-badge-color-fallback: $color-gray-300;
 $mt-color-badge-color-warning: $color-pumpkin-spice-500;
 $mt-color-badge-color-critical: $color-crimson-500;

--- a/packages/component-library/src/components/feedback-indicator/mt-loader/mt-loader.vue
+++ b/packages/component-library/src/components/feedback-indicator/mt-loader/mt-loader.vue
@@ -61,8 +61,6 @@ export default defineComponent({
 </script>
 
 <style lang="scss">
-@import "../../assets/scss/variables.scss";
-
 $mt-loader-color-overlay: rgba(255, 255, 255, 0.8);
 $mt-loader-element-color: $color-shopware-brand-500;
 $mt-loader-rotate-duration: 1.4s;

--- a/packages/component-library/src/components/feedback-indicator/mt-progress-bar/mt-progress-bar.vue
+++ b/packages/component-library/src/components/feedback-indicator/mt-progress-bar/mt-progress-bar.vue
@@ -126,8 +126,6 @@ export default defineComponent({
 </script>
 
 <style lang="scss">
-@import "../../assets/scss/variables.scss";
-
 .mt-progress-bar {
   .mt-block-field__block {
     border: none;

--- a/packages/component-library/src/components/feedback-indicator/mt-skeleton-bar/mt-skeleton-bar.vue
+++ b/packages/component-library/src/components/feedback-indicator/mt-skeleton-bar/mt-skeleton-bar.vue
@@ -13,8 +13,6 @@ export default defineComponent({
 </script>
 
 <style lang="scss">
-@import "../../assets/scss/variables.scss";
-
 $mt-skeleton-bar-color: $color-gray-100;
 $mt-skeleton-bar-height: 32px;
 $mt-skeleton-shimmer-dark: $color-gray-200;

--- a/packages/component-library/src/components/feedback-indicator/mt-toast/mt-toast-notification.vue
+++ b/packages/component-library/src/components/feedback-indicator/mt-toast/mt-toast-notification.vue
@@ -225,8 +225,6 @@ onBeforeUnmount(() => {
 </script>
 
 <style scoped lang="scss">
-@import "../../assets/scss/variables.scss";
-
 .mt-toast-notification {
   position: absolute;
   bottom: 0;

--- a/packages/component-library/src/components/feedback-indicator/mt-toast/mt-toast.vue
+++ b/packages/component-library/src/components/feedback-indicator/mt-toast/mt-toast.vue
@@ -109,8 +109,6 @@ function onMouseLeave() {
 </script>
 
 <style scoped lang="scss">
-@import "../../assets/scss/variables.scss";
-
 .mt-toast {
   display: flex;
   position: fixed;

--- a/packages/component-library/src/components/form/_internal/mt-base-field/mt-base-field.vue
+++ b/packages/component-library/src/components/form/_internal/mt-base-field/mt-base-field.vue
@@ -242,8 +242,6 @@ export default defineComponent({
 </script>
 
 <style lang="scss">
-@import "../../../assets/scss/variables.scss";
-
 $mt-field-transition: border-color 0.3s ease-out;
 $mt-field-transition:
   border-color 0.3s ease-out,

--- a/packages/component-library/src/components/form/_internal/mt-field-error/mt-field-error.vue
+++ b/packages/component-library/src/components/form/_internal/mt-field-error/mt-field-error.vue
@@ -82,8 +82,6 @@ export default defineComponent({
 </script>
 
 <style lang="scss">
-@import "../../../assets/scss/variables.scss";
-
 .mt-field__error {
   display: flex;
   align-items: center;

--- a/packages/component-library/src/components/form/_internal/mt-select-base/_internal/mt-select-result.vue
+++ b/packages/component-library/src/components/form/_internal/mt-select-base/_internal/mt-select-result.vue
@@ -165,8 +165,6 @@ export default defineComponent({
 </script>
 
 <style lang="scss">
-@import "../../../../assets/scss/variables.scss";
-
 $mt-select-result-active-color-background: lighten($color-shopware-brand-500, 40%);
 $mt-select-result-active-color-text: $color-shopware-brand-500;
 $mt-select-result-color-border: $color-gray-300;

--- a/packages/component-library/src/components/form/_internal/mt-select-base/mt-select-base.vue
+++ b/packages/component-library/src/components/form/_internal/mt-select-base/mt-select-base.vue
@@ -280,8 +280,6 @@ export default defineComponent({
 </script>
 
 <style lang="scss">
-@import "../../../assets/scss/variables.scss";
-
 $mt-select-focus-transition: all ease-in-out 0.2s;
 
 .mt-select {

--- a/packages/component-library/src/components/form/mt-button/mt-button.vue
+++ b/packages/component-library/src/components/form/mt-button/mt-button.vue
@@ -145,8 +145,6 @@ export default defineComponent({
 </script>
 
 <style lang="scss">
-@import "../../assets/scss/variables.scss";
-
 $mt-button-transition: all 0.15s ease-out;
 
 .mt-button {

--- a/packages/component-library/src/components/form/mt-checkbox/mt-checkbox.vue
+++ b/packages/component-library/src/components/form/mt-checkbox/mt-checkbox.vue
@@ -235,8 +235,6 @@ export default defineComponent({
 </script>
 
 <style lang="scss">
-@import "../../assets/scss/variables.scss";
-
 $mt-field-color-text: $color-darkgray-200;
 $mt-field-color-focus: $color-shopware-brand-500;
 $mt-field-color-background: $color-white;

--- a/packages/component-library/src/components/form/mt-colorpicker/mt-colorpicker.vue
+++ b/packages/component-library/src/components/form/mt-colorpicker/mt-colorpicker.vue
@@ -1212,9 +1212,6 @@ export default defineComponent({
 </script>
 
 <style lang="scss">
-@import "../../assets/scss/variables.scss";
-@import "../../assets/scss/mixins.scss";
-
 .mt-colorpicker {
   position: relative;
 

--- a/packages/component-library/src/components/form/mt-datepicker/mt-datepicker.vue
+++ b/packages/component-library/src/components/form/mt-datepicker/mt-datepicker.vue
@@ -577,8 +577,6 @@ export default defineComponent({
 </script>
 
 <style lang="scss">
-@import "../../assets/scss/variables.scss";
-
 $mt-datepicker-color-border: $color-gray-300;
 $mt-datepicker-color-font: $color-darkgray-200;
 $mt-datepicker-color-disabled-font: #b3bfcc;

--- a/packages/component-library/src/components/form/mt-external-link/mt-external-link.vue
+++ b/packages/component-library/src/components/form/mt-external-link/mt-external-link.vue
@@ -103,8 +103,6 @@ export default defineComponent({
 </script>
 
 <style lang="scss">
-@import "../../assets/scss/variables.scss";
-
 .mt-external-link {
   color: $color-shopware-brand-500;
   font-size: $font-size-small;

--- a/packages/component-library/src/components/form/mt-help-text/mt-help-text.vue
+++ b/packages/component-library/src/components/form/mt-help-text/mt-help-text.vue
@@ -72,8 +72,6 @@ export default defineComponent({
 </script>
 
 <style lang="scss">
-@import "../../assets/scss/variables.scss";
-
 .mt-help-text {
   color: $color-shopware-brand-500;
   display: inline-flex;

--- a/packages/component-library/src/components/form/mt-number-field/mt-number-field.vue
+++ b/packages/component-library/src/components/form/mt-number-field/mt-number-field.vue
@@ -388,8 +388,6 @@ export default defineComponent({
 </script>
 
 <style lang="scss">
-@import "../../assets/scss/variables.scss";
-
 .mt-field {
   &--controls {
     background: $color-white;

--- a/packages/component-library/src/components/form/mt-switch/mt-switch.vue
+++ b/packages/component-library/src/components/form/mt-switch/mt-switch.vue
@@ -220,8 +220,6 @@ export default defineComponent({
 </script>
 
 <style lang="scss">
-@import "../../assets/scss/variables.scss";
-
 $mt-field--switch-color-border: $color-gray-300;
 $mt-field--switch-color-background: $color-white;
 $mt-field--switch-color-text: $color-darkgray-200;

--- a/packages/component-library/src/components/form/mt-textarea/mt-textarea.vue
+++ b/packages/component-library/src/components/form/mt-textarea/mt-textarea.vue
@@ -184,8 +184,6 @@ export default defineComponent({
 </script>
 
 <style lang="scss">
-@import "../../assets/scss/variables.scss";
-
 .mt-field--textarea {
   textarea {
     line-height: 22px;

--- a/packages/component-library/src/components/icons-media/mt-avatar/mt-avatar.vue
+++ b/packages/component-library/src/components/icons-media/mt-avatar/mt-avatar.vue
@@ -206,8 +206,6 @@ export default defineComponent({
 </script>
 
 <style lang="scss">
-@import "../../assets/scss/variables.scss";
-
 $mt-avatar-size-default: 40px;
 
 .mt-avatar {

--- a/packages/component-library/src/components/icons-media/mt-icon/mt-icon.vue
+++ b/packages/component-library/src/components/icons-media/mt-icon/mt-icon.vue
@@ -126,8 +126,6 @@ export default defineComponent({
 </script>
 
 <style lang="scss">
-@import "../../assets/scss/variables.scss";
-@import "../../assets/scss/mixins.scss";
 @import "node_modules/@shopware-ag/meteor-icon-kit/icons/meteor-icon-kit.scss";
 
 .mt-icon {

--- a/packages/component-library/src/components/layout/mt-empty-state/mt-empty-state.vue
+++ b/packages/component-library/src/components/layout/mt-empty-state/mt-empty-state.vue
@@ -86,8 +86,6 @@ export default defineComponent({
 </script>
 
 <style lang="scss">
-@import "../../assets/scss/variables.scss";
-
 .mt-empty-state {
   &__icon {
     display: inline-block;

--- a/packages/component-library/src/components/navigation/mt-search/mt-search.vue
+++ b/packages/component-library/src/components/navigation/mt-search/mt-search.vue
@@ -134,8 +134,6 @@ export default defineComponent({
 </script>
 
 <style lang="scss">
-@import "../../assets/scss/variables.scss";
-
 .mt-search.mt-field {
   .icon--regular-search-s {
     transition: 0.3s all ease;

--- a/packages/component-library/src/components/navigation/mt-segmented-control/mt-segmented-control.vue
+++ b/packages/component-library/src/components/navigation/mt-segmented-control/mt-segmented-control.vue
@@ -207,9 +207,6 @@ export default defineComponent({
 </script>
 
 <style lang="scss">
-@import "../../assets/scss/variables.scss";
-@import "../../assets/scss/mixins.scss";
-
 .mt-segmented-control {
   display: flex;
   gap: 2px;

--- a/packages/component-library/src/components/navigation/mt-tabs/mt-tabs.vue
+++ b/packages/component-library/src/components/navigation/mt-tabs/mt-tabs.vue
@@ -342,8 +342,6 @@ export default defineComponent({
 </script>
 
 <style lang="scss">
-@import "../../assets/scss/variables.scss";
-
 .mt-tabs {
   display: flex;
   position: relative;

--- a/packages/component-library/src/components/overlay/mt-popover-item-result/mt-popover-item-result.vue
+++ b/packages/component-library/src/components/overlay/mt-popover-item-result/mt-popover-item-result.vue
@@ -207,9 +207,6 @@ export default defineComponent({
 </script>
 
 <style lang="scss">
-@import "../../assets/scss/variables.scss";
-@import "../../assets/scss/mixins.scss";
-
 /**
 * Use inter-font instead of normal font for popover. Also add the new variables to this file.
 */

--- a/packages/component-library/src/components/overlay/mt-popover-item/mt-popover-item.vue
+++ b/packages/component-library/src/components/overlay/mt-popover-item/mt-popover-item.vue
@@ -306,9 +306,6 @@ export default defineComponent({
 </script>
 
 <style lang="scss">
-@import "../../assets/scss/variables.scss";
-@import "../../assets/scss/mixins.scss";
-
 /**
 * Use inter-font instead of normal font for popover. Also add the new variables to this file.
 */

--- a/packages/component-library/src/components/overlay/mt-popover/mt-popover.vue
+++ b/packages/component-library/src/components/overlay/mt-popover/mt-popover.vue
@@ -215,9 +215,6 @@ export default defineComponent({
 </script>
 
 <style lang="scss">
-@import "../../assets/scss/variables.scss";
-@import "../../assets/scss/mixins.scss";
-
 /**
 * Use inter-font instead of normal font for popover. Also add the new variables to this file.
 */

--- a/packages/component-library/src/components/table-and-list/mt-data-table/mt-data-table.vue
+++ b/packages/component-library/src/components/table-and-list/mt-data-table/mt-data-table.vue
@@ -1939,8 +1939,6 @@ export default defineComponent({
 </script>
 
 <style lang="scss">
-@import "../../assets/scss/variables.scss";
-
 /**
 * Use inter-font instead of normal font for data-table. Also add the new variables to this file.
 */

--- a/packages/component-library/src/components/table-and-list/mt-data-table/renderer/mt-data-table-text-renderer.vue
+++ b/packages/component-library/src/components/table-and-list/mt-data-table/renderer/mt-data-table-text-renderer.vue
@@ -52,8 +52,6 @@ export default defineComponent({
 </script>
 
 <style lang="scss" scoped>
-@import "../../../assets/scss/variables.scss";
-
 a.mt-data-table-text-renderer {
   font-weight: $font-weight-medium;
   text-decoration: none;

--- a/packages/component-library/src/components/table-and-list/mt-data-table/sub-components/mt-data-table-filter/mt-data-table-filter.vue
+++ b/packages/component-library/src/components/table-and-list/mt-data-table/sub-components/mt-data-table-filter/mt-data-table-filter.vue
@@ -90,8 +90,6 @@ export default defineComponent({
 </script>
 
 <style lang="scss" scoped>
-@import "../../../../assets/scss/variables.scss";
-
 .mt-data-table-filter {
   display: inline-flex;
   font-size: 12px;

--- a/packages/component-library/src/components/table-and-list/mt-data-table/sub-components/mt-data-table-settings/mt-data-table-settings.vue
+++ b/packages/component-library/src/components/table-and-list/mt-data-table/sub-components/mt-data-table-settings/mt-data-table-settings.vue
@@ -64,8 +64,8 @@
         @change-switch="($event) => $emit('change-outline-framing', $event)"
       />
 
-      <!-- 
-        More popover items will be added in the future. 
+      <!--
+        More popover items will be added in the future.
         Some examples can be found in the mt-popover story.
       -->
 
@@ -313,8 +313,6 @@ export default defineComponent({
 </script>
 
 <style lang="scss">
-@import "../../../../assets/scss/variables.scss";
-
 .mt-data-table-settings {
 }
 </style>

--- a/packages/component-library/src/components/table-and-list/mt-pagination/mt-pagination.vue
+++ b/packages/component-library/src/components/table-and-list/mt-pagination/mt-pagination.vue
@@ -145,8 +145,6 @@ export default defineComponent({
 </script>
 
 <style lang="scss">
-@import "../../assets/scss/variables.scss";
-
 .mt-pagination {
   display: flex;
   flex-wrap: nowrap;

--- a/packages/component-library/vite.config.ts
+++ b/packages/component-library/vite.config.ts
@@ -1,3 +1,4 @@
+import path from "path";
 import { fileURLToPath, URL } from "node:url";
 
 import { defineConfig } from "vite";
@@ -43,6 +44,17 @@ export default defineConfig({
     },
     rollupOptions: {
       external: ["vue"],
+    },
+  },
+  css: {
+    preprocessorOptions: {
+      scss: {
+        additionalData: `
+          @use "sass:math";
+          @import "${path.resolve(__dirname, "src/components/assets/scss/variables.scss")}";
+          @import "${path.resolve(__dirname, "src/components/assets/scss/mixins.scss")}";
+        `,
+      },
     },
   },
 });


### PR DESCRIPTION
## What?

We should get rid of SCSS imports in every single component by using this 👉🏻 https://vitejs.dev/config/shared-options#css-preprocessoroptions

## Why?

This work is repetitive and somewhat boring. Sometimes the import path is wrong.

## How?

N/A

## Testing?

N/A

## Screenshots (optional)

N/A

## Anything Else?

N/A