### PR TITLE
Migrate mt-field-copyable to custom i18n

### DIFF
--- a/packages/component-library/src/components/form/_internal/mt-field-copyable/mt-field-copyable.vue
+++ b/packages/component-library/src/components/form/_internal/mt-field-copyable/mt-field-copyable.vue
@@ -100,10 +100,8 @@ export default defineComponent({
 });
 </script>
 
-<style lang="scss">
+<style scoped>
 .mt-field-copyable {
-  &.mt-icon {
-    cursor: pointer;
-  }
+  cursor: pointer;
 }
 </style>

--- a/packages/component-library/src/components/form/_internal/mt-field-copyable/mt-field-copyable.vue
+++ b/packages/component-library/src/components/form/_internal/mt-field-copyable/mt-field-copyable.vue
@@ -12,47 +12,20 @@
     name="regular-copy"
     size="18"
     @click="copyToClipboard"
-    @mouseleave="resetTooltipText"
+    @mouseleave="wasCopied = false"
   />
 </template>
 
 <script lang="ts">
-import { defineComponent } from "vue";
+import { computed, defineComponent, ref } from "vue";
 import MtIcon from "../../../icons-media/mt-icon/mt-icon.vue";
 import MtTooltipDirective from "../../../../directives/tooltip.directive";
 import MtNotificationMixin from "../../../../mixins/notification.mixin";
 import { copyToClipboard as copyToClipboardUtil } from "../../../../utils/dom";
+import { useI18n } from "@/composables/useI18n";
 
 export default defineComponent({
   name: "MtFieldCopyable",
-
-  i18n: {
-    messages: {
-      en: {
-        "mt-field-copyable": {
-          tooltip: {
-            wasCopied: "Copied to clipboard.",
-            canCopy: "Copy to clipboard.",
-            notificationCopySuccessMessage: "Text has been copied to clipboard.",
-            notificationCopyFailureMessage: "Text could not be copied to clipboard.",
-            errorTitle: "Error copying to clipboard",
-          },
-        },
-      },
-      de: {
-        "mt-field-copyable": {
-          tooltip: {
-            wasCopied: "In Zwischenablage kopiert.",
-            canCopy: "In Zwischenablage kopieren.",
-            notificationCopySuccessMessage: "Der Text wurde in die Zwischenablage kopiert.",
-            notificationCopyFailureMessage:
-              "Der Text konnte nicht in die Zwischenablage kopiert werden.",
-            errorTitle: "Fehler beim kopieren in die Zwischenablage",
-          },
-        },
-      },
-    },
-  },
 
   directives: {
     tooltip: MtTooltipDirective,
@@ -78,56 +51,51 @@ export default defineComponent({
     },
   },
 
-  data() {
+  setup(props) {
+    const wasCopied = ref(false);
+
+    const { t } = useI18n({
+      messages: {
+        en: {
+          tooltip: {
+            wasCopied: "Copied to clipboard.",
+            canCopy: "Copy to clipboard.",
+            notificationCopySuccessMessage: "Text has been copied to clipboard.",
+            notificationCopyFailureMessage: "Text could not be copied to clipboard.",
+            errorTitle: "Error copying to clipboard",
+          },
+        },
+        de: {
+          tooltip: {
+            wasCopied: "In Zwischenablage kopiert.",
+            canCopy: "In Zwischenablage kopieren.",
+            notificationCopySuccessMessage: "Der Text wurde in die Zwischenablage kopiert.",
+            notificationCopyFailureMessage:
+              "Der Text konnte nicht in die Zwischenablage kopiert werden.",
+            errorTitle: "Fehler beim kopieren in die Zwischenablage",
+          },
+        },
+      },
+    });
+
+    const tooltipText = computed(() =>
+      wasCopied.value ? t("tooltip.wasCopied") : t("tooltip.canCopy"),
+    );
+
+    function copyToClipboard() {
+      if (!props.copyableText) return;
+      copyToClipboardUtil(props.copyableText);
+
+      if (props.tooltip) {
+        wasCopied.value = true;
+      }
+    }
+
     return {
-      wasCopied: false,
+      copyToClipboard,
+      tooltipText,
+      wasCopied,
     };
-  },
-
-  computed: {
-    tooltipText(): string {
-      if (this.wasCopied) {
-        return this.$tc("mt-field-copyable.tooltip.wasCopied");
-      }
-
-      return this.$tc("mt-field-copyable.tooltip.canCopy");
-    },
-  },
-
-  methods: {
-    copyToClipboard() {
-      if (!this.copyableText) {
-        return;
-      }
-
-      try {
-        copyToClipboardUtil(this.copyableText);
-        if (this.tooltip) {
-          this.tooltipSuccess();
-        } else {
-          this.notificationSuccess();
-        }
-      } catch (err) {
-        this.createNotificationError({
-          title: this.$tc("mt-field-copyable.errorTitle"),
-          message: this.$tc("mt-field-copyable.notificationCopyFailureMessage"),
-        });
-      }
-    },
-
-    tooltipSuccess() {
-      this.wasCopied = true;
-    },
-
-    notificationSuccess() {
-      this.createNotificationInfo({
-        message: this.$tc("mt-field-copyable.notificationCopySuccessMessage"),
-      });
-    },
-
-    resetTooltipText() {
-      this.wasCopied = false;
-    },
   },
 });
 </script>


### PR DESCRIPTION
## What?

I've migrated the component over to the composition api and the new usei18n composable.

## Why?

The `vue-18n` package makes setting up the component library much harder. This custom built one makes it easier.

## How?

I've migrated the component from the vue-i18n package to the custom built useI18n composable.

## Testing?

Feel free to test it yourself.
