### PR TITLE
Migrate mt-inheritance-switch to custom i18n

### DIFF
--- a/packages/component-library/src/components/form/_internal/mt-inheritance-switch/mt-inheritance-switch.vue
+++ b/packages/component-library/src/components/form/_internal/mt-inheritance-switch/mt-inheritance-switch.vue
@@ -1,11 +1,13 @@
 <template>
   <div
-    class="mt-inheritance-switch"
-    :class="{
-      'mt-inheritance-switch--disabled': disabled,
-      'mt-inheritance-switch--is-inherited': isInherited,
-      'mt-inheritance-switch--is-not-inherited': !isInherited,
-    }"
+    :class="[
+      'mt-inheritance-switch',
+      {
+        'mt-inheritance-switch--disabled': disabled,
+        'mt-inheritance-switch--is-inherited': isInherited,
+        'mt-inheritance-switch--is-not-inherited': !isInherited,
+      },
+    ]"
   >
     <mt-icon
       v-if="isInherited"
@@ -20,6 +22,7 @@
       size="14"
       @click="onClickRemoveInheritance"
     />
+
     <mt-icon
       v-else
       key="uninherit-icon"
@@ -27,7 +30,9 @@
         message: t('tooltipRestoreInheritance'),
         disabled: disabled,
       }"
-      :class="unInheritClasses"
+      :class="{
+        'is--clickable': !disabled,
+      }"
       :multicolor="true"
       name="regular-link-horizontal-slash"
       size="14"
@@ -67,29 +72,7 @@ export default defineComponent({
     },
   },
 
-  computed: {
-    unInheritClasses(): { "is--clickable": boolean } {
-      return { "is--clickable": !this.disabled };
-    },
-  },
-
-  methods: {
-    onClickRestoreInheritance() {
-      if (this.disabled) {
-        return;
-      }
-      this.$emit("inheritance-restore");
-    },
-
-    onClickRemoveInheritance() {
-      if (this.disabled) {
-        return;
-      }
-      this.$emit("inheritance-remove");
-    },
-  },
-
-  setup() {
+  setup(props, { emit }) {
     const { t } = useI18n({
       messages: {
         en: {
@@ -103,7 +86,19 @@ export default defineComponent({
       },
     });
 
-    return { t };
+    function onClickRestoreInheritance() {
+      if (props.disabled) return;
+
+      emit("inheritance-restore");
+    }
+
+    function onClickRemoveInheritance() {
+      if (props.disabled) return;
+
+      emit("inheritance-remove");
+    }
+
+    return { t, onClickRemoveInheritance, onClickRestoreInheritance };
   },
 });
 </script>

--- a/packages/component-library/src/components/form/_internal/mt-inheritance-switch/mt-inheritance-switch.vue
+++ b/packages/component-library/src/components/form/_internal/mt-inheritance-switch/mt-inheritance-switch.vue
@@ -103,13 +103,13 @@ export default defineComponent({
 });
 </script>
 
-<style lang="scss">
+<style scoped>
 .mt-inheritance-switch {
   cursor: pointer;
   margin-top: -1px;
+}
 
-  &.mt-inheritance-switch--disabled {
-    cursor: default;
-  }
+.mt-inheritance-switch--disabled {
+  cursor: default;
 }
 </style>

--- a/packages/component-library/src/components/form/_internal/mt-inheritance-switch/mt-inheritance-switch.vue
+++ b/packages/component-library/src/components/form/_internal/mt-inheritance-switch/mt-inheritance-switch.vue
@@ -11,7 +11,7 @@
       v-if="isInherited"
       key="inherit-icon"
       v-tooltip="{
-        message: $tc('mt-inheritance-switch.tooltipRemoveInheritance'),
+        message: t('tooltipRemoveInheritance'),
         disabled: disabled,
       }"
       data-testid="mt-inheritance-switch-icon"
@@ -24,7 +24,7 @@
       v-else
       key="uninherit-icon"
       v-tooltip="{
-        message: $tc('mt-inheritance-switch.tooltipRestoreInheritance'),
+        message: t('tooltipRestoreInheritance'),
         disabled: disabled,
       }"
       :class="unInheritClasses"
@@ -40,26 +40,10 @@
 import { defineComponent } from "vue";
 import MtTooltipDirective from "../../../../directives/tooltip.directive";
 import MtIcon from "../../../icons-media/mt-icon/mt-icon.vue";
+import { useI18n } from "@/composables/useI18n";
 
 export default defineComponent({
   name: "MtInheritanceSwitch",
-
-  i18n: {
-    messages: {
-      en: {
-        "mt-inheritance-switch": {
-          tooltipRemoveInheritance: "Remove inheritance",
-          tooltipRestoreInheritance: "Restore inheritance",
-        },
-      },
-      de: {
-        "mt-inheritance-switch": {
-          tooltipRemoveInheritance: "Vererbung entfernen",
-          tooltipRestoreInheritance: "Vererbung wiederherstellen",
-        },
-      },
-    },
-  },
 
   components: {
     "mt-icon": MtIcon,
@@ -103,6 +87,23 @@ export default defineComponent({
       }
       this.$emit("inheritance-remove");
     },
+  },
+
+  setup() {
+    const { t } = useI18n({
+      messages: {
+        en: {
+          tooltipRemoveInheritance: "Remove inheritance",
+          tooltipRestoreInheritance: "Restore inheritance",
+        },
+        de: {
+          tooltipRemoveInheritance: "Vererbung entfernen",
+          tooltipRestoreInheritance: "Vererbung wiederherstellen",
+        },
+      },
+    });
+
+    return { t };
   },
 });
 </script>


### PR DESCRIPTION
## What?

I've migrated the component over to the composition api and the new usei18n composable.

## Why?

The `vue-18n` package makes setting up the component library much harder. This custom built one makes it easier.

## How?

I've migrated the component from the vue-i18n package to the custom built useI18n composable.

## Testing?

Feel free to test it yourself.
