### PR TITLE
change default placement of tooltip to top

### DIFF
--- a/packages/component-library/src/components/overlay/mt-tooltip/mt-tooltip.vue
+++ b/packages/component-library/src/components/overlay/mt-tooltip/mt-tooltip.vue
@@ -85,12 +85,12 @@ const props = withDefaults(
     content: string;
     delayDurationInMs?: number;
     hideDelayDurationInMs?: number;
-    placement: Placement;
+    placement?: Placement;
   }>(),
   {
     delayDurationInMs: 500,
     hideDelayDurationInMs: 300,
-    placement: "bottom",
+    placement: "top",
   },
 );
 


### PR DESCRIPTION
## What?

Changes the default `placement` of the tooltip to `top`

## Why?

In most cases the tooltip will appear above the element.

## How?

I changed the `placement` property to `top`

## Testing?

Adding an automated test does not provide much value here.
