### PR TITLE
Resolve tokens recursively

### DIFF
--- a/packages/tokens/src/deliverable/domain/CSSDeliverable.test.ts
+++ b/packages/tokens/src/deliverable/domain/CSSDeliverable.test.ts
@@ -627,3 +627,130 @@ test('resolves an aliased token to a number value', () => {
   "
 `);
 });
+
+test('resolves an aliased token from the same dictionary', () => {
+  // GIVEN
+  const adminTokenResponse: FigmaApiResponse = {
+    status: 200,
+    error: false,
+    meta: {
+      variables: {
+        'VariableID:41413:11953': {
+          id: 'VariableID:41413:11953',
+          name: 'border radius/m',
+          key: 'd7db1858980b1b6fcbde5ebbaeb48b1880c68a55',
+          variableCollectionId: 'VariableCollectionId:11953:115879',
+          resolvedType: 'FLOAT',
+          valuesByMode: {
+            '11953:0': {
+              type: 'VARIABLE_ALIAS',
+              id: 'VariableID:db9aa5d3b7c6f03b4cddb78e045b566fae112d17/51413:51953',
+            },
+          },
+          remote: false,
+          description: '',
+          hiddenFromPublishing: false,
+          scopes: ['ALL_SCOPES'],
+        },
+        'VariableID:64259:28974': {
+          id: 'VariableID:64259:28974',
+          name: 'border radius/card',
+          key: 'l4dh1d48980b1b6fcbde5ebbaeb48b1880c68a55',
+          variableCollectionId: 'VariableCollectionId:11953:115879',
+          resolvedType: 'FLOAT',
+          valuesByMode: {
+            '11953:0': {
+              type: 'VARIABLE_ALIAS',
+              id: 'VariableID:41413:11953',
+            },
+          },
+          remote: false,
+          description: '',
+          hiddenFromPublishing: false,
+          scopes: ['ALL_SCOPES'],
+        },
+      },
+      variableCollections: {
+        'VariableCollectionId:11953:115879': {
+          id: 'VariableCollectionId:11953:115879',
+          name: '.Design Tokens',
+          key: '9130479ef323598b1ccfb32e7b16dc80fcb30f14',
+          modes: [{ modeId: '11953:0', name: 'Default' }],
+          defaultModeId: '11953:0',
+          remote: false,
+          hiddenFromPublishing: true,
+          variableIds: ['VariableID:41413:11953', 'VariableID:64259:28974'],
+        },
+      },
+    },
+  };
+
+  const primitiveTokenResponse: FigmaApiResponse = {
+    status: 200,
+    error: false,
+    meta: {
+      variableCollections: {
+        'VariableCollectionId:21953:215879': {
+          id: 'VariableCollectionId:21953:215879',
+          name: '.Design Tokens',
+          key: '9130479ef323598b1ccfb32e7b16dc80fcb30f14',
+          modes: [{ modeId: '11953:0', name: 'Default' }],
+          defaultModeId: '11953:0',
+          remote: false,
+          hiddenFromPublishing: true,
+          variableIds: ['VariableID:51413:51953'],
+        },
+      },
+      variables: {
+        'VariableID:51413:51953': {
+          id: 'VariableID:51413:51953',
+          name: 'scale/size/8',
+          key: 'db9aa5d3b7c6f03b4cddb78e045b566fae112d17',
+          variableCollectionId: 'VariableCollectionId:21953:215879',
+          resolvedType: 'FLOAT',
+          valuesByMode: {
+            '11953:0': 8,
+          },
+          remote: false,
+          description: '',
+          hiddenFromPublishing: false,
+          scopes: ['ALL_SCOPES'],
+        },
+      },
+    },
+  };
+
+  const adminLightDictionary = Dictionary.fromFigmaApiResponse(
+    adminTokenResponse,
+    {
+      mode: 'Default',
+      remoteFiles: [primitiveTokenResponse],
+    },
+  );
+
+  const primitiveDictionary = Dictionary.fromFigmaApiResponse(
+    primitiveTokenResponse,
+    {
+      mode: 'Default',
+    },
+  );
+
+  const subject = CSSDeliverable;
+
+  // WHEN
+  const result = subject
+    .fromDictionary(adminLightDictionary, {
+      selector: ':root',
+      additionalDictionaries: [primitiveDictionary],
+    })
+    .toString();
+
+  // THEN
+  expect(result).toMatchInlineSnapshot(`
+  ":root {
+    --border-radius-m: 0.5rem;
+    --border-radius-card: 0.5rem;
+  }
+  "
+`);
+});

--- a/packages/tokens/src/dictionary/domain/Dictionary.test.ts
+++ b/packages/tokens/src/dictionary/domain/Dictionary.test.ts
@@ -663,3 +663,123 @@ test('creates a dictionary with number tokens', () => {
     },
   });
 });
+
+test('Creates a dictionary with variable aliases from the same file', () => {
+  // GIVEN
+  const response: FigmaApiResponse = {
+    status: 200,
+    error: false,
+    meta: {
+      variables: {
+        'VariableID:41413:11953': {
+          id: 'VariableID:41413:11953',
+          name: 'border radius/m',
+          key: 'd7db1858980b1b6fcbde5ebbaeb48b1880c68a55',
+          variableCollectionId: 'VariableCollectionId:11953:115879',
+          resolvedType: 'FLOAT',
+          valuesByMode: {
+            '11953:0': {
+              type: 'VARIABLE_ALIAS',
+              id: 'VariableID:db9aa5d3b7c6f03b4cddb78e045b566fae112d17/51413:51953',
+            },
+          },
+          remote: false,
+          description: '',
+          hiddenFromPublishing: false,
+          scopes: ['ALL_SCOPES'],
+        },
+        'VariableID:64259:28974': {
+          id: 'VariableID:64259:28974',
+          name: 'border radius/card',
+          key: 'l4dh1d48980b1b6fcbde5ebbaeb48b1880c68a55',
+          variableCollectionId: 'VariableCollectionId:11953:115879',
+          resolvedType: 'FLOAT',
+          valuesByMode: {
+            '11953:0': {
+              type: 'VARIABLE_ALIAS',
+              id: 'VariableID:41413:11953',
+            },
+          },
+          remote: false,
+          description: '',
+          hiddenFromPublishing: false,
+          scopes: ['ALL_SCOPES'],
+        },
+      },
+      variableCollections: {
+        'VariableCollectionId:11953:115879': {
+          id: 'VariableCollectionId:11953:115879',
+          name: '.Design Tokens',
+          key: '9130479ef323598b1ccfb32e7b16dc80fcb30f14',
+          modes: [{ modeId: '11953:0', name: 'Default' }],
+          defaultModeId: '11953:0',
+          remote: false,
+          hiddenFromPublishing: true,
+          variableIds: ['VariableID:41413:11953', 'VariableID:64259:28974'],
+        },
+      },
+    },
+  };
+
+  const responseOfFileWithPrimitiveTokens: FigmaApiResponse = {
+    status: 200,
+    error: false,
+    meta: {
+      variableCollections: {
+        'VariableCollectionId:21953:215879': {
+          id: 'VariableCollectionId:21953:215879',
+          name: '.Design Tokens',
+          key: '9130479ef323598b1ccfb32e7b16dc80fcb30f14',
+          modes: [{ modeId: '11953:0', name: 'Default' }],
+          defaultModeId: '11953:0',
+          remote: false,
+          hiddenFromPublishing: true,
+          variableIds: ['VariableID:51413:51953'],
+        },
+      },
+      variables: {
+        'VariableID:51413:51953': {
+          id: 'VariableID:51413:51953',
+          name: 'scale/size/8',
+          key: 'db9aa5d3b7c6f03b4cddb78e045b566fae112d17',
+          variableCollectionId: 'VariableCollectionId:21953:215879',
+          resolvedType: 'FLOAT',
+          valuesByMode: {
+            '11953:0': {
+              r: 0,
+              g: 0,
+              b: 0,
+              a: 1,
+            },
+          },
+          remote: false,
+          description: '',
+          hiddenFromPublishing: false,
+          scopes: ['ALL_SCOPES'],
+        },
+      },
+    },
+  };
+
+  const subject = Dictionary;
+
+  // WHEN
+  const result = subject.fromFigmaApiResponse(response, {
+    mode: 'Default',
+    remoteFiles: [responseOfFileWithPrimitiveTokens],
+  }).value;
+
+  // THEN
+  expect(result).toStrictEqual({
+    'border-radius': {
+      m: {
+        $type: 'float',
+        $value: '{scale.size.8}',
+      },
+      card: {
+        $type: 'float',
+        $value: '{border-radius.m}',
+      },
+    },
+  });
+});

--- a/packages/tokens/src/dictionary/domain/Dictionary.ts
+++ b/packages/tokens/src/dictionary/domain/Dictionary.ts
@@ -82,6 +82,17 @@ export class Dictionary {
         ].reduce<undefined | string>((accumulator, remoteFile) => {
           if (accumulator) return accumulator;
 
+          const referencingVariableFromSameFile = !rawValue.id.includes('/');
+          if (referencingVariableFromSameFile) {
+            const resolvedVariable = Object.values(
+              remoteFile.meta.variables,
+            ).find((variable) => variable.id === rawValue.id);
+
+            if (!resolvedVariable) return undefined;
+
+            return kebabCase(resolvedVariable.name);
+          }
+
           const START_OF_KEY = 11;
           const END_OF_KEY = 51;
           const variableKey = rawValue.id.slice(START_OF_KEY, END_OF_KEY);

--- a/packages/tokens/src/figma/infrastructure/FigmaApi.ts
+++ b/packages/tokens/src/figma/infrastructure/FigmaApi.ts
@@ -2,7 +2,7 @@ import { type HttpClient } from '../../common/domain/http-client/HttpClient.js';
 import { z } from 'zod';
 
 const variableAlias = z.object({
-  id: z.string().regex(/^VariableID:[0-9a-f]{40}\/\d+:\d+$/),
+  id: z.string().regex(/^VariableID:([0-9a-f]{40}\/)?\d+:\d+$/),
   type: z.literal('VARIABLE_ALIAS'),
 });
 

--- a/packages/tokens/src/figma/infrastructure/FigmaApi.ts
+++ b/packages/tokens/src/figma/infrastructure/FigmaApi.ts
@@ -68,7 +68,18 @@ export class FigmaApi {
         Accept: '*/*',
         'X-Figma-Token': this.config.apiKey,
       })
-      .then((response) => responseSchema.parse(response))
+      .then((response) => {
+        try {
+          return responseSchema.parse(response);
+        } catch (error) {
+          const notAZodError = !(error instanceof z.ZodError);
+          if (notAZodError) throw error;
+
+          throw new Error(
+            `Failed to parse Figma API response: ${error.message}`,
+          );
+        }
+      })
       .then((response) => {
         // filter out all remote variables and variable collections
         response.meta.variables = Object.fromEntries(


### PR DESCRIPTION
## What?

The script now resolves tokens recursively.

## Why?

This is needed so we can have multiple layers of semantic tokens.

## How?

Instead of resolving tokens only one layer deep we do this recursively until it resolves to a valid value.

## Testing?

I've written some unit tests that should be enough
