### PR TITLE
use semantic border radius tokens in card component

### DIFF
--- a/.changeset/brave-pillows-kneel.md
+++ b/.changeset/brave-pillows-kneel.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": patch
+---
+
+Use semantic border radius tokens in card component

--- a/packages/component-library/src/components/layout/mt-card/mt-card.vue
+++ b/packages/component-library/src/components/layout/mt-card/mt-card.vue
@@ -242,7 +242,7 @@ export default defineComponent({
   overflow: hidden;
 
   &:not(&--hero) {
-    border-radius: var(--border-radius-m);
+    border-radius: var(--border-radius-card);
   }
 
   &.mt-card--is-inherited {
@@ -440,7 +440,7 @@ export default defineComponent({
   &.mt-card--has-footer {
     .mt-card__content {
       border: none;
-      border-radius: 0;
+      border-radius: var(--border-radius-none);
     }
   }
 }


### PR DESCRIPTION
## What?

I added some semantic border radii token to the mt-card component.

## Why?

This allows us to theme the card component.

## How?

Replaced the old values with the new semantic tokens.

## Testing?

The visual tests will catch issues. 
