### PR TITLE
ignore .pnpm-store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules/
 chrome/
 .idea/
 .DS_Store
+.pnpm-store/
 # Devenv
 .direnv
 .devenv*


### PR DESCRIPTION
## What?

I added the `.pnpm-store` folder to the `.gitignore`

## Why?

We do not need, and should, commit this directory. It's used by pnpm to optimize the dependency installation process.

## How?

I added the file to the `.gitignore` file

## Testing?

Feel free to create the directory by hand on your machine and see if git ignores it.

