### PR TITLE
Fix typo sync script

### DIFF
--- a/packages/tokens/src/common/domain/utils/string.test.ts
+++ b/packages/tokens/src/common/domain/utils/string.test.ts
@@ -2,12 +2,13 @@ import { expect, test } from 'vitest';
 import { kebabCase } from './string.js';
 
 test.each([
-  'Slate / 50',
-  ' Slate / 50 ',
-  'Slate     /     50 ',
-  'slate.50',
-  'slate / 50',
-])("turns %s into 'slate.50'", (input) => {
+  ['Slate / 50', 'slate.50'],
+  [' Slate / 50 ', 'slate.50'],
+  ['Slate     /     50 ', 'slate.50'],
+  ['slate.50', 'slate.50'],
+  ['slate / 50', 'slate.50'],
+  ['border radius / 50', 'border-radius.50'],
+])("turns %s into '%s'", (input, output) => {
   // GIVEN
   const subject = kebabCase;
 
@@ -15,5 +16,5 @@ test.each([
   const result = subject(input);
 
   // THEN
-  expect(result).toBe('slate.50');
+  expect(result).toBe(output);
 });

--- a/packages/tokens/src/common/domain/utils/string.ts
+++ b/packages/tokens/src/common/domain/utils/string.ts
@@ -1,3 +1,6 @@
 export function kebabCase(input: string) {
-  return input.toLowerCase().replace(/\//g, '.').replace(/ /g, '');
+  return input
+    .split('/')
+    .map((value) => value.toLocaleLowerCase().trim().replaceAll(' ', '-'))
+    .join('.');
 }

--- a/packages/tokens/src/deliverable/domain/CSSDeliverable.ts
+++ b/packages/tokens/src/deliverable/domain/CSSDeliverable.ts
@@ -47,7 +47,7 @@ export class CSSDeliverable implements Deliverable {
 
           if (typeof resolvedValue !== 'string') {
             throw new Error(
-              'Failed to create CSSDeliverable; Could not resolve value of aliased token',
+              `Failed to create CSSDeliverable; Could not resolve value of aliased token: ${pathToAliasedTokenValue}`,
             );
           }
 


### PR DESCRIPTION
## What?

This PR improves the debugging experience when the script fails to generate a `CSSDeliverable`

## Why?

Improves debugging information for when the script fails to resolve an aliased token

## How?

I print the path of the resolved alias token.
