### PR TITLE
Deprecate large prop of card

### DIFF
--- a/packages/component-library/src/components/layout/mt-card/mt-card.vue
+++ b/packages/component-library/src/components/layout/mt-card/mt-card.vue
@@ -142,6 +142,7 @@ export default defineComponent({
 
     /**
      * Render the card in a large size
+     * @depracated v4.0.0 - will be removed without replacement
      */
     large: {
       type: Boolean,
@@ -308,6 +309,7 @@ export default defineComponent({
   }
 }
 
+/* @depracated v4.0.0 - will be removed without replacement */
 .mt-card--large {
   max-width: 83.125rem;
 

--- a/packages/component-library/src/components/layout/mt-card/mt-card.vue
+++ b/packages/component-library/src/components/layout/mt-card/mt-card.vue
@@ -91,7 +91,6 @@ import { computed, defineComponent, useSlots, type PropType } from "vue";
 import MtContextButton from "../../context-menu/mt-context-button/mt-context-button.vue";
 import MtLoader from "../../feedback-indicator/mt-loader/mt-loader.vue";
 import MtIcon from "../../icons-media/mt-icon/mt-icon.vue";
-// TODO: this file needs to be one level lower
 import MtText from "../../content/mt-text/mt-text.vue";
 
 export default defineComponent({


### PR DESCRIPTION
## What?

This pr deprecates the `large` property of the card component.

## Why?

Components should almost never have a max-width set by themselves. The parent element should
be responsible for doing that.

## How?

I deprecated the property.
