### PR TITLE
migrate skeleton over to plain css

### DIFF
--- a/packages/component-library/src/components/feedback-indicator/mt-skeleton-bar/mt-skeleton-bar.vue
+++ b/packages/component-library/src/components/feedback-indicator/mt-skeleton-bar/mt-skeleton-bar.vue
@@ -4,51 +4,38 @@
   </div>
 </template>
 
-<script lang="ts">
-import { defineComponent } from "vue";
-
-export default defineComponent({
-  name: "MtSkeletonBar",
-});
-</script>
-
-<style lang="scss">
-$mt-skeleton-bar-color: var(--color-background-primary-disabled);
-$mt-skeleton-bar-height: 32px;
-$mt-skeleton-shimmer-dark: var(--color-elevation-surface-sunken);
-$mt-skeleton-shimmer-light: var(--color-background-primary-disabled);
-
+<style scoped>
 .mt-skeleton-bar {
-  height: $mt-skeleton-bar-height;
+  height: 2rem;
   width: 100%;
-  background-color: $mt-skeleton-bar-color;
+  background-color: var(--color-background-primary-disabled);
   overflow: hidden;
   border-radius: var(--border-radius-xs);
 
   &:not(:last-child) {
-    margin-bottom: 32px;
+    margin-bottom: 2rem;
   }
+}
 
-  &__shimmer {
-    height: 100%;
-    background-image: linear-gradient(
-      89.17deg,
-      $mt-skeleton-shimmer-light 0.8%,
-      $mt-skeleton-shimmer-dark 50.09%,
-      $mt-skeleton-shimmer-light 96.31%
-    );
-    background-size: 100%;
-    background-repeat: no-repeat;
-    background-position: 0 0;
-    animation: barShimmer 1800ms infinite;
-    animation-timing-function: linear;
-    transform: translate(-100%);
+.mt-skeleton-bar__shimmer {
+  height: 100%;
+  background-image: linear-gradient(
+    89.17deg,
+    var(--color-background-primary-disabled) 0.8%,
+    var(--color-elevation-surface-sunken) 50.09%,
+    var(--color-background-primary-disabled) 96.31%
+  );
+  background-size: 100%;
+  background-repeat: no-repeat;
+  background-position: 0 0;
+  animation: barShimmer 1.8s infinite;
+  animation-timing-function: linear;
+  transform: translate(-100%);
+}
 
-    @keyframes barShimmer {
-      to {
-        transform: translate(120%);
-      }
-    }
+@keyframes barShimmer {
+  to {
+    transform: translate(120%);
   }
 }
 </style>


### PR DESCRIPTION
## What?

This PR migrates the skeleton component over to plain css.

## Why?

This brings us a step closer to getting rid of SCSS.

## How?

Replaced the SCSS with plain CSS.

## Testing?

The visual tests should catch issues.

## Anything Else?

I've also enabled scoped css for this component.
