### PR TITLE
add useI18n composable

### DIFF
--- a/packages/component-library/src/components/theme/mt-theme-provider.vue
+++ b/packages/component-library/src/components/theme/mt-theme-provider.vue
@@ -3,13 +3,14 @@
 </template>
 
 <script setup lang="ts">
+import { provideI18n } from "@/composables/useI18n";
 import { type FutureFlags, provideFutureFlags } from "../../composables/useFutureFlags";
 
-type Props = {
+const props = defineProps<{
   future?: FutureFlags;
-};
-
-const props = defineProps<Props>();
+  locale?: string;
+}>();
 
 provideFutureFlags(props.future);
+provideI18n(props.locale);
 </script>

--- a/packages/component-library/src/composables/useI18n.spec.ts
+++ b/packages/component-library/src/composables/useI18n.spec.ts
@@ -1,0 +1,34 @@
+import { render, screen } from "@testing-library/vue";
+import { useI18n } from "./useI18n";
+
+describe("useI18n", () => {
+  it("returns the translation for the given path", () => {
+    render({
+      setup() {
+        const { t } = useI18n({
+          messages: { en: { greeting: "Hello!" } },
+        });
+
+        return { t };
+      },
+      template: "{{ t('greeting') }}",
+    });
+
+    expect(screen.getByText("Hello!")).toBeInTheDocument();
+  });
+
+  it("returns the path to the translation if no translation is found", () => {
+    render({
+      setup() {
+        const { t } = useI18n({
+          messages: { en: { greeting: "Hello!" } },
+        });
+
+        return { t };
+      },
+      template: "{{ t('path.to.translation') }}",
+    });
+
+    expect(screen.getByText("path.to.translation")).toBeInTheDocument();
+  });
+});

--- a/packages/component-library/src/composables/useI18n.ts
+++ b/packages/component-library/src/composables/useI18n.ts
@@ -1,0 +1,53 @@
+import { provide, inject } from "vue";
+
+function get(obj: Record<string, unknown>, path: string) {
+  if (typeof obj !== "object" || obj === null) return undefined;
+
+  const keys = path.split(".");
+  let result = obj;
+
+  for (const key of keys) {
+    if (result === undefined || result === null) return undefined;
+
+    // @ts-ignore
+    result = result[key];
+  }
+
+  return result;
+}
+
+interface TranslationDictionary {
+  [key: string]: string | TranslationDictionary;
+}
+
+type Options = { messages: TranslationDictionary };
+
+const defaultI18nState = {
+  locale: "en",
+  defaultLocale: "en",
+};
+
+const i18nInjectionKey = Symbol("mt-i18n");
+
+export function provideI18n(locale: string = "en") {
+  const state = {
+    ...defaultI18nState,
+    locale: locale,
+  };
+
+  provide(i18nInjectionKey, state);
+}
+
+export function useI18n({ messages }: Options) {
+  const i18n = inject(i18nInjectionKey, defaultI18nState);
+
+  function translate(path: string): string {
+    const translation = get(messages, `${i18n.locale}.${path}`);
+    if (translation) return translation.toString();
+
+    const fallback = get(messages, `${i18n.defaultLocale}.${path}`);
+    return fallback ? fallback.toString() : path;
+  }
+
+  return { t: translate };
+}


### PR DESCRIPTION
## What?

I added a custom built `useI18n` composable for translating text.

## Why?

Right now apps are forced to install the i18n plugin and configure it by themselves.

## How?

I added a new useI18n hook that will be used by the components. You can toggle the locale by setting the `locale` prop on the `mt-theme-provider` component.

## Testing?

I've written some unit tests that make sure the composable works as intended.

## Anything Else?
