### PR TITLE
remove default margin from card

### DIFF
--- a/.changeset/strange-ducks-learn.md
+++ b/.changeset/strange-ducks-learn.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": patch
+---
+
+remove default margin from card component, hidden by future flag

--- a/packages/component-library/src/components/layout/mt-card/mt-card.vue
+++ b/packages/component-library/src/components/layout/mt-card/mt-card.vue
@@ -203,6 +203,7 @@ export default defineComponent({
       "mt-card--has-footer": !!slots.footer,
       "mt-card--is-inherited": !!props.inheritance,
       "mt-card--future-ignore-max-width": futureFlags.removeCardWidth,
+      "mt-card--future-remove-default-margin": futureFlags.removeDefaultMargin,
     }));
 
     const titleWrapperClasses = computed(() => ({
@@ -252,6 +253,10 @@ export default defineComponent({
   &:not(:has(.mt-card__tabs:empty)) .mt-card__header {
     border-bottom: none;
   }
+}
+
+.mt-card--future-remove-default-margin {
+  margin-block-end: 0;
 }
 
 .mt-card__content {


### PR DESCRIPTION
## What?

This PR removes the default margin from the card component.

## Why?

Components should not have margin set by themselves. The parent component should always take care of spacing elements.

## How?

The default margin will only be removed when the `removeDefaultMargin` flag is enabled.

## Testing?

Add a `mt-theme-provider` component and enable the `removeDefaultMargin` flag
