### PR TITLE
add future flag to remove card max width

### DIFF
--- a/.changeset/chatty-shirts-think.md
+++ b/.changeset/chatty-shirts-think.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": minor
+---
+
+Add future flag for removing card max width

--- a/packages/component-library/src/components/layout/mt-card/mt-card.vue
+++ b/packages/component-library/src/components/layout/mt-card/mt-card.vue
@@ -92,6 +92,7 @@ import MtContextButton from "../../context-menu/mt-context-button/mt-context-but
 import MtLoader from "../../feedback-indicator/mt-loader/mt-loader.vue";
 import MtIcon from "../../icons-media/mt-icon/mt-icon.vue";
 import MtText from "../../content/mt-text/mt-text.vue";
+import { useFutureFlags } from "@/composables/useFutureFlags";
 
 export default defineComponent({
   name: "MtCard",
@@ -187,6 +188,8 @@ export default defineComponent({
   setup(props) {
     const slots = useSlots();
 
+    const futureFlags = useFutureFlags();
+
     const showHeader = computed(
       () =>
         !!props.title || !!slots.title || !!props.subtitle || !!slots.subtitle || !!slots.avatar,
@@ -199,6 +202,7 @@ export default defineComponent({
       "mt-card--large": props.large,
       "mt-card--has-footer": !!slots.footer,
       "mt-card--is-inherited": !!props.inheritance,
+      "mt-card--future-ignore-max-width": futureFlags.removeCardWidth,
     }));
 
     const titleWrapperClasses = computed(() => ({
@@ -325,6 +329,11 @@ export default defineComponent({
     left: 0;
     text-align: left;
   }
+}
+
+.mt-card--future-ignore-max-width {
+  max-width: none;
+  margin-inline: 0;
 }
 
 .mt-card__titles {

--- a/packages/component-library/src/composables/useFutureFlags.ts
+++ b/packages/component-library/src/composables/useFutureFlags.ts
@@ -1,8 +1,12 @@
 import { inject, provide } from "vue";
 
-export type FutureFlags = {};
+export type FutureFlags = {
+  removeCardWidth: boolean;
+};
 
-const defaultFutureFlags: FutureFlags = {};
+const defaultFutureFlags: FutureFlags = {
+  removeCardWidth: false,
+};
 
 export const futureFlagsInjectionKey = Symbol("mt-future-flags");
 


### PR DESCRIPTION
## What?

I've added a new future flag to toggle the max-width behavior of cards.

## Why?

The max width of the card component has been deprecated. To enable an easier transition to the new behavior people are able to switch to the new behavior before we make the breaking change.

## How?

I've added a new future flag.

The project can decide wether they want to adapt the new feature early or not.

To do that they need to add the `mt-theme-provider` component and enable the `removeCardWidth` flag like this:

```vue
<template>
  <mt-theme-provider :future="{ removeCardWidth: true }">
    <!-- Your content -->
  </mt-theme-provider>
</template>
```
 
## Anything Else?

By default the old behavior is applied, but you can decide to change it by editing the them config via the `mt-theme-provider` component
