### PR TITLE
migrate mt-data-table-filter over to plain css

### DIFF
--- a/.changeset/hot-plums-smell.md
+++ b/.changeset/hot-plums-smell.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": patch
+---
+
+Migrate mt-data-table-filter over to plain css

--- a/.changeset/plenty-flowers-sing.md
+++ b/.changeset/plenty-flowers-sing.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": patch
+---
+
+Migrate mt-data-table-filter to custom built useI18n composable

--- a/packages/component-library/src/components/form/_internal/mt-select-base/_internal/mt-select-result-list.vue
+++ b/packages/component-library/src/components/form/_internal/mt-select-base/_internal/mt-select-result-list.vue
@@ -39,7 +39,7 @@
 <script lang="ts">
 import type { PropType } from "vue";
 
-import { defineComponent } from "vue";
+import { computed, defineComponent } from "vue";
 import MtPopoverDeprecated from "../../../../_internal/mt-popover-deprecated/mt-popover-deprecated.vue";
 import MtIcon from "../../../../icons-media/mt-icon/mt-icon.vue";
 import { provide } from "vue";
@@ -50,24 +50,10 @@ import {
   MtSelectResultRemoveItemSelectByKeyboardListener,
 } from "@/helper/provideInjectKeys";
 import { ref } from "vue";
