### PR TITLE
NEXT-36817 - fix typo sync script

### DIFF
--- a/packages/tokens/src/deliverable/domain/CSSDeliverable.test.ts
+++ b/packages/tokens/src/deliverable/domain/CSSDeliverable.test.ts
@@ -68,9 +68,10 @@ test('creates a CSSDeliverable with the default selector of ":root"', () => {
     mode: 'Default',
   });
 
+  const subject = CSSDeliverable;
+
   // WHEN
-  const subject = CSSDeliverable.fromDictionary(dictionary);
-  const result = subject.toString();
+  const result = subject.fromDictionary(dictionary).toString();
 
   // THEN
   expect(result).toMatchInlineSnapshot(`
@@ -123,16 +124,19 @@ test('creates a CSSDeliverable with a custom selector', () => {
       },
     },
   };
+
   const dictionary = Dictionary.fromFigmaApiResponse(response, {
     mode: 'Default',
   });
 
-  // WHEN
-  const subject = CSSDeliverable.fromDictionary(dictionary, {
-    selector: '[data-theme="dark"]',
-  });
+  const subject = CSSDeliverable;
 
-  const result = subject.toString();
+  // WHEN
+  const result = subject
+    .fromDictionary(dictionary, {
+      selector: '[data-theme="dark"]',
+    })
+    .toString();
 
   // THEN
   expect(result).toMatchInlineSnapshot(`
@@ -189,9 +193,10 @@ test('creates a CSSDeliverable with nested tokens', () => {
     mode: 'Default',
   });
 
+  const subject = CSSDeliverable;
+
   // WHEN
-  const subject = CSSDeliverable.fromDictionary(dictionary);
-  const result = subject.toString();
+  const result = subject.fromDictionary(dictionary).toString();
 
   // THEN
   expect(result).toMatchInlineSnapshot(`
@@ -323,12 +328,15 @@ test('creates a CSSDeliverable with aliased token', () => {
     },
   );
 
+  const subject = CSSDeliverable;
+
   // WHEN
-  const subject = CSSDeliverable.fromDictionary(adminDarkDictionary, {
-    selector: ':root',
-    additionalDictionaries: [primitiveTokenDictionary],
-  });
-  const result = subject.toString();
+  const result = subject
+    .fromDictionary(adminDarkDictionary, {
+      selector: ':root',
+      additionalDictionaries: [primitiveTokenDictionary],
+    })
+    .toString();
 
   // THEN
   expect(result).toMatchInlineSnapshot(`
@@ -380,8 +388,10 @@ test('creates a CSSDeliverable with string tokens', () => {
     mode: 'Default',
   });
 
+  const subject = CSSDeliverable;
+
   // WHEN
-  const result = CSSDeliverable.fromDictionary(dictionary).toString();
+  const result = subject.fromDictionary(dictionary).toString();
 
   // THEN
   expect(result).toMatchInlineSnapshot(`
@@ -433,8 +443,10 @@ test('creates a CSSDeliverable with font weight tokens', () => {
     mode: 'Default',
   });
 
+  const subject = CSSDeliverable;
+
   // WHEN
-  const result = CSSDeliverable.fromDictionary(dictionary).toString();
+  const result = subject.fromDictionary(dictionary).toString();
 
   // THEN
   expect(result).toMatchInlineSnapshot(`
@@ -486,13 +498,131 @@ test('creates a CSSDeliverable with font weight font size', () => {
     mode: 'Default',
   });
 
+  const subject = CSSDeliverable;
+
   // WHEN
-  const result = CSSDeliverable.fromDictionary(dictionary).toString();
+  const result = subject.fromDictionary(dictionary).toString();
 
   // THEN
   expect(result).toMatchInlineSnapshot(`
   ":root {
     --font-size-s: 1rem;
+  }
+  "
+`);
+});
+
+test('resolves an aliased token to a number value', () => {
+  // GIVEN
+  const primitiveTokensResponse: FigmaApiResponse = {
+    status: 200,
+    error: false,
+    meta: {
+      variables: {
+        'VariableID:12362:253': {
+          id: 'VariableID:12362:253',
+          name: 'spacing/16',
+          key: '41815235668468a5b0abd05e420f2fd252422d82',
+          variableCollectionId: 'VariableCollectionId:12362:179',
+          resolvedType: 'FLOAT',
+          valuesByMode: {
+            '12362:0': 16,
+          },
+          remote: false,
+          description: '',
+          hiddenFromPublishing: false,
+          scopes: ['ALL_SCOPES'],
+        },
+      },
+      variableCollections: {
+        'VariableCollectionId:12362:179': {
+          id: 'VariableCollectionId:12362:179',
+          name: 'Primitives',
+          key: '2bd5662002cb0d016b4f7603cffcf825e5537bfc',
+          modes: [{ modeId: '12362:0', name: 'Light mode' }],
+          defaultModeId: '12362:0',
+          remote: false,
+          hiddenFromPublishing: false,
+          variableIds: ['VariableID:12362:253'],
+        },
+      },
+    },
+  };
+
+  const adminTokenResponse: FigmaApiResponse = {
+    status: 200,
+    error: false,
+    meta: {
+      variables: {
+        'VariableID:2:1764': {
+          id: 'VariableID:2:1764',
+          name: 'border radius/l',
+          key: 'dcc4dd0912912eb8216b47a914b6a8ed017a43f4',
+          variableCollectionId: 'VariableCollectionId:2:1625',
+          resolvedType: 'FLOAT',
+          valuesByMode: {
+            '2:1': {
+              id: 'VariableID:41815235668468a5b0abd05e420f2fd252422d82/12362:253',
+              type: 'VARIABLE_ALIAS',
+            },
+            '2:2': {
+              id: 'VariableID:41815235668468a5b0abd05e420f2fd252422d82/12362:253',
+              type: 'VARIABLE_ALIAS',
+            },
+          },
+          remote: false,
+          description: '',
+          hiddenFromPublishing: false,
+          scopes: ['ALL_SCOPES'],
+        },
+      },
+      variableCollections: {
+        'VariableCollectionId:2:1625': {
+          id: 'VariableCollectionId:2:1625',
+          name: 'Tokens',
+          key: '80c5c6a36e5779d966dd579fa9eb05df9537c128',
+          modes: [
+            { modeId: '2:1', name: 'Light mode' },
+            { modeId: '2:2', name: 'Dark mode' },
+          ],
+          defaultModeId: '2:1',
+          remote: false,
+          hiddenFromPublishing: false,
+          variableIds: ['VariableID:2:1764'],
+        },
+      },
+    },
+  };
+
+  const adminLightDictionary = Dictionary.fromFigmaApiResponse(
+    adminTokenResponse,
+    {
+      mode: 'Light mode',
+      remoteFiles: [primitiveTokensResponse],
+    },
+  );
+
+  const primitiveDictionary = Dictionary.fromFigmaApiResponse(
+    primitiveTokensResponse,
+    {
+      mode: 'Light mode',
+    },
+  );
+
+  const subject = CSSDeliverable;
+
+  // WHEN
+  const result = subject
+    .fromDictionary(adminLightDictionary, {
+      selector: ':root',
+      additionalDictionaries: [primitiveDictionary],
+    })
+    .toString();
+
+  // THEN
+  expect(result).toMatchInlineSnapshot(`
+  ":root {
+    --border-radius-l: 1rem;
   }
   "
 `);

--- a/packages/tokens/src/deliverable/domain/CSSDeliverable.ts
+++ b/packages/tokens/src/deliverable/domain/CSSDeliverable.ts
@@ -45,10 +45,21 @@ export class CSSDeliverable implements Deliverable {
           const resolvedValue =
             tokensInAdditionalDictionaries[pathToAliasedTokenValue];
 
-          if (typeof resolvedValue !== 'string') {
+          if (
+            typeof resolvedValue !== 'string' &&
+            typeof resolvedValue !== 'number'
+          ) {
             throw new Error(
               `Failed to create CSSDeliverable; Could not resolve value of aliased token: ${pathToAliasedTokenValue}`,
             );
+          }
+
+          if (typeof resolvedValue === 'number') {
+            if (!variableName.includes('weight')) {
+              return `--${variableName}: ${resolvedValue / 16}rem;`;
+            }
+
+            return `--${variableName}: ${resolvedValue};`;
           }
 
           return `--${variableName}: ${resolvedValue};`;


### PR DESCRIPTION
## What?

This script fixes the token sync script. It allows us to sync non-string tokens.

## Why?

This allows us to sync the new tokens for things like typography, sizing and border radius.

## How?

I allowed the dictionary to resolve tokens that contain string and number values.

## Testing?

I've written a unit test in TDD style for this change.
