### PR TITLE
Allow disabling individual tab items

### DIFF
--- a/.changeset/stupid-toes-punch.md
+++ b/.changeset/stupid-toes-punch.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": patch
+---
+
+Allow disabling individual tab items

--- a/packages/component-library/src/components/navigation/mt-tabs/mt-tabs.interactive.stories.ts
+++ b/packages/component-library/src/components/navigation/mt-tabs/mt-tabs.interactive.stories.ts
@@ -267,3 +267,38 @@ export const VisualTestRenderTabsWithContextMenuBadge: MtTabsStory = {
     await expect(menuItem[menuItem.length - 9]).toHaveTextContent("Item with critical badge");
   },
 };
+
+export const VisualTestRenderTabsWithDisabledItem: MtTabsStory = {
+  name: "Render tabs with disabled item",
+  args: {
+    defaultItem: "item1",
+    items: [
+      ...tabItems.slice(0, 4),
+      {
+        label: "Disabled item",
+        name: "item5",
+        disabled: true,
+      },
+    ],
+  },
+  async play({ canvasElement }) {
+    const canvas = within(canvasElement);
+
+    const disabledTabItem = canvas.getByRole("tab", { name: /disabled/i });
+
+    expect(disabledTabItem).toBeDisabled();
+
+    await userEvent.tab();
+    await userEvent.tab();
+    await userEvent.tab();
+    await userEvent.tab();
+    await userEvent.tab();
+    await userEvent.tab();
+
+    expect(canvas.getByRole("tab", { name: /item 1/i })).toHaveFocus();
+
+    await userEvent.click(disabledTabItem);
+
+    expect(canvas.getByRole("tab", { name: /item 1/i })).toHaveAttribute("aria-selected", "true");
+  },
+};

--- a/packages/component-library/src/components/navigation/mt-tabs/mt-tabs.vue
+++ b/packages/component-library/src/components/navigation/mt-tabs/mt-tabs.vue
@@ -1,10 +1,10 @@
 <template>
   <priority-plus ref="priorityPlus" #default="{ mainItems, moreItems }" :list="items">
-    <ul :class="tabClasses" role="tablist">
+    <div :class="tabClasses" role="tablist">
       <span class="mt-tabs__slider" :class="sliderClasses" :style="sliderStyle" />
 
       <template v-if="!vertical">
-        <li
+        <button
           v-for="item in mainItems"
           :key="item.name"
           :data-priority-plus="item.name"
@@ -15,7 +15,7 @@
           :data-item-name="item.name"
           role="tab"
           :aria-selected="item.name === activeItemName"
-          :tabindex="0"
+          :disabled="item.disabled"
           @click="handleClick(item.name)"
           @keyup.enter="handleClick(item.name)"
         >
@@ -28,7 +28,7 @@
           />
 
           <mt-color-badge v-if="item.badge" :variant="item.badge" rounded />
-        </li>
+        </button>
 
         <!-- @vue-skip -->
         <mt-context-button
@@ -72,7 +72,7 @@
           {{ item.label }}
         </li>
       </template>
-    </ul>
+    </div>
   </priority-plus>
 </template>
 
@@ -399,6 +399,11 @@ export default defineComponent({
   line-height: var(--font-line-height-xs);
   cursor: pointer;
   color: var(--color-text-primary-default);
+
+  &:disabled {
+    cursor: not-allowed;
+    color: var(--color-text-primary-disabled);
+  }
 
   /* Trick to stop items from jumping when the active item changes
    * see: https://css-tricks.com/bold-on-hover-without-the-layout-shift/

--- a/packages/component-library/src/components/navigation/mt-tabs/mt-tabs.vue
+++ b/packages/component-library/src/components/navigation/mt-tabs/mt-tabs.vue
@@ -405,6 +405,12 @@ export default defineComponent({
     color: var(--color-text-primary-disabled);
   }
 
+  &:focus-visible {
+    outline: 2px solid var(--color-border-brand-selected);
+    outline-offset: 2px;
+    border-radius: var(--border-radius-xs);
+  }
+
   /* Trick to stop items from jumping when the active item changes
    * see: https://css-tricks.com/bold-on-hover-without-the-layout-shift/
    */


### PR DESCRIPTION
## What?

This PR allows developers to disable individual tab items.

## Why?

There are cases where individual tab items need to be disabled.

## How?

I've change the `li`'s to `button` elements and added a `disabled` property.

## Testing?

I've created a new story with an automated test. But feel free to verify the new behavior by yourself.

## Anything Else?

This PR also updates the focus styles for the tab component to be more in tune with the other focus styles.
