### PR TITLE
NTR - Fix tag deletion is not working on the Safari browser

### DIFF
--- a/.changeset/pretty-adults-grab.md
+++ b/.changeset/pretty-adults-grab.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": patch
+---
+
+Fix tag deletion is not working on the Safari browser

--- a/packages/component-library/src/components/_internal/mt-label.vue
+++ b/packages/component-library/src/components/_internal/mt-label.vue
@@ -1,6 +1,6 @@
 <template>
   <!-- eslint-disable-next-line vuejs-accessibility/click-events-have-key-events -->
-  <span class="mt-label" :class="labelClasses" @click.stop="$emit('selected')">
+  <span class="mt-label" :class="labelClasses" @click.stop="$emit('selected')" tabindex="0">
     <mt-color-badge v-if="appearance === 'badged'" :variant="variant" :rounded="true" />
 
     <span class="mt-label__caption">

--- a/packages/component-library/src/components/form/_internal/mt-select-base/_internal/mt-select-selection-list.vue
+++ b/packages/component-library/src/components/form/_internal/mt-select-base/_internal/mt-select-selection-list.vue
@@ -38,6 +38,7 @@
         <mt-button
           class="mt-select-selection-list__load-more-button"
           @click.stop="onClickInvisibleCount"
+          tabindex="0"
         >
           +{{ invisibleCount }}
         </mt-button>


### PR DESCRIPTION
## What?

A fix for this issue: https://github.com/shopware/meteor/issues/199

## Why?

Safari guy doesn't always trigger click events on non-interactive elements.

## How?

My fix is to make the span focusable and send a signal to Safari to trigger the click event.