### PR TITLE
fix: disable next and last page button in mt-pagination

### DIFF
--- a/.changeset/gorgeous-snakes-press.md
+++ b/.changeset/gorgeous-snakes-press.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": minor
+---
+
+Disable next page and last page button in mt-pagination when data table is empty

--- a/packages/component-library/src/components/table-and-list/mt-pagination/mt-pagination.spec.ts
+++ b/packages/component-library/src/components/table-and-list/mt-pagination/mt-pagination.spec.ts
@@ -1,5 +1,11 @@
 import { mount } from "@vue/test-utils";
 import MtPagination from "./mt-pagination.vue";
+import { render, screen } from "@testing-library/vue";
+
+// Mock the $t function
+const mockT = (key: any) => {
+  return key;
+};
 
 function createWrapper() {
   return mount(MtPagination, {
@@ -114,6 +120,27 @@ describe("mt-pagination", () => {
       await pageInput.trigger("change");
 
       expect(wrapper.emitted()["change-current-page"][0]).toStrictEqual([7]);
+    });
+
+    it("should disable the next page and last page button when total page value is zero", async () => {
+      render(MtPagination, {
+        props: {
+          currentPage: 1,
+          totalItems: 0,
+          limit: 25,
+        },
+        global: {
+          mocks: {
+            $t: mockT,
+          },
+        },
+      });
+
+      const nextPageButton = screen.getByRole("button", { name: /mt-pagination.nextPage/i });
+      const lastPageButton = screen.getByRole("button", { name: /mt-pagination.lastPage/i });
+
+      expect(nextPageButton).toBeDisabled();
+      expect(lastPageButton).toBeDisabled();
     });
   });
 });

--- a/packages/component-library/src/components/table-and-list/mt-pagination/mt-pagination.vue
+++ b/packages/component-library/src/components/table-and-list/mt-pagination/mt-pagination.vue
@@ -124,7 +124,7 @@ export default defineComponent({
     );
 
     const totalPages = computed(() => {
-      return Math.ceil(props.totalItems / props.limit);
+      return Math.max(1, Math.ceil(props.totalItems / props.limit));
     });
 
     const isOnFirstPage = computed(() => props.currentPage === 1);


### PR DESCRIPTION
## What?
We can click the "Next Page" and "Last Page" buttons even when the data table is empty.
https://meteor-component-library.vercel.app/?path=/story/interaction-tests-table-and-list-mt-data-table--visual-test-render-empty-state

## Why?
Calculate the value of totalPages will be zero if totalItems is zero, which will lead to the value of isOnLastPage being false.

## How?
I add a max value as one in the case totalItems is zero.

## Testing?
Unit test