### PR TITLE
Deprecate mt-external link component

### DIFF
--- a/.changeset/gentle-plants-flash.md
+++ b/.changeset/gentle-plants-flash.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": patch
+---
+
+Deprecated mt-external link component

--- a/packages/component-library/src/components/form/mt-external-link/mt-external-link.vue
+++ b/packages/component-library/src/components/form/mt-external-link/mt-external-link.vue
@@ -31,6 +31,7 @@
 import { defineComponent } from "vue";
 import MtIcon from "../../icons-media/mt-icon/mt-icon.vue";
 
+/** @deprecated tag:4.0 -- use mt-link instead */
 export default defineComponent({
   name: "MtExternalLink",
 


### PR DESCRIPTION
## What?

I deprecated the mt-external link

## Why?

This component is no longer needed as we have another `mt-link` component. That component can do the same things this component can do.

## How?

I added a deprecation.

## Testing?

The visual tests will catch issues, but feel free to test it yourself.

## Anything Else?

* I add a notification that the default value for the `as` property will be `a` instead of `router-link`