+import { useI18n } from "@/composables/useI18n";
 
 export default defineComponent({
   name: "MtSelectResultList",
-
-  i18n: {
-    messages: {
-      en: {
-        "mt-select-result-list": {
-          messageNoResults: "No results found.",
-        },
-      },
-      de: {
-        "mt-select-result-list": {
-          messageNoResults: "Es wurden keine Ergebnisse gefunden.",
-        },
-      },
-    },
-  },
 
   components: {
     "mt-popover-deprecated": MtPopoverDeprecated,
@@ -80,7 +66,7 @@ export default defineComponent({
     };
   },
 
-  setup() {
+  setup(props) {
     const activeItemIndex = ref(0);
     const activeItemChangeListeners = ref<Array<(index: number) => void>>([]);
     const itemSelectByKeyboardListeners = ref<Array<(index: number) => void>>([]);
@@ -121,8 +107,22 @@ export default defineComponent({
     provide(MtSelectResultAddItemSelectByKeyboardListener, addToItemSelectByKeyboardListeners);
     provide(MtSelectResultRemoveItemSelectByKeyboardListener, removeItemSelectByKeyboardListener);
 
+    const { t } = useI18n({
+      messages: {
+        en: {
+          messageNoResults: "No results found.",
+        },
+        de: {
+          messageNoResults: "Es wurden keine Ergebnisse gefunden.",
+        },
+      },
+    });
+
+    const emptyMessageText = computed(() => props.emptyMessage || t("messageNoResults"));
+
     return {
       activeItemIndex,
+      emptyMessageText,
       emitActiveItemIndex,
       setActiveItemIndex,
       addToActiveItemChangeListeners,
@@ -187,10 +187,6 @@ export default defineComponent({
   },
 
   computed: {
-    emptyMessageText(): string {
-      return this.emptyMessage || this.$tc("mt-select-result-list.messageNoResults");
-    },
-
     popoverClass(): string[] {
       return [...this.popoverClasses, "mt-select-result-list-popover-wrapper"];
     },

--- a/packages/component-library/src/components/table-and-list/mt-data-table/sub-components/mt-data-table-filter/mt-data-table-filter.vue
+++ b/packages/component-library/src/components/table-and-list/mt-data-table/sub-components/mt-data-table-filter/mt-data-table-filter.vue
@@ -93,7 +93,7 @@ export default defineComponent({
 });
 </script>
 
-<style lang="scss" scoped>
+<style scoped>
 .mt-data-table-filter {
   display: inline-flex;
 
@@ -102,71 +102,71 @@ export default defineComponent({
     display: grid;
     place-items: center;
   }
+}
 
-  .mt-data-table-filter__property {
-    border: 1px solid var(--color-border-primary-default);
-    border-right: 0 none;
-    border-top-left-radius: var(--border-radius-xs);
-    border-bottom-left-radius: var(--border-radius-xs);
-    color: var(--color-text-primary-default);
-    padding-inline: 8px;
-  }
+.mt-data-table-filter__property {
+  border: 1px solid var(--color-border-primary-default);
+  border-right: 0 none;
+  border-top-left-radius: var(--border-radius-xs);
+  border-bottom-left-radius: var(--border-radius-xs);
+  color: var(--color-text-primary-default);
+  padding-inline: 8px;
+}
 
-  .mt-data-table-filter__rule {
-    border-top: 1px solid var(--color-border-primary-default);
-    border-bottom: 1px solid var(--color-border-primary-default);
-    padding-right: 4px;
-  }
+.mt-data-table-filter__rule {
+  border-top: 1px solid var(--color-border-primary-default);
+  border-bottom: 1px solid var(--color-border-primary-default);
+  padding-right: 4px;
+}
 
-  .mt-data-table-filter__option {
-    color: var(--color-text-primary-default);
-    font-size: var(--font-size-2xs);
-    font-family: var(--font-family-body);
-    line-height: var(--font-line-height-2xs);
-    border-top: 1px solid var(--color-border-primary-default);
-    border-bottom: 1px solid var(--color-border-primary-default);
-    padding-inline: 4px 8px;
+.mt-data-table-filter__option {
+  color: var(--color-text-primary-default);
+  font-size: var(--font-size-2xs);
+  font-family: var(--font-family-body);
+  line-height: var(--font-line-height-2xs);
+  border-top: 1px solid var(--color-border-primary-default);
+  border-bottom: 1px solid var(--color-border-primary-default);
+  padding-inline: 4px 8px;
 
-    button {
-      outline: 0 none;
-    }
-
-    &:has(button:hover) {
-      background-color: var(--color-interaction-secondary-hover);
-    }
-
-    &:has(button:focus-visible) {
-      background-color: var(--color-background-brand-default);
-      outline: var(--color-border-brand-selected) solid 1px;
-      outline-offset: -1px;
-    }
-  }
-
-  .mt-data-table-filter__remove-button {
-    color: var(--color-icon-primary-default);
-    border-top-right-radius: var(--border-radius-xs);
-    border-bottom-right-radius: var(--border-radius-xs);
-    border: 1px solid var(--color-border-primary-default);
+  & button {
     outline: 0 none;
-    position: relative;
-    height: 24px;
-    width: 24px;
+  }
 
-    .mt-icon {
-      position: absolute;
-      top: 50%;
-      left: 50%;
-      transform: translate(-50%, -50%);
-    }
+  &:has(button:hover) {
+    background-color: var(--color-interaction-secondary-hover);
+  }
 
-    &:focus-visible {
-      background-color: var(--color-background-brand-default);
-      border-color: var(--color-border-brand-selected);
-    }
+  &:has(button:focus-visible) {
+    background-color: var(--color-background-brand-default);
+    outline: var(--color-border-brand-selected) solid 1px;
+    outline-offset: -1px;
+  }
+}
 
-    &:hover {
-      background-color: var(--color-interaction-secondary-hover);
-    }
+.mt-data-table-filter__remove-button {
+  color: var(--color-icon-primary-default);
+  border-top-right-radius: var(--border-radius-xs);
+  border-bottom-right-radius: var(--border-radius-xs);
+  border: 1px solid var(--color-border-primary-default);
+  outline: 0 none;
+  position: relative;
+  height: 24px;
+  width: 24px;
+
+  & .mt-icon {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+  }
+
+  &:focus-visible {
+    background-color: var(--color-background-brand-default);
+    border-color: var(--color-border-brand-selected);
+  }
+
+  &:hover {
+    background-color: var(--color-interaction-secondary-hover);
   }
 }
 </style>

--- a/packages/component-library/src/components/table-and-list/mt-data-table/sub-components/mt-data-table-filter/mt-data-table-filter.vue
+++ b/packages/component-library/src/components/table-and-list/mt-data-table/sub-components/mt-data-table-filter/mt-data-table-filter.vue
@@ -34,7 +34,7 @@
 
     <button
       class="mt-data-table-filter__remove-button"
-      :aria-label="$t('mt-data-table-filter.remove-button')"
+      :aria-label="t('remove-button')"
       @keydown.delete="$emit('removeFilter')"
       @click="$emit('removeFilter')"
     >
@@ -50,6 +50,7 @@ import MtPopoverItem from "@/components/overlay/mt-popover-item/mt-popover-item.
 import { defineComponent, type PropType } from "vue";
 import type { Filter, Option } from "../../mt-data-table.interfaces";
 import MtText from "@/components/content/mt-text/mt-text.vue";
+import { useI18n } from "vue-i18n";
 
 export default defineComponent({
   name: "MtDataTableFilter",
@@ -60,17 +61,9 @@ export default defineComponent({
     "mt-popover-item": MtPopoverItem,
     "mt-text": MtText,
   },
-  i18n: {
-    messages: {
-      en: {
-        "mt-data-table-filter.remove-button": "Remove filter",
-      },
-      de: {
-        "mt-data-table-filter.remove-button": "Filter entfernen",
-      },
-    },
-  },
+
   emits: ["removeOption", "addOption", "removeFilter"],
+
   props: {
     filter: {
       type: Object as PropType<Filter>,
@@ -86,8 +79,20 @@ export default defineComponent({
       return !!props.appliedOptions.find((option) => option.id === optionId);
     }
 
+    const { t } = useI18n({
+      messages: {
+        en: {
+          "remove-button": "Remove filter",
+        },
+        de: {
+          "remove-button": "Filter entfernen",
+        },
+      },
+    });
+
     return {
       isOptionSelected,
+      t,
     };
   },
 });


### PR DESCRIPTION
## What?

This PR migrates the `mt-data-table-filter` over to the custom built `useI18n` composable.

## Why?

This makes setting up the component library much easier and reduces the bundles size as we can get rid of a package.

## How?

I've migrated the component away from the `vue-i18n` package and moved it to the custom built `useI18n` composable.

## Testing?

Feel free to test the changes yourself.
