### PR TITLE
Migrate avatar to plain css and composition api

### DIFF
--- a/packages/component-library/src/components/icons-media/mt-avatar/mt-avatar.spec.ts
+++ b/packages/component-library/src/components/icons-media/mt-avatar/mt-avatar.spec.ts
@@ -1,0 +1,25 @@
+import { render, screen } from "@testing-library/vue";
+import MtAvatar from "./mt-avatar.vue";
+
+describe("mt-avatar", () => {
+  it("shows only a placeholder", () => {
+    render(MtAvatar, { props: { placeholder: true } });
+
+    const result = screen.getByTestId("mt-avatar-placeholder");
+
+    expect(result).toBeInTheDocument();
+
+    expect(screen.queryByTestId("mt-avatar-initials")).not.toBeInTheDocument();
+  });
+
+  it("shows only initials", () => {
+    render(MtAvatar, { props: { firstName: "John", lastName: "Doe" } });
+
+    const result = screen.getByTestId("mt-avatar-initials");
+
+    expect(result).toBeInTheDocument();
+    expect(result).toHaveTextContent("JD");
+
+    expect(screen.queryByTestId("mt-avatar-placeholder")).not.toBeInTheDocument();
+  });
+});

--- a/packages/component-library/src/components/icons-media/mt-avatar/mt-avatar.vue
+++ b/packages/component-library/src/components/icons-media/mt-avatar/mt-avatar.vue
@@ -11,7 +11,7 @@
         {{ avatarInitials }}
       </span>
       <span v-if="showPlaceholder">
-        <mt-icon name="default-avatar-single" />
+        <mt-icon color="var(--color-icon-brand-default)" name="default-avatar-single" />
       </span>
     </slot>
   </span>
@@ -205,28 +205,22 @@ export default defineComponent({
 });
 </script>
 
-<style lang="scss">
-$mt-avatar-size-default: 40px;
-
+<style scoped>
 .mt-avatar {
   display: inline-block;
-  width: $mt-avatar-size-default;
-  height: $mt-avatar-size-default;
-  border-radius: 100%;
-  background: $color-gray-200 no-repeat center center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: var(--border-radius-round);
+  background: #ffc700 no-repeat center center;
   background-size: cover;
   text-align: center;
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
   text-transform: uppercase;
-  color: $color-white;
+  color: var(--color-text-static-default);
   user-select: none;
+}
 
-  .mt-icon {
-    color: $color-shopware-brand-500;
-  }
-
-  &.mt-avatar__square {
-    border-radius: 4px;
-  }
+.mt-avatar__square {
+  border-radius: var(--border-radius-xs);
 }
 </style>

--- a/packages/component-library/src/components/icons-media/mt-avatar/mt-avatar.vue
+++ b/packages/component-library/src/components/icons-media/mt-avatar/mt-avatar.vue
@@ -7,13 +7,16 @@
     role="img"
   >
     <slot>
-      <span v-if="showInitials" class="mt-avatar__initials">
+      <span v-if="showInitials" class="mt-avatar__initials" data-testid="mt-avatar-initials">
         {{ avatarInitials }}
       </span>
 
-      <span v-if="showPlaceholder">
-        <mt-icon name="regular-user" />
-      </span>
+      <mt-icon
+        v-if="showPlaceholder"
+        aria-hidden
+        name="regular-user"
+        data-testid="mt-avatar-placeholder"
+      />
     </slot>
   </span>
 </template>

--- a/packages/component-library/src/components/icons-media/mt-avatar/mt-avatar.vue
+++ b/packages/component-library/src/components/icons-media/mt-avatar/mt-avatar.vue
@@ -1,6 +1,6 @@
 <template>
   <span
-    ref="MtAvatar"
+    ref="avatarRef"
     class="mt-avatar"
     :class="'mt-avatar__' + variant"
     :style="[avatarImage, avatarColor, avatarSize, avatarInitialsSize]"
@@ -10,16 +10,27 @@
       <span v-if="showInitials" class="mt-avatar__initials">
         {{ avatarInitials }}
       </span>
+
       <span v-if="showPlaceholder">
-        <mt-icon color="var(--color-icon-brand-default)" name="default-avatar-single" />
+        <mt-icon name="regular-user" />
       </span>
     </slot>
   </span>
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
 import cloneDeep from "lodash-es/cloneDeep";
