### PR TITLE
fix: console warnings

### DIFF
--- a/.changeset/clever-clocks-pull.md
+++ b/.changeset/clever-clocks-pull.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": patch
+---
+
+Fixed missing emit definition and console warning

--- a/packages/component-library/src/components/navigation/mt-tabs/mt-tabs.vue
+++ b/packages/component-library/src/components/navigation/mt-tabs/mt-tabs.vue
@@ -108,7 +108,7 @@ export default defineComponent({
     "mt-icon": MtIcon,
   },
 
-  emits: ['new-item-active'],
+  emits: ["new-item-active"],
 
   props: {
     items: {

--- a/packages/component-library/src/components/navigation/mt-tabs/mt-tabs.vue
+++ b/packages/component-library/src/components/navigation/mt-tabs/mt-tabs.vue
@@ -108,6 +108,8 @@ export default defineComponent({
     "mt-icon": MtIcon,
   },
 
+  emits: ['new-item-active'],
+
   props: {
     items: {
       type: Array as PropType<TabItem[]>,

--- a/packages/component-library/src/components/overlay/mt-modal/mt-modal.vue
+++ b/packages/component-library/src/components/overlay/mt-modal/mt-modal.vue
@@ -48,7 +48,7 @@
 </template>
 
 <script setup lang="ts">
-import { nextTick, onMounted, onUnmounted, ref, watch, type PropType, defineEmits } from "vue";
+import { nextTick, onMounted, onUnmounted, ref, watch, type PropType } from "vue";
 import { useModalContext } from "./composables/useModalContext";
 import MtIcon from "@/components/icons-media/mt-icon/mt-icon.vue";
 import MtModalClose from "./sub-components/mt-modal-close.vue";


### PR DESCRIPTION
## What?

Fixes warning in console `[Vue warn]: Extraneous non-emits event listeners (newItemActive) were passed to component but could not be automatically inherited because component renders fragment or text root nodes. If the listener is intended to be a component custom event listener only, declare it using the "emits" option.` and eslint warning `'defineEmits' is defined but never used`.

## Why?

## How?

## Testing?

## Screenshots (optional)

## Anything Else?
