### PR TITLE
deprecate small prop on tab component

### DIFF
--- a/.changeset/smart-cobras-boil.md
+++ b/.changeset/smart-cobras-boil.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": patch
+---
+
+Deprecate small prop on tabs component

--- a/packages/component-library/src/components/navigation/mt-tabs/mt-tabs.vue
+++ b/packages/component-library/src/components/navigation/mt-tabs/mt-tabs.vue
@@ -122,6 +122,9 @@ export default defineComponent({
       default: false,
     },
 
+    /**
+     * @deprecated v4.0.0 - Set max-width through parent container element
+     */
     small: {
       type: Boolean,
       required: false,


### PR DESCRIPTION
## What?

I deprecated the `small` property.

## Why?

Elements should not set their max-width on their own. This is the job of the container element.

## How?

I marked the property as deprecated

## Testing?

No testing possible
