### PR TITLE
feat: add auto close options for toast

### DIFF
--- a/packages/component-library/src/components/feedback-indicator/mt-toast/mt-toast-notification.vue
+++ b/packages/component-library/src/components/feedback-indicator/mt-toast/mt-toast-notification.vue
@@ -96,6 +96,11 @@ const messageClasses = computed(() => {
 });
 
 const showTimer = computed(() => {
+  // If autoClose is set, use that value
+  if (toast.value.autoClose !== undefined) {
+    return toast.value.autoClose;
+  }
+
   // Quick toasts, toasts in background and critical toasts with an action never show a timer
   if (
     quickDisplay.value ||

--- a/packages/component-library/src/components/feedback-indicator/mt-toast/mt-toast.interactive.stories.ts
+++ b/packages/component-library/src/components/feedback-indicator/mt-toast/mt-toast.interactive.stories.ts
@@ -538,26 +538,3 @@ export const VisualTestMessageTooLong: MtToastStory = {
     expect(toast).toBeInTheDocument();
   },
 };
-
-export const TestPreventAutoClose: MtToastStory = {
-  name: "Render toast with prevent auto close",
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-
-    const message = "This message is too long to be displayed";
-    const msg = await canvas.getByRole("textbox");
-    await userEvent.clear(msg);
-    await userEvent.type(msg, message);
-
-    const actionCheckbox = await canvas.findByText("Add action?");
-    await userEvent.click(actionCheckbox);
-
-    const toastButton = await canvas.findByText("Add critical toast");
-    await userEvent.click(toastButton);
-
-    await userEvent.hover(await canvas.getByRole("alertdialog"));
-
-    const toast = await canvas.getByText(message);
-    expect(toast).toBeInTheDocument();
-  },
-};

--- a/packages/component-library/src/components/feedback-indicator/mt-toast/mt-toast.interactive.stories.ts
+++ b/packages/component-library/src/components/feedback-indicator/mt-toast/mt-toast.interactive.stories.ts
@@ -538,3 +538,26 @@ export const VisualTestMessageTooLong: MtToastStory = {
     expect(toast).toBeInTheDocument();
   },
 };
+
+export const TestPreventAutoClose: MtToastStory = {
+  name: "Render toast with prevent auto close",
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const message = "This message is too long to be displayed";
+    const msg = await canvas.getByRole("textbox");
+    await userEvent.clear(msg);
+    await userEvent.type(msg, message);
+
+    const actionCheckbox = await canvas.findByText("Add action?");
+    await userEvent.click(actionCheckbox);
+
+    const toastButton = await canvas.findByText("Add critical toast");
+    await userEvent.click(toastButton);
+
+    await userEvent.hover(await canvas.getByRole("alertdialog"));
+
+    const toast = await canvas.getByText(message);
+    expect(toast).toBeInTheDocument();
+  },
+};

--- a/packages/component-library/src/components/feedback-indicator/mt-toast/mt-toast.stories.ts
+++ b/packages/component-library/src/components/feedback-indicator/mt-toast/mt-toast.stories.ts
@@ -55,7 +55,7 @@ export default {
         id: number;
         label: string;
         value: number;
-      }[]
+      }[];
     } {
       return {
         toasts: [],
@@ -68,7 +68,7 @@ export default {
           { id: 0, label: "Default auto close behavior", value: 1 },
           { id: 1, label: "Enable Auto close", value: 2 },
           { id: 2, label: "Disable auto close", value: 3 },
-        ]
+        ],
       };
     },
     methods: {

--- a/packages/component-library/src/components/feedback-indicator/mt-toast/mt-toast.stories.ts
+++ b/packages/component-library/src/components/feedback-indicator/mt-toast/mt-toast.stories.ts
@@ -18,16 +18,17 @@ export default {
     template: `
           <h2>Spawn some toasts 🍞</h2>
 
-          <div style="width: 420px;">
+          <div style="width: 500px;">
             <mt-text-field label="ToastMessage" v-model="msg" />
             <div style="display: flex; gap: 12px;">
               <mt-checkbox label="Display toast icon?" v-model:checked="displayIcon" />
               <mt-checkbox label="Toast manually dismissible?" v-model:checked="dismissible" />
               <mt-checkbox label="Add action?" v-model:checked="action" />
+              <mt-select small hide-clearable-button :options="autoCloseOptions" v-model="autoClose" />
             </div>
           </div>
 
-          <div style="width: 420px; display: flex; justify-content: space-around;">
+          <div style="width: 500px; display: flex; justify-content: space-around;">
             <mt-button @click="onAddToast('critical')" variant="critical">Add critical toast</mt-button>
             <mt-button @click="onAddToast('positive')" variant="primary">Add positive toast</mt-button>
             <mt-button @click="onAddToast('informal')" variant="secondary">Add informal toast</mt-button>
@@ -49,6 +50,12 @@ export default {
       displayIcon: boolean;
       dismissible: boolean;
       action: boolean;
+      autoClose: number;
+      autoCloseOptions: {
+        id: number;
+        label: string;
+        value: number;
+      }[]
     } {
       return {
         toasts: [],
@@ -56,6 +63,12 @@ export default {
         displayIcon: false,
         dismissible: false,
         action: false,
+        autoClose: 1,
+        autoCloseOptions: [
+          { id: 0, label: "Default auto close behavior", value: 1 },
+          { id: 1, label: "Enable Auto close", value: 2 },
+          { id: 2, label: "Disable auto close", value: 3 },
+        ]
       };
     },
     methods: {
@@ -67,6 +80,15 @@ export default {
 
         if (type === "informal") {
           icon = "regular-lightbulb";
+        }
+
+        let autoCloseValue;
+        if (this.autoClose === 1) {
+          autoCloseValue = undefined;
+        } else if (this.autoClose === 2) {
+          autoCloseValue = true;
+        } else if (this.autoClose === 3) {
+          autoCloseValue = false;
         }
 
         this.toasts = [
@@ -81,6 +103,7 @@ export default {
             action: this.action
               ? { label: "action", callback: () => console.log("action") }
               : undefined,
+            autoClose: autoCloseValue,
           },
           ...this.toasts,
         ];

--- a/packages/component-library/src/components/feedback-indicator/mt-toast/mt-toast.vue
+++ b/packages/component-library/src/components/feedback-indicator/mt-toast/mt-toast.vue
@@ -47,6 +47,7 @@ export interface Toast {
     callback: () => void; // Callback will be called on click
   };
   dismissible?: boolean; // Toggles if the toast is manually closable
+  autoClose?: boolean; // Toggles if the toast should auto close
 }
 
 const emit = defineEmits(["remove-toast"]);


### PR DESCRIPTION
## What?
Add auto close options for toast
## Why?
Refer: https://github.com/shopware/meteor/issues/168
## How?
create a new option `autoClose`, 
when it true, it will auto-close.
when it false, it will never auto-close.
when it undefine, follow the default behavior in toast matrix.

## Testing?
N/A
## Screenshots (optional)
N/A
## Anything Else?
N/A