### PR TITLE
remove default margin from base field

### DIFF
--- a/.changeset/tender-llamas-sleep.md
+++ b/.changeset/tender-llamas-sleep.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": patch
+---
+
+Remove default margin from base field, hidden by future flag

--- a/packages/component-library/src/components/form/_internal/mt-base-field/mt-base-field.vue
+++ b/packages/component-library/src/components/form/_internal/mt-base-field/mt-base-field.vue
@@ -1,5 +1,17 @@
 <template>
-  <div class="mt-field" :class="classes">
+  <div
+    class="mt-field"
+    :class="[
+      {
+        'has--error': hasError,
+        'is--disabled': disabled,
+        'is--inherited': isInherited,
+        'has--focus': hasFocus,
+        'mt-field--future-remove-default-margin': future.removeDefaultMargin,
+      },
+      mtBlockSize,
+    ]"
+  >
     <div class="mt-field__label">
       <mt-inheritance-switch
         v-if="isInheritanceField"
@@ -59,6 +71,7 @@ import useEmptySlotCheck from "../../../../composables/useEmptySlotCheck";
 import MtValidationMixin from "../../../../mixins/validation.mixin";
 import MtFormFieldMixin from "../../../../mixins/form-field.mixin";
 import { createId } from "../../../../utils/id";
+import { useFutureFlags } from "@/composables/useFutureFlags";
 
 export default defineComponent({
   name: "MtBaseField",
@@ -209,19 +222,6 @@ export default defineComponent({
       };
     },
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    classes(): any[] {
-      return [
-        {
-          "has--error": this.hasError,
-          "is--disabled": this.disabled,
-          "is--inherited": this.isInherited,
-          "has--focus": this.hasFocus,
-        },
-        this.mtBlockSize,
-      ];
-    },
-
     mtBlockSize(): string {
       return `mt-field--${this.size}`;
     },
@@ -233,9 +233,11 @@ export default defineComponent({
 
   setup() {
     const { hasSlotContent } = useEmptySlotCheck();
+    const future = useFutureFlags();
 
     return {
       hasSlotContent,
+      future,
     };
   },
 });
@@ -470,5 +472,9 @@ $mt-field-transition:
       }
     }
   }
+}
+
+.mt-field--future-remove-default-margin {
+  margin-bottom: 0;
 }
 </style>


### PR DESCRIPTION
## What?

This PR remove the default margin for the base field and therefore for many of the form elements.

## Why?

The parent component should always take care of spacing elements, not the element itself.

## How?

The default margin gets removed when the `removeDefaultMargin` future flag is enabled.

## Testing?

The visual tests should catch every issue, but feel free to test it out yourself using the branch preview below.

## Anything Else?
