### PR TITLE
PS-304 - improve styling of disabled pagination buttons

### DIFF
--- a/.changeset/young-parrots-talk.md
+++ b/.changeset/young-parrots-talk.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": patch
+---
+
+Make difference between enabled and disabled paginations button more clear

--- a/packages/component-library/src/components/table-and-list/mt-pagination/mt-pagination.vue
+++ b/packages/component-library/src/components/table-and-list/mt-pagination/mt-pagination.vue
@@ -225,8 +225,8 @@ export default defineComponent({
     }
 
     &:disabled {
-      color: var(--color-icon-primary-disabled);
-      cursor: default;
+      background-color: var(--color-interaction-secondary-disabled);
+      cursor: not-allowed;
     }
   }
 


### PR DESCRIPTION
## What?

I changed the design of the disabled pagination buttons.

## Why?

Before this changes, it was not obvious that some buttons in for the pagination were disabled. This has now changed.

## How?

I added `cursor: not-allowed` and I also changed the background color of the disabled buttons.

## Testing?

You can see the changes in the branch preview below.