### PR TITLE
fix: remove @vue/compiler-sfc warning

### DIFF
--- a/packages/component-library/src/components/feedback-indicator/mt-toast/mt-toast.vue
+++ b/packages/component-library/src/components/feedback-indicator/mt-toast/mt-toast.vue
@@ -31,7 +31,7 @@
 </template>
 
 <script setup lang="ts">
-import { type PropType, ref, toRef, defineProps, computed, watch, defineEmits } from "vue";
+import { type PropType, ref, toRef, computed, watch } from "vue";
 import MtToastNotification from "./mt-toast-notification.vue";
 
 export interface Toast {

--- a/packages/component-library/src/components/overlay/mt-modal/sub-components/mt-modal-action.vue
+++ b/packages/component-library/src/components/overlay/mt-modal/sub-components/mt-modal-action.vue
@@ -3,7 +3,7 @@
 </template>
 
 <script setup lang="ts">
-import { defineProps, defineEmits, type Component } from "vue";
+import { type Component } from "vue";
 import { useModalContext } from "../composables/useModalContext";
 
 defineEmits(["click"]);

--- a/packages/component-library/src/components/overlay/mt-modal/sub-components/mt-modal-close.vue
+++ b/packages/component-library/src/components/overlay/mt-modal/sub-components/mt-modal-close.vue
@@ -5,7 +5,7 @@
 </template>
 
 <script setup lang="ts">
-import { defineProps, type Component } from "vue";
+import { type Component } from "vue";
 import { useModalContext } from "../composables/useModalContext";
 
 defineProps<{

--- a/packages/component-library/src/components/overlay/mt-modal/sub-components/mt-modal-trigger.vue
+++ b/packages/component-library/src/components/overlay/mt-modal/sub-components/mt-modal-trigger.vue
@@ -3,7 +3,7 @@
 </template>
 
 <script setup lang="ts">
-import { defineProps, type Component } from "vue";
+import { type Component } from "vue";
 import { useModalContext } from "../composables/useModalContext";
 
 defineProps<{ as: Component }>();


### PR DESCRIPTION
## What?

It removes `defineProps` and `defineEmits` imports, [provided by @vue/compiler-sfc in script setup](https://vuejs.org/api/sfc-script-setup#defineprops-defineemits).

## Why?

Because of compilation warning

```
WARN  [@vue/compiler-sfc] defineProps is a compiler macro and no longer needs to be imported.
WARN  [@vue/compiler-sfc] defineEmits is a compiler macro and no longer needs to be imported.
```

## How?

By removing such imports.

## Testing?

## Screenshots (optional)

## Anything Else?
