### PR TITLE
NEXT-35971 - Make timeoutMs configurable

### DIFF
--- a/.changeset/calm-squids-design.md
+++ b/.changeset/calm-squids-design.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-admin-sdk": minor
+---
+
+Make timeoutMs configurable

--- a/packages/admin-sdk/src/channel.ts
+++ b/packages/admin-sdk/src/channel.ts
@@ -21,6 +21,10 @@ export type extensions = {
   [key: string]: extension,
 }
 
+export type Config = {
+  timeoutMs: number,
+};
+
 // This can't be exported and used in other files as it leads to circular dependencies. Use window._swsdk.adminExtensions instead
 const adminExtensions: extensions = {};
 
@@ -91,6 +95,14 @@ const subscriberRegistry: Set<{
  * MAIN FUNCTIONS FOR EXPORT
  * ----------------
  */
+
+let config: Config = {
+  timeoutMs: 7000,
+};
+
+export function configure(newConfig: Config): void {
+  config = { ...config, ...newConfig };
+}
 
 /**
  * With this method you can send actions or you can request data:
@@ -166,7 +178,6 @@ export function send<MESSAGE_TYPE extends keyof ShopwareMessageTypes>(
 
   // Set value if send was resolved
   let isResolved = false;
-  const timeoutMs = 7000;
 
   // Return a promise which resolves when the response is received
   return new Promise((resolve, reject) => {
@@ -251,7 +262,7 @@ export function send<MESSAGE_TYPE extends keyof ShopwareMessageTypes>(
       }
 
       reject('Send timeout expired. It could be possible that no handler for the postMessage request exists or that the handler freezed.');
-    }, timeoutMs);
+    }, config.timeoutMs);
   });
 }
 
@@ -521,7 +532,7 @@ const datasets = new Map<string, unknown>();
   handle('datasetSubscribeRegistration', (data, { _event_ }) => {
     let source: Window | undefined;
     let origin: string | undefined;
-  
+
     if (_event_.source) {
       source = _event_.source as Window;
       origin = _event_.origin;
@@ -529,7 +540,7 @@ const datasets = new Map<string, unknown>();
       source = window;
       origin = window.origin;
     }
-  
+
     subscriberRegistry.add({
       id: data.id,
       source: source,

--- a/packages/admin-sdk/src/index.ts
+++ b/packages/admin-sdk/src/index.ts
@@ -1,3 +1,4 @@
+import { configure } from './channel';
 import * as window from './window';
 import * as notification from './notification';
 import * as toast from './toast';
@@ -37,6 +38,7 @@ const ui = {
  * The main export which will be available by direct imports.
  */
 export {
+  configure,
   window,
   notification,
   toast,


### PR DESCRIPTION
## What?

I'm allowing any project that uses the package to be able to configure the timeouts.

## Why?

Some requests require more than 7 seconds to finish.

## How?

```javascript
import { configure } from '@shopware-ag/meteor-component-library';

configure({ 
    timeoutMs: 30000, 
    ...
});
```

## Testing?

N/A

## Screenshots (optional)

N/A

## Anything Else?

N/A