### PR TITLE
remove scss from modal

### DIFF
--- a/packages/component-library/src/components/overlay/mt-modal/mt-modal.vue
+++ b/packages/component-library/src/components/overlay/mt-modal/mt-modal.vue
@@ -205,7 +205,7 @@ onUnmounted(() => {
 });
 </script>
 
-<style scoped lang="scss">
+<style scoped>
 .mt-modal {
   height: auto;
   position: fixed;
@@ -360,7 +360,7 @@ onUnmounted(() => {
   width: 2rem;
   height: 2rem;
 
-  // prevents hover stlyes from being applied to non-hoverable devices
+  /* prevents hover stlyes from being applied to non-hoverable devices */
   @media (hover: hover) {
     &:hover {
       background-color: var(--color-interaction-secondary-hover);


### PR DESCRIPTION
## What?

Removes the SCSS from the modal component.

## Why?

This gets us closer to the goal of getting rid of SCSS.

## How?

I replaced the SCSS with plain css.

## Testing?

The visual tests should catch everything.

# Anything else

This PR has no changelog because it's only a refactor and does not have any effect on users of this package.