-import { defineComponent, type StyleValue } from "vue";
+import MtIcon from "../mt-icon/mt-icon.vue";
+import {
+  reactive,
+  computed,
+  onMounted,
+  ref,
+  watch,
+  nextTick,
+  type CSSProperties,
+  type PropType,
+} from "vue";
 
 const colors = [
   "#FFD700",
@@ -36,172 +47,142 @@ const colors = [
   "#3CCA88",
 ];
 
-export default defineComponent({
-  name: "MtAvatar",
-
-  props: {
-    color: {
-      type: String,
-      required: false,
-      default: "",
-    },
-    size: {
-      type: String,
-      required: false,
-      default: null,
-    },
-    firstName: {
-      type: String,
-      required: false,
-      default: "",
-    },
-    lastName: {
-      type: String,
-      required: false,
-      default: "",
-    },
-    imageUrl: {
-      type: String,
-      required: false,
-      default: null,
-    },
-    placeholder: {
-      type: Boolean,
-      required: false,
-      default: false,
-    },
-    sourceContext: {
-      type: Object,
-      required: false,
-      default: null,
-    },
-    variant: {
-      type: String,
-      required: false,
-      default: "circle",
-      validator: (value: string) => ["circle", "square"].includes(value),
-    },
+const props = defineProps({
+  color: {
+    type: String,
+    required: false,
+    default: "",
   },
+  size: {
+    type: String,
+    required: false,
+    default: null,
+  },
+  firstName: {
+    type: String,
+    required: false,
+    default: "",
+  },
+  lastName: {
+    type: String,
+    required: false,
+    default: "",
+  },
+  imageUrl: {
+    type: String,
+    required: false,
+    default: null,
+  },
+  placeholder: {
+    type: Boolean,
+    required: false,
+    default: false,
+  },
+  sourceContext: {
+    type: Object as PropType<{
+      avatarMedia: { url: string; thumbnails: { width: number; url: string }[] } | undefined;
+    }>,
+    required: false,
+    default: null,
+  },
+  variant: {
+    type: String,
+    required: false,
+    default: "circle",
+    validator: (value: string) => ["circle", "square"].includes(value),
+  },
+});
 
-  data() {
+const sizes = reactive({
+  fontSize: 16,
+  lineHeight: 16,
+});
+
+const avatarSize = computed(() => ({
+  width: props.size,
+  height: props.size,
+}));
+
+const avatarInitials = computed(() => {
+  const firstNameLetter = props.firstName ? props.firstName[0] : "";
+  const lastNameLetter = props.lastName ? props.lastName[0] : "";
+
+  return firstNameLetter + lastNameLetter;
+});
+
+const avatarInitialsSize = computed(() => ({
+  "font-size": `${sizes.fontSize / 16}rem`,
+  "line-height": `${sizes.lineHeight / 16}rem`,
+}));
+
+const avatarRef = ref<HTMLElement | null>(null);
+function generateAvatarInitialsSize() {
+  if (!avatarRef.value) return;
+
+  const avatarSize = avatarRef.value.offsetHeight;
+
+  sizes.fontSize = Math.round(avatarSize * 0.4);
+  sizes.lineHeight = Math.round(avatarSize * 0.98);
+}
+
+onMounted(() => {
+  generateAvatarInitialsSize();
+});
+
+watch(
+  () => props.size,
+  () => {
+    nextTick(() => {
+      generateAvatarInitialsSize();
+    });
+  },
+);
+
+const avatarImage = computed<CSSProperties>(() => {
+  if (props.imageUrl) {
+    return { "background-image": `url('${props.imageUrl}')` };
+  }
+
+  if (!props.sourceContext?.avatarMedia?.url) {
+    return {};
+  }
+
+  const avatarMedia = cloneDeep(props.sourceContext.avatarMedia);
+
+  const thumbnailImage = avatarMedia.thumbnails.sort((a, b) => a.width - b.width)[0];
+  const previewImageUrl = thumbnailImage ? thumbnailImage.url : avatarMedia.url;
+
+  return { "background-image": `url('${previewImageUrl}')` };
+});
+
+const hasAvatarImage = computed(() => {
+  return !!avatarImage.value && !!avatarImage.value["background-image"];
+});
+
+const showPlaceholder = computed(() => {
+  return props.placeholder && !hasAvatarImage.value;
+});
+
+const showInitials = computed(() => {
+  return !props.placeholder && !hasAvatarImage.value;
+});
+
+const avatarColor = computed<CSSProperties>(() => {
+  if (props.color.length) {
     return {
-      fontSize: 16,
-      lineHeight: 16,
+      "background-color": props.color,
     };
-  },
+  }
 
-  computed: {
-    avatarSize(): {
-      width: string;
-      height: string;
-    } {
-      return {
-        width: this.size,
-        height: this.size,
-      };
-    },
+  const firstNameLength = props.firstName ? props.firstName.length : 0;
+  const lastNameLength = props.lastName ? props.lastName.length : 0;
 
-    avatarInitials(): string {
-      const firstNameLetter = this.firstName ? this.firstName[0] : "";
-      const lastNameLetter = this.lastName ? this.lastName[0] : "";
+  const nameLength = firstNameLength + lastNameLength;
+  const color = colors[nameLength % colors.length];
 
-      return firstNameLetter + lastNameLetter;
-    },
-
-    avatarInitialsSize(): {
-      "font-size": string;
-      "line-height": string;
-    } {
-      return {
-        "font-size": `${this.fontSize}px`,
-        "line-height": `${this.lineHeight}px`,
-      };
-    },
-
-    avatarImage():
-      | {
-          "background-image": string;
-        }
-      | StyleValue {
-      if (this.imageUrl) {
-        return { "background-image": `url('${this.imageUrl}')` };
-      }
-
-      if (!this.sourceContext?.avatarMedia?.url) {
-        return {};
-      }
-
-      const avatarMedia = cloneDeep(this.sourceContext.avatarMedia);
-      // @ts-expect-error - thumbnails exists
-      const thumbnailImage = avatarMedia.thumbnails.sort((a, b) => a.width - b.width)[0];
-      const previewImageUrl = thumbnailImage ? thumbnailImage.url : avatarMedia.url;
-
-      return { "background-image": `url('${previewImageUrl}')` };
-    },
-
-    avatarColor(): {
-      "background-color": string;
-    } {
-      if (this.color.length) {
-        return {
-          "background-color": this.color,
-        };
-      }
-
-      const firstNameLength = this.firstName ? this.firstName.length : 0;
-      const lastNameLength = this.lastName ? this.lastName.length : 0;
-
-      const nameLength = firstNameLength + lastNameLength;
-      const color = colors[nameLength % colors.length];
-
-      return {
-        "background-color": color,
-      };
-    },
-
-    hasAvatarImage(): boolean {
-      // @ts-expect-error - background-image exists in avatarImage
-      return !!this.avatarImage && !!this.avatarImage["background-image"];
-    },
-
-    showPlaceholder(): boolean {
-      return this.placeholder && !this.hasAvatarImage;
-    },
-
-    showInitials(): boolean {
-      return !this.placeholder && !this.hasAvatarImage;
-    },
-  },
-
-  watch: {
-    size() {
-      this.$nextTick(() => {
-        this.generateAvatarInitialsSize();
-      });
-    },
-  },
-
-  mounted() {
-    this.mountedComponent();
-  },
-
-  methods: {
-    mountedComponent() {
-      this.generateAvatarInitialsSize();
-    },
-
-    generateAvatarInitialsSize() {
-      if (!this.$refs.MtAvatar) {
-        return;
-      }
-
-      // @ts-expect-error - offsetHeight exists on element
-      const avatarSize = this.$refs.MtAvatar.offsetHeight;
-
-      this.fontSize = Math.round(avatarSize * 0.4);
-      this.lineHeight = Math.round(avatarSize * 0.98);
-    },
-  },
+  return {
+    "background-color": color,
+  };
 });
 </script>
 


### PR DESCRIPTION
## What?

I moved the `mt-avatar` component over to plain CSS.

## Why?

This helps us to get rid of SCSS.

## How?

Migrated the SCSS over to CSS.

## Testing?

I've written some tests for the component, but feel free to test it yourself.

## Anything Else?

* I've added some tests for the `mt-avatar` component
* I've moved the component over to the composition api
