### PR TITLE
deprecate mt-url-field component

### DIFF
--- a/.changeset/curvy-walls-dress.md
+++ b/.changeset/curvy-walls-dress.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": patch
+---
+
+Deprecated the mt-url-field component

--- a/packages/component-library/src/components/form/mt-url-field/mt-url-field.vue
+++ b/packages/component-library/src/components/form/mt-url-field/mt-url-field.vue
@@ -78,6 +78,9 @@ const URL_REGEX = {
   TRAILING_SLASH: /\/+$/,
 };
 
+/**
+ * @deprecated tag:4.0 -- will be removed without replacement
+ */
 export default defineComponent({
   name: "MtUrlField",
 


### PR DESCRIPTION
## What?

This PR deprecates the `mt-url-field`

## Why?

This component is not really used anywhere. The same functionality can also be achieved by wrapping the text component and adding a suffix.

## How?

I deprecated the component.

## Testing?

There's no need for testing.
