### PR TITLE
Bug: dropZone show wrong highlights when drag & drop on touch devices

### DIFF
--- a/packages/component-library/src/directives/dragdrop.directive.ts
+++ b/packages/component-library/src/directives/dragdrop.directive.ts
@@ -284,7 +284,7 @@ function moveDrag(event: MouseEvent | TouchEvent) {
         if (currentDrop === null || zone.el !== currentDrop.el) {
           enterDropZone(zone.el, zone.dropConfig);
         }
-      } else if (currentDrop !== null && zone.el === currentDrop.el) {
+      } else if (currentDrop !== null) {
         leaveDropZone(zone.el, zone.dropConfig);
       }
     });
@@ -428,8 +428,9 @@ function leaveDropZone(el: HTMLElement, dropConfig: DropConfig) {
     dragElement.classList.remove(currentDrag.dragConfig.validDragCls);
     dragElement.classList.remove(currentDrag.dragConfig.invalidDragCls);
   }
-
-  currentDrop = null;
+  if (el === currentDrop.el) {
+    currentDrop = null;
+  }
 }
 
 /**


### PR DESCRIPTION
## What?
https://github.com/shopware/meteor/issues/232
## Why?
https://github.com/shopware/meteor/issues/232
## How?
- Update the logic of `touchmove` 
## Testing?
N/A
## Screenshots (optional)
N/A
## Anything Else?
N/A