### PR TITLE
Migrate mt data table reset filter button to custom i18n

### DIFF
--- a/packages/component-library/src/components/table-and-list/mt-data-table/sub-components/mt-data-table-reset-filter-button/mt-data-table-reset-filter-button.vue
+++ b/packages/component-library/src/components/table-and-list/mt-data-table/sub-components/mt-data-table-reset-filter-button/mt-data-table-reset-filter-button.vue
@@ -23,7 +23,7 @@ const { t } = useI18n({
 });
 </script>
 
-<style lang="scss" scoped>
+<style scoped>
 .mt-data-table-reset-filter-button {
   color: var(--color-text-brand-default);
   text-decoration: underline;

--- a/packages/component-library/src/components/table-and-list/mt-data-table/sub-components/mt-data-table-reset-filter-button/mt-data-table-reset-filter-button.vue
+++ b/packages/component-library/src/components/table-and-list/mt-data-table/sub-components/mt-data-table-reset-filter-button/mt-data-table-reset-filter-button.vue
@@ -1,6 +1,6 @@
 <template>
   <button class="mt-data-table-reset-filter-button">
-    {{ t("mt-data-table-reset-filter-button.label", { n: numberOfAppliedFilters }) }}
+    {{ t("label", { n: numberOfAppliedFilters }) }}
   </button>
 </template>
 
@@ -14,14 +14,10 @@ defineProps<{
 const { t } = useI18n({
   messages: {
     en: {
-      "mt-data-table-reset-filter-button": {
-        label: "Remove filter | Remove filters",
-      },
+      label: "Remove filter | Remove filters",
     },
     de: {
-      "mt-data-table-reset-filter-button": {
-        label: "Filter entfernen | Filter entfernen",
-      },
+      label: "Filter entfernen | Filter entfernen",
     },
   },
 });

--- a/packages/component-library/src/components/table-and-list/mt-data-table/sub-components/mt-data-table-reset-filter-button/mt-data-table-reset-filter-button.vue
+++ b/packages/component-library/src/components/table-and-list/mt-data-table/sub-components/mt-data-table-reset-filter-button/mt-data-table-reset-filter-button.vue
@@ -4,36 +4,27 @@
   </button>
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
 import { useI18n } from "@/composables/useI18n";
 
-export default {
-  props: {
-    numberOfAppliedFilters: {
-      type: Number,
-      required: true,
-      validator: (value: number) => value >= 1,
+defineProps<{
+  numberOfAppliedFilters: number;
+}>();
+
+const { t } = useI18n({
+  messages: {
+    en: {
+      "mt-data-table-reset-filter-button": {
+        label: "Remove filter | Remove filters",
+      },
+    },
+    de: {
+      "mt-data-table-reset-filter-button": {
+        label: "Filter entfernen | Filter entfernen",
+      },
     },
   },
-  setup() {
-    const { t } = useI18n({
-      messages: {
-        en: {
-          "mt-data-table-reset-filter-button": {
-            label: "Remove filter | Remove filters",
-          },
-        },
-        de: {
-          "mt-data-table-reset-filter-button": {
-            label: "Filter entfernen | Filter entfernen",
-          },
-        },
-      },
-    });
-
-    return { t };
-  },
-};
+});
 </script>
 
 <style lang="scss" scoped>

--- a/packages/component-library/src/components/table-and-list/mt-data-table/sub-components/mt-data-table-reset-filter-button/mt-data-table-reset-filter-button.vue
+++ b/packages/component-library/src/components/table-and-list/mt-data-table/sub-components/mt-data-table-reset-filter-button/mt-data-table-reset-filter-button.vue
@@ -1,10 +1,12 @@
 <template>
   <button class="mt-data-table-reset-filter-button">
-    {{ $tc("mt-data-table-reset-filter-button.label", numberOfAppliedFilters) }}
+    {{ t("mt-data-table-reset-filter-button.label", { n: numberOfAppliedFilters }) }}
   </button>
 </template>
 
 <script lang="ts">
+import { useI18n } from "@/composables/useI18n";
+
 export default {
   props: {
     numberOfAppliedFilters: {
@@ -13,19 +15,23 @@ export default {
       validator: (value: number) => value >= 1,
     },
   },
-  i18n: {
-    messages: {
-      en: {
-        "mt-data-table-reset-filter-button": {
-          label: "Remove filter | Remove filters",
+  setup() {
+    const { t } = useI18n({
+      messages: {
+        en: {
+          "mt-data-table-reset-filter-button": {
+            label: "Remove filter | Remove filters",
+          },
+        },
+        de: {
+          "mt-data-table-reset-filter-button": {
+            label: "Filter entfernen | Filter entfernen",
+          },
         },
       },
-      de: {
-        "mt-data-table-reset-filter-button": {
-          label: "Filter entfernen | Filter entfernen",
-        },
-      },
-    },
+    });
+
+    return { t };
   },
 };
 </script>


### PR DESCRIPTION
## What?

I've migrated the component over to the composition api and the new usei18n composable.

## Why?

The `vue-18n` package makes setting up the component library much harder. This custom built one makes it easier.

## How?

I've migrated the component from the vue-i18n package to the custom built useI18n composable.

## Testing?

Feel free to test it yourself.
