### PR TITLE
NEXT-37183 - Allow set title for Criteria

### DIFF
--- a/.changeset/shy-dolphins-pay.md
+++ b/.changeset/shy-dolphins-pay.md
@@ -1,0 +1,8 @@
+---
+"@shopware-ag/meteor-admin-sdk": patch
+---
+
+Add title for Criteria for debugging
+
+Fix typescript typehint annotations
+

--- a/packages/admin-sdk/src/_internals/data/EntityCollection.ts
+++ b/packages/admin-sdk/src/_internals/data/EntityCollection.ts
@@ -7,6 +7,13 @@ type ApiAuthToken = {
     refresh: string,
 }
 
+type Aggregations = {
+  [key: string]: {
+    name: string,
+    [key: string]: unknown,
+  },
+}
+
 export interface ApiContext {
     apiPath: null | string,
     apiResourcePath: null | string,
@@ -36,7 +43,7 @@ export default class EntityCollection<EntityName extends keyof Entities> extends
 
   criteria: Criteria|null;
 
-  aggregations: string[]|null;
+  aggregations: Aggregations|null;
 
   total: number|null;
 
@@ -69,7 +76,7 @@ export default class EntityCollection<EntityName extends keyof Entities> extends
     criteria: Criteria|null = null,
     entities: Entity<EntityName>[] = [],
     total: number|null = null,
-    aggregations: string[]|null = null,
+    aggregations: Aggregations|null = null,
   ) {
     super();
 

--- a/packages/admin-sdk/src/_internals/serializer/criteria-serializer.spec.ts
+++ b/packages/admin-sdk/src/_internals/serializer/criteria-serializer.spec.ts
@@ -27,6 +27,7 @@ describe('Criteria Serializer', () => {
           page: 1,
           limit: null,
           term: null,
+          title: null,
           filters: [],
           ids: [],
           queries: [],
@@ -69,6 +70,7 @@ describe('Criteria Serializer', () => {
           page: 50,
           limit: 500,
           term: null,
+          title: null,
           filters: [],
           ids: [],
           queries: [],
@@ -98,6 +100,7 @@ describe('Criteria Serializer', () => {
     const myCriteria = new Criteria();
 
     myCriteria.setTerm('Hello world')
+    myCriteria.setTitle('Test title')
 
     myCriteria.addFilter(
       Criteria.equals('name', 'Hello world'),
@@ -165,6 +168,7 @@ describe('Criteria Serializer', () => {
         data: {
           page: 1,
           limit: null,
+          title: 'Test title',
           term: 'Hello world',
           filters: [
             {
@@ -218,6 +222,7 @@ describe('Criteria Serializer', () => {
                   page: null,
                   limit: null,
                   term: null,
+                  title: null,
                   filters: [],
                   ids: [],
                   queries: [],
@@ -238,6 +243,7 @@ describe('Criteria Serializer', () => {
                           page: null,
                           limit: null,
                           term: null,
+                          title: null,
                           filters: [],
                           ids: [],
                           queries: [],

--- a/packages/admin-sdk/src/_internals/serializer/criteria-serializer.ts
+++ b/packages/admin-sdk/src/_internals/serializer/criteria-serializer.ts
@@ -20,14 +20,16 @@ const CriteriaSerializer: SerializerFactory = () => ({
       if (hasType('__Criteria__', value) && typeof value['data'] === 'object') {
         // The original values
         const serializedData = value.data;
-  
+
         // Create new criteria object
         const deserializedCriteria = new Criteria();
-  
         // Hydrate the criteria with the orignal values
         deserializedCriteria.setPage(serializedData.page);
         deserializedCriteria.setLimit(serializedData.limit);
         deserializedCriteria.setTerm(serializedData.term);
+        if (serializedData.title !== null) {
+          deserializedCriteria.setTitle(serializedData.title);
+        }
         // @ts-expect-error
         serializedData.filters.forEach((filter) => {
           deserializedCriteria.addFilter(filter);

--- a/packages/admin-sdk/src/data/Criteria.spec.ts
+++ b/packages/admin-sdk/src/data/Criteria.spec.ts
@@ -15,4 +15,12 @@ describe('Test Criteria class', () => {
     expect(criteria.getLimit()).toBe(42);
     expect(criteria.getPage()).toBe(1);
   });
+
+  it('should able to add a title', () => {
+    const criteria = new Criteria();
+
+    expect(criteria.getTitle()).toBe(null);
+    criteria.setTitle('foo');
+    expect(criteria.getTitle()).toBe('foo');
+  });
 });

--- a/packages/admin-sdk/src/data/Criteria.ts
+++ b/packages/admin-sdk/src/data/Criteria.ts
@@ -105,17 +105,24 @@ interface Aggregations {
         name: string,
         field: string,
     },
+    entity: {
+        type: 'entity',
+        name: string,
+        field: string,
+        definition: keyof EntitySchema.Entities,
+    },
+    filter: {
+        type: 'filter',
+        name: string,
+        filter: SingleFilter[],
+        aggregation: Aggregation,
+    },
 }
 
 type ValueOf<T> = T[keyof T]
 type SingleFilter = ValueOf<Filters>;
 type Aggregation = ValueOf<Aggregations>;
-interface Filter {
-    type: 'filter',
-    name: string,
-    filter: SingleFilter[],
-    aggregation: Aggregation[],
-}
+
 interface Include {
     [entityName: string]: string[],
 }
@@ -169,6 +176,8 @@ export function setDefaultValues(options: { page?: number|null, limit?: number|n
 }
 
 export default class Criteria {
+  title: string | null;
+
   page: number | null;
 
   limit: number | null;
@@ -203,6 +212,7 @@ export default class Criteria {
     this.page = page;
     this.limit = limit;
     this.term = null;
+    this.title = null;
     this.filters = [];
     this.includes = null;
     this.ids = [];
@@ -282,6 +292,17 @@ export default class Criteria {
     return params;
   }
 
+  /**
+   * Allows to provide a title for the criteria. This title will be shown in the `repository.search` request url so it can be used for debugging in network's tab
+   */
+  setTitle(title: string): this {
+    this.title = title;
+    return this;
+  }
+
+  getTitle(): string|null {
+    return this.title;
+  }
   /**
    * Allows to provide a list of ids which are used as a filter
    */
@@ -474,6 +495,7 @@ export default class Criteria {
       page: Criteria['page'],
       limit: Criteria['limit'],
       term: Criteria['term'],
+      title: Criteria['title'],
       filters: Criteria['filters'],
       ids: Criteria['ids'],
       queries: Criteria['queries'],
@@ -491,6 +513,7 @@ export default class Criteria {
       page: this.page,
       limit: this.limit,
       term: this.term,
+      title: this.title,
       filters: this.filters,
       ids: this.ids,
       queries: this.queries,
@@ -582,10 +605,18 @@ export default class Criteria {
   }
 
   /**
+   * @see \Shopware\Core\Framework\DataAbstractionLayer\Search\Aggregation\Metric\EntityAggregation
+   * Allows to filter an aggregation result
+   */
+  static entityAggregation(name: string, field: string, definition: keyof EntitySchema.Entities): Aggregations['entity'] {
+    return { type: 'entity', name, field, definition };
+  }
+
+  /**
    * @see \Shopware\Core\Framework\DataAbstractionLayer\Search\Aggregation\Bucket\FilterAggregation
    * Allows to filter an aggregation result
    */
-  static filter(name: string, filter: SingleFilter[], aggregation: Aggregation[]): Filter {
+  static filter(name: string, filter: SingleFilter[], aggregation: Aggregation): Aggregations['filter'] {
     return { type: 'filter', name, filter, aggregation };
   }
 


### PR DESCRIPTION
## What?

1.  I fixed some wrongly typed in admin-sdk (NEXT-36488) and added some missing aggregation types in Criteria.ts

2. I added a new title in Criteria so it's can be used for debugging

Example usage:

```ts
criteria.setTitle('fetchNewlyCreatedCustomers');
```

## Why?

It's hard to distinguish different search requests, it can used for apps & platform to have better overview in network tab

## How?

Add title property in Criteria.ts.

I will create a following up MR in platform after this change is released.

## Testing?

Unit test

## Screenshots (optional)

**Before:**

You can't quickly see the difference between search requests without reading the payload

<img width="1067" alt="Screenshot 2024-07-11 at 20 00 23" src="https://github.com/user-attachments/assets/e5f34136-f339-481f-8c03-bd539d452404">

**After**

The search requests now have a name

<img width="1213" alt="Screenshot 2024-07-11 at 21 55 47" src="https://github.com/user-attachments/assets/8ccb580b-6aee-4e8f-9a9b-dbba03ed5bf4">
