### PR TITLE
NEXT-37979 - Fix  input arrow up and down issue

### DIFF
--- a/.changeset/dirty-rules-live.md
+++ b/.changeset/dirty-rules-live.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": patch
+---
+
+fix the issue in the sw-number-field component when pressing the up or down arrow keys if a new value was typed

--- a/packages/component-library/src/components/form/mt-number-field/mt-number-field.interactive.stories.ts
+++ b/packages/component-library/src/components/form/mt-number-field/mt-number-field.interactive.stories.ts
@@ -64,7 +64,6 @@ export const TestIncreaseByControl: MtNumberFieldStory = {
     expect(args.updateModelValue).toHaveBeenCalledWith(11);
   },
 };
-
 export const TestDecreaseByKeyStroke: MtNumberFieldStory = {
   name: "Should decrease value by key stroke",
   args: {
@@ -171,6 +170,40 @@ export const TestIncreaseConsiderMax: MtNumberFieldStory = {
 
     expect(args.change).toHaveBeenCalledWith(10);
     expect(args.updateModelValue).toHaveBeenCalledWith(10);
+  },
+};
+
+export const TestIncreaseByKeyStrokeAfterTyping: MtNumberFieldStory = {
+  name: "Should increase value by key stroke after typing a value",
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(canvas.getByRole("textbox"));
+    await userEvent.type(canvas.getByRole("textbox"), "10");
+    await userEvent.type(canvas.getByRole("textbox"), "{arrowup}");
+
+    // Notice that the value is of type string and the value of the event is of type number
+    expect((canvas.getByRole("textbox") as HTMLInputElement).value).toBe("11");
+
+    expect(args.change).toHaveBeenCalledWith(11);
+    expect(args.updateModelValue).toHaveBeenCalledWith(11);
+  },
+};
+
+export const TestDecreaseByKeyStrokeAfterTyping: MtNumberFieldStory = {
+  name: "Should decrease value by key stroke after typing a value",
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(canvas.getByRole("textbox"));
+    await userEvent.type(canvas.getByRole("textbox"), "10");
+    await userEvent.type(canvas.getByRole("textbox"), "{arrowdown}");
+
+    // Notice that the value is of type string and the value of the event is of type number
+    expect((canvas.getByRole("textbox") as HTMLInputElement).value).toBe("9");
+
+    expect(args.change).toHaveBeenCalledWith(9);
+    expect(args.updateModelValue).toHaveBeenCalledWith(9);
   },
 };
 

--- a/packages/component-library/src/components/form/mt-number-field/mt-number-field.vue
+++ b/packages/component-library/src/components/form/mt-number-field/mt-number-field.vue
@@ -253,6 +253,7 @@ export default defineComponent({
           val = this.min;
         }
 
+        this.computeValue(val.toString());
         this.$emit("input-change", val);
       }
     },


### PR DESCRIPTION
## What?
This MR fixes the issue in the sw-number-field component when pressing the up or down arrow keys if a new value was typed.

## Why?
Before the fix, when the user types some value in a number field and after pressing the arrow up key or arrow down key, the new value is incorrect.

## How?
The solution was to update the internal value on any key input. This way when the arrow keys are pressed, the actual value is there.

## Testing?

Test cases were added

To manually testing:
1. Go to components-form-mt-number-field--docs
3. Focus in the input and type some number
4. Without moving the focus from the field press arrow up or arrow down.

