### PR TITLE
NEXT-37472 - Fix select-selection-list placeholder not wrapping issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,5 +13,5 @@
   "devDependencies": {
     "turbo": "^2.0.1"
   },
-  "packageManager": "pnpm@8.15.4"
+  "packageManager": "pnpm@9.5.0"
 }

--- a/packages/component-library/src/components/form/_internal/mt-select-base/_internal/mt-select-selection-list.vue
+++ b/packages/component-library/src/components/form/_internal/mt-select-base/_internal/mt-select-selection-list.vue
@@ -46,7 +46,7 @@
       </slot>
     </li>
 
-    <li v-if="!disableInput">
+    <li v-if="!disableInput" class="mt-select-selection-list__input-wrapper">
       <slot name="input" v-bind="{ placeholder, searchTerm, onSearchTermChange, onKeyDownDelete }">
         <!-- eslint-disable-next-line vuejs-accessibility/form-control-has-label -->
         <input
@@ -271,6 +271,9 @@ export default defineComponent({
     border-color: var(--color-border-primary-default);
   }
 
+  .mt-select-selection-list__input-wrapper {
+    flex: 1 1 0;
+  }
   .mt-select-selection-list__input {
     display: inline-block;
     min-width: 200px;
@@ -278,6 +281,7 @@ export default defineComponent({
 
     &::placeholder {
       color: lighten($color-darkgray-200, 25%);
+      white-space: break-spaces;
     }
   }
 }


### PR DESCRIPTION
## What?
Fixing the wrapping issue for the select placeholder. [NEXT-37472](https://shopware.atlassian.net/browse/NEXT-37472)

## Why?
It is causing to show a clipped placeholder in case the placeholder text is too long to fit

## How?
Add CSS in the input wrapper to expand to full width and make the placeholder text to wrap

## Testing?
1. Run Storybook locally and go to http://localhost:6006/?path=/docs/interaction-tests-form-mt-select--docs
2. remove the selected values and set the `placeholder` prop to a very long text

## Screenshots (optional)
![image](https://github.com/user-attachments/assets/24e412f9-6179-4dc6-a1dd-3326b6879494)
![image](https://github.com/user-attachments/assets/6564ff6e-6125-46af-beea-584e4532032d)

# Anything else?
This PR also updates the package.json `packageManager` version to match the current `pnpm-lock.yaml` version



[NEXT-37472]: https://shopware.atlassian.net/browse/NEXT-37472?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