### PR TITLE
fix: allow negative spacing values

### DIFF
--- a/packages/stylelint-plugin-meteor/src/rules/prefer-sizing-token/index.ts
+++ b/packages/stylelint-plugin-meteor/src/rules/prefer-sizing-token/index.ts
@@ -71,9 +71,11 @@ const ruleFunction: Rule = (primary, secondaryOptions, context) => {
         const isUsingSCSSVariable = /^\$/.test(value);
 
         const valueIsZero = /^0(px)?/.test(value);
+        const isNegativeValue = /^-/.test(value);
 
         if (
           isASpacingToken &&
+          !isNegativeValue &&
           ((usingPixelValue && !valueIsZero) ||
             isUsingRemValue ||
             isUsingCapValue ||

--- a/packages/stylelint-plugin-meteor/src/rules/prefer-sizing-token/prefer-sizing-token.test.ts
+++ b/packages/stylelint-plugin-meteor/src/rules/prefer-sizing-token/prefer-sizing-token.test.ts
@@ -34,6 +34,8 @@ testRule({
     { code: ".a { margin: 10vi; }" },
     { code: ".a { margin: 0 auto; }" },
     { code: ".a { margin: var(--scale-size-4) var(--scale-size-8); }" },
+    { code: ".a { margin: -4px; }" },
+    { code: ".a { margin: -1rem; }" },
   ],
 
   reject: [


### PR DESCRIPTION
## What?

This PR changes the rule to ignore negative spacing values

## Why?

It does not make sense to report negative spacing values. 

## How?

I've updated the rule to exclude negative spacing values.

## Testing?

I've added some test to make sure the changes work as expected
