### PR TITLE
add focus ring to checkbox

### DIFF
--- a/.changeset/three-plums-trade.md
+++ b/.changeset/three-plums-trade.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": patch
+---
+
+Add focus ring to checkbox

--- a/packages/component-library/src/components/form/mt-checkbox/mt-checkbox.vue
+++ b/packages/component-library/src/components/form/mt-checkbox/mt-checkbox.vue
@@ -289,6 +289,11 @@ export default defineComponent({
         cursor: pointer;
         z-index: 2;
 
+        &:focus-visible ~ .mt-field__checkbox-state {
+          border-color: var(--color-border-brand-selected);
+          box-shadow: 0 0 4px 0 rgba(24, 158, 255, 0.3);
+        }
+
         &:disabled {
           cursor: not-allowed;
         }


### PR DESCRIPTION
## What?

Adds focus ring to the checkbox.

## Why?

This improves a11y. Users can now see when they focused a checkbox.

## How?

I changed the border color and added a shadow to the checkbox.

## Testing?

You can check out the branch preview below.
