### PR TITLE
NEXT-35638 - add tokens for password field

### DIFF
--- a/.changeset/gentle-roses-kneel.md
+++ b/.changeset/gentle-roses-kneel.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": patch
+---
+
+Add tokens for password field

--- a/packages/component-library/src/components/form/mt-password-field/mt-password-field.vue
+++ b/packages/component-library/src/components/form/mt-password-field/mt-password-field.vue
@@ -49,9 +49,9 @@
           class="mt-field__toggle-password-visibility"
           @click="onTogglePasswordVisibility(disabled)"
         >
-          <mt-icon v-if="showPassword" name="regular-eye-slash" small />
+          <mt-icon v-if="showPassword" name="solid-eye-slash" size="18" />
 
-          <mt-icon v-else data-testid="mt-password-field-show-button" name="regular-eye" small />
+          <mt-icon v-else data-testid="mt-password-field-show-button" name="solid-eye" size="18" />
         </span>
       </div>
     </template>
@@ -177,15 +177,7 @@ export default defineComponent({
   }
 
   .mt-icon {
-    #meteor-icon-kit__regular-eye-slash {
-      width: 16px;
-      height: 16px;
-    }
-
-    #meteor-icon-kit__regular-eye {
-      width: 16px;
-      height: 16px;
-    }
+    color: var(--color-icon-primary-default);
   }
 }
 </style>


### PR DESCRIPTION
## What?

Add tokens to the password field.

## Why?

Brings the tokens closer to the designs in Figma.

## How?

I replaced the SCSS variables with tokens.

## Testing?

You can checkout the branch preview below.

## Screenshots (optional)

## Anything Else?

* I changed the eye icon from regular to solid
