### PR TITLE
add translation for mt-banner

### DIFF
--- a/.changeset/chilled-apricots-grab.md
+++ b/.changeset/chilled-apricots-grab.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": patch
+---
+
+Add translation for mt-banner

--- a/packages/component-library/src/components/feedback-indicator/mt-banner/mt-banner.vue
+++ b/packages/component-library/src/components/feedback-indicator/mt-banner/mt-banner.vue
@@ -23,8 +23,7 @@
     <button
       v-if="closable"
       class="mt-banner__close"
-      aria-label="Schließen"
-      title="Schließen"
+      :aria-label="t('close')"
       @click.prevent="$emit('close', bannerIndex)"
     >
       <mt-icon name="solid-times-s" />
@@ -37,6 +36,18 @@ import { computed } from "vue";
 import MtIcon from "../../icons-media/mt-icon/mt-icon.vue";
 import MtText from "@/components/content/mt-text/mt-text.vue";
 import { useFutureFlags } from "@/composables/useFutureFlags";
+import { useI18n } from "@/composables/useI18n";
+
+const { t } = useI18n({
+  messages: {
+    de: {
+      close: "Schließen",
+    },
+    en: {
+      close: "Close",
+    },
+  },
+});
 
 const props = withDefaults(
   defineProps<{


### PR DESCRIPTION
## What?

This PR adds some translations for the mt-banner component.

## Why?

They were missing.

## How?

I've made use of the new `useI18n` composable.

## Testing?

You can test the changes yourself by swapping out the locale of the `mt-theme-provider` you can find it inside the `preview.ts` file

## Anything Else?
