### PR TITLE
NEXT-35973 - Allow getting user's timezone

### DIFF
--- a/.changeset/soft-years-hope.md
+++ b/.changeset/soft-years-hope.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-admin-sdk": minor
+---
+
+Allow getting user's timezone

--- a/docs/admin-sdk/docs/guide/2_api-reference/context.md
+++ b/docs/admin-sdk/docs/guide/2_api-reference/context.md
@@ -271,6 +271,31 @@ Promise<{
 }
 ```
 
+## User Timezone
+
+### Get user timezone
+
+:::caution
+Do not use this feature yet. It is not implemented in a Shopware release yet.
+:::
+
+This feature allows you to get the timezone of the user.
+
+#### Usage:
+```ts
+const userTimezone = await sw.context.getUserTimezone();
+```
+
+#### Parameters
+No parameters needed.
+
+#### Return value:
+```ts
+Promise<string>
+```
+
+This function returns a Promise that resolves to a string representing the user's timezone.
+
 ## Module information
 
 ### Get module information

--- a/packages/admin-sdk/src/context/index.ts
+++ b/packages/admin-sdk/src/context/index.ts
@@ -8,6 +8,7 @@ export const subscribeLocale = createSubscriber('contextLocale');
 export const getCurrency = createSender('contextCurrency', {});
 export const getShopwareVersion = createSender('contextShopwareVersion', {});
 export const getUserInformation = createSender('contextUserInformation', {});
+export const getUserTimezone = createSender('contextUserTimezone', {});
 export const getAppInformation = createSender('contextAppInformation', {});
 export const getModuleInformation = createSender('contextModuleInformation', {});
 
@@ -89,6 +90,13 @@ export type contextUserInformation = {
     type: string,
     username: string,
   },
+}
+
+/**
+ * Get the user's timezone
+ */
+export type contextUserTimezone = {
+  responseType: string,
 }
 
 /**

--- a/packages/admin-sdk/src/message-types.ts
+++ b/packages/admin-sdk/src/message-types.ts
@@ -1,7 +1,17 @@
 import type { notificationDispatch } from './notification/index';
 import type { toastDispatch } from './toast';
 import type { windowRedirect, windowReload, windowRouterPush } from './window/index';
-import type { contextLanguage, contextEnvironment, contextLocale, contextCurrency, contextShopwareVersion, contextAppInformation, contextModuleInformation, contextUserInformation } from './context/index';
+import type {
+  contextLanguage,
+  contextEnvironment,
+  contextLocale,
+  contextCurrency,
+  contextShopwareVersion,
+  contextAppInformation,
+  contextModuleInformation,
+  contextUserInformation,
+  contextUserTimezone,
+} from './context/index';
 import type { uiComponentSectionRenderer } from './ui/component-section/index';
 import type { uiTabsAddTabItem } from './ui/tabs';
 import type { uiModulePaymentOverviewCard } from './ui/module/payment/overview-card';
@@ -45,6 +55,7 @@ export interface ShopwareMessageTypes {
   contextCurrency: contextCurrency,
   contextShopwareVersion: contextShopwareVersion,
   contextUserInformation: contextUserInformation,
+  contextUserTimezone: contextUserTimezone,
   contextAppInformation: contextAppInformation,
   contextModuleInformation: contextModuleInformation,
   getPageTitle: getPageTitle,


### PR DESCRIPTION
## What?

I'm allowing Shopware apps to get the user's timezone.

## Why?

Some applications need the user's timezone to calculate and display data based on it.

## How?

```ts
const userTimezone = await sw.context.getUserTimezone();
```

## Testing?

N/A

## Screenshots (optional)

N/A

## Anything Else?

N/A