### PR TITLE
fix: mixed declarations (sass)

### DIFF
--- a/packages/component-library/src/components/context-menu/mt-context-button/mt-context-button.vue
+++ b/packages/component-library/src/components/context-menu/mt-context-button/mt-context-button.vue
@@ -175,11 +175,11 @@ $mt-context-button-color-disabled: var(--color-icon-primary-disabled);
 
   &.has--error {
     .mt-context-button__button {
+      color: $color-crimson-300;
+
       .mt-icon {
         color: $mt-context-button-color-text;
       }
-
-      color: $color-crimson-300;
     }
   }
 }


### PR DESCRIPTION
## What?

Sass compiler throws Deprecation Warning.

## Why?

Because of Mixed declarations.

## How?

https://sass-lang.com/documentation/breaking-changes/mixed-decls/

## Testing?

*Not rly.*

## Screenshots (optional)

![image](https://github.com/user-attachments/assets/26637c23-ca32-43fb-9175-0f465e3e1ae7)

## Anything Else?

We will create a few PRs in the following weeks, addressing small issues with other components in Vite/Nuxt env.