### PR TITLE
Improve a11y of card

### DIFF
--- a/.changeset/calm-pillows-collect.md
+++ b/.changeset/calm-pillows-collect.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": patch
+---
+
+Improve reading order for card titles when using a screen reader

--- a/.changeset/happy-zoos-tan.md
+++ b/.changeset/happy-zoos-tan.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": patch
+---
+
+Update focus style of inheritance toggle in card

--- a/.changeset/pretty-hotels-own.md
+++ b/.changeset/pretty-hotels-own.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": patch
+---
+
+Add landmarks to card component for screen readers

--- a/packages/component-library/src/components/layout/mt-card/mt-card.vue
+++ b/packages/component-library/src/components/layout/mt-card/mt-card.vue
@@ -368,6 +368,12 @@ const cardClasses = computed(() => ({
   outline-offset: 2px;
   outline-color: var(--color-border-brand-selected);
   color: var(--color-icon-primary-default);
+
+  &:focus-visible {
+    outline: 2px solid var(--color-border-brand-selected);
+    outline-offset: 2px;
+    border-radius: var(--border-radius-button);
+  }
 }
 
 .mt-card__titles-right-slot {

--- a/packages/component-library/src/components/layout/mt-card/mt-card.vue
+++ b/packages/component-library/src/components/layout/mt-card/mt-card.vue
@@ -17,18 +17,6 @@
           },
         ]"
       >
-        <button
-          v-if="inheritance !== undefined"
-          class="mt-card__inheritance-toggle"
-          :aria-label="!!inheritance ? t('disableInheritance') : t('enableInheritance')"
-          @click="$emit('update:inheritance', !inheritance)"
-        >
-          <mt-icon
-            :name="inheritance ? 'regular-link-horizontal' : 'regular-link-horizontal-slash'"
-            size="1.25rem"
-          />
-        </button>
-
         <!-- @slot Alternative slot to the title property -->
         <slot name="title">
           <MtText v-if="title" as="h3" weight="semibold" size="m" class="mt-card__title">
@@ -47,6 +35,19 @@
             {{ subtitle }}
           </MtText>
         </slot>
+
+        <button
+          v-if="inheritance !== undefined"
+          class="mt-card__inheritance-toggle"
+          :aria-label="!!inheritance ? t('disableInheritance') : t('enableInheritance')"
+          style="grid-area: inheritance"
+          @click="$emit('update:inheritance', !inheritance)"
+        >
+          <mt-icon
+            :name="inheritance ? 'regular-link-horizontal' : 'regular-link-horizontal-slash'"
+            size="1.25rem"
+          />
+        </button>
       </div>
 
       <div class="mt-card__titles-right-slot">
@@ -289,6 +290,9 @@ const cardClasses = computed(() => ({
   display: grid;
   grid-template-columns: min-content 1fr;
   column-gap: 0.25rem;
+  grid-template-areas:
+    "inheritance title"
+    "subtitle subtitle";
 
   & .mt-card__subtitle {
     grid-column: 1 / -1;

--- a/packages/component-library/src/components/layout/mt-card/mt-card.vue
+++ b/packages/component-library/src/components/layout/mt-card/mt-card.vue
@@ -2,8 +2,8 @@
   <!-- @slot This slot is @private and should not be used -->
   <slot name="before-card" />
 
-  <div class="mt-card" :class="cardClasses" v-bind="$attrs">
-    <div v-if="showHeader" class="mt-card__header">
+  <article class="mt-card" :class="cardClasses" :aria-label="title" v-bind="$attrs">
+    <header v-if="showHeader" class="mt-card__header">
       <div class="mt-card__avatar">
         <!-- @slot Slot for an avatar or logo -->
         <slot name="avatar" />
@@ -31,7 +31,7 @@
 
         <!-- @slot Alternative slot to the title property -->
         <slot name="title">
-          <MtText v-if="title" weight="semibold" size="m" class="mt-card__title">
+          <MtText v-if="title" as="h3" weight="semibold" size="m" class="mt-card__title">
             {{ title }}
           </MtText>
         </slot>
@@ -60,7 +60,7 @@
           <slot name="context-actions" />
         </mt-context-button>
       </div>
-    </div>
+    </header>
 
     <div class="mt-card__tabs">
       <!-- @slot Slot for adding a tab bar. The content need to be changed manually and you can't use the content slot of the tab bar -->
@@ -82,11 +82,11 @@
       <mt-loader v-if="isLoading" />
     </div>
 
-    <div class="mt-card__footer">
+    <footer class="mt-card__footer">
       <!-- @slot The footer slot which allows rendering additional things after the content -->
       <slot name="footer" />
-    </div>
-  </div>
+    </footer>
+  </article>
 
   <!-- @slot This slot is @private and should not be used -->
   <slot name="after-card" />
@@ -325,6 +325,10 @@ const cardClasses = computed(() => ({
   gap: 0.75rem;
   padding: 1.5rem;
   border-bottom: 1px solid var(--color-border-primary-default);
+}
+
+.mt-card__title {
+  margin: 0;
 }
 
 .mt-card__toolbar {


### PR DESCRIPTION
## What?

This PR improves the a11y of the card component.

## Why?

This improves the user experience for people who use a screen reader.

## How?

The reading order changed. It first announces the title, then the subtitle and after that the inheritance toggle. Before this change it was inheritance toggle, title and then the subtitle.

I added landmarks to the card component, now screen readers are able to quickly jump to any card.

## Testing?

Checkout the PR and test it yourself by using a screen reader.
