### PR TITLE
feat(stylelint-plugin-meteor): add no primitive token rule

### DIFF
--- a/.changeset/sour-chicken-juggle.md
+++ b/.changeset/sour-chicken-juggle.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/stylelint-plugin-meteor": minor
+---
+
+Add no-primitive-token rule

--- a/packages/component-library/.stylelintrc.json
+++ b/packages/component-library/.stylelintrc.json
@@ -3,7 +3,8 @@
   "rules": {
     "meteor/prefer-sizing-token": [true, { "severity": "warning" }],
     "meteor/prefer-background-token": [true, { "severity": "warning" }],
-    "meteor/prefer-color-token": [true, { "severity": "warning" }]
+    "meteor/prefer-color-token": [true, { "severity": "warning" }],
+    "meteor/no-primitive-token": [true, { "severity": "warning" }]
   },
   "overrides": [
     {

--- a/packages/stylelint-plugin-meteor/package.json
+++ b/packages/stylelint-plugin-meteor/package.json
@@ -10,11 +10,12 @@
   "license": "MIT",
   "description": "The stylelint plugin for the Meteor Design System",
   "peerDependencies": {
+    "@shopware-ag/meteor-tokens": "workspace:*",
     "stylelint": "^16.10.0"
   },
   "devDependencies": {
-    "tshy": "^3.0.2",
     "stylelint-test-rule-node": "^0.3.0",
+    "tshy": "^3.0.2",
     "tsx": "^4.7.0"
   },
   "type": "module",

--- a/packages/stylelint-plugin-meteor/src/index.ts
+++ b/packages/stylelint-plugin-meteor/src/index.ts
@@ -1,5 +1,11 @@
 import preferSizingTokens from "./rules/prefer-sizing-token/index.js";
 import preferBackgroundToken from "./rules/prefer-background-token/index.js";
 import preferColorToken from "./prefer-color-token/index.js";
+import noPrimitiveToken from "./rules/no-primitive-token/index.js";
 
-export default [preferSizingTokens, preferColorToken, preferBackgroundToken];
+export default [
+  preferSizingTokens,
+  preferColorToken,
+  preferBackgroundToken,
+  noPrimitiveToken,
+];

--- a/packages/stylelint-plugin-meteor/src/rules/no-primitive-token/application/TokenGateway.ts
+++ b/packages/stylelint-plugin-meteor/src/rules/no-primitive-token/application/TokenGateway.ts
@@ -1,0 +1,3 @@
+export interface TokenGateway {
+  getTokens(): Promise<string[]>;
+}

--- a/packages/stylelint-plugin-meteor/src/rules/no-primitive-token/index.ts
+++ b/packages/stylelint-plugin-meteor/src/rules/no-primitive-token/index.ts
@@ -1,0 +1,72 @@
+import stylelint, { Rule } from "stylelint";
+import { TokenGateway } from "./application/TokenGateway.js";
+import { TokenGatewayUsingImport } from "./infrastructure/TokenGatewayUsingImport.js";
+
+const {
+  createPlugin,
+  utils: { report, ruleMessages, validateOptions },
+} = stylelint;
+
+const ruleName = "meteor/no-primitive-token";
+
+const messages = ruleMessages(ruleName, {
+  rejected: (token, property) =>
+    `Unexpected primitve token "${token}" for ${property}, use a semantic token instead`,
+});
+
+const meta = {
+  url: "",
+};
+
+export function makeNoPrimitiveRule(dependencies: {
+  tokenGateway: TokenGateway;
+}) {
+  const ruleFunction: Rule = (primary) => {
+    return async (root, result) => {
+      const validOptions = validateOptions(result, ruleName, {
+        actual: primary,
+        possible: [true],
+      });
+
+      if (!validOptions) return;
+
+      const tokens = await dependencies.tokenGateway.getTokens();
+
+      root.walkDecls((ruleNode) => {
+        const values = ruleNode.value.split(" ");
+
+        values.forEach((value) => {
+          const usingACustomProperty = /^var\(.*\)$/.test(value);
+
+          if (!usingACustomProperty) return;
+
+          const token = value.replace(/^var\(--/, "").replace(/\)$/, "");
+          const usingAPrimitiveToken = tokens.includes(token);
+          const isScaleToken = /^scale\-size\-\d+$/.test(token);
+
+          if (usingAPrimitiveToken && !isScaleToken) {
+            report({
+              message: messages.rejected(token, ruleNode.prop),
+              node: ruleNode,
+              result,
+              ruleName,
+            });
+          }
+        });
+      });
+    };
+  };
+
+  ruleFunction.ruleName = ruleName;
+  ruleFunction.messages = messages;
+  ruleFunction.meta = meta;
+
+  return ruleFunction;
+}
+
+export default createPlugin(
+  ruleName,
+  makeNoPrimitiveRule({
+    tokenGateway: new TokenGatewayUsingImport(),
+  })
+);

--- a/packages/stylelint-plugin-meteor/src/rules/no-primitive-token/infrastructure/InMemoryTokenGateway.ts
+++ b/packages/stylelint-plugin-meteor/src/rules/no-primitive-token/infrastructure/InMemoryTokenGateway.ts
@@ -1,0 +1,9 @@
+import { TokenGateway } from "../application/TokenGateway.js";
+
+export class InMemoryTokenGateway implements TokenGateway {
+  constructor(public tokens: string[]) {}
+
+  async getTokens(): Promise<string[]> {
+    return this.tokens;
+  }
+}

--- a/packages/stylelint-plugin-meteor/src/rules/no-primitive-token/infrastructure/TokenGatewayUsingImport.ts
+++ b/packages/stylelint-plugin-meteor/src/rules/no-primitive-token/infrastructure/TokenGatewayUsingImport.ts
@@ -1,0 +1,30 @@
+import { TokenGateway } from "../application/TokenGateway.js";
+
+const extractTokens = (obj: any, path: string[] = []): string[] => {
+  let tokens: string[] = [];
+
+  for (const [key, value] of Object.entries(obj)) {
+    if (typeof value === "object" && value !== null && !("$value" in value)) {
+      tokens = tokens.concat(extractTokens(value, [...path, key]));
+    } else if (
+      typeof value === "object" &&
+      value !== null &&
+      "$value" in value
+    ) {
+      tokens.push([...path, key].join("-"));
+    }
+  }
+
+  return tokens;
+};
+
+export class TokenGatewayUsingImport implements TokenGateway {
+  async getTokens(): Promise<string[]> {
+    const dictionary = await import(
+      "@shopware-ag/meteor-tokens/foundation/primitives.json",
+      { with: { type: "json" } }
+    );
+
+    return extractTokens(dictionary.default);
+  }
+}

--- a/packages/stylelint-plugin-meteor/src/rules/no-primitive-token/no-primitive-token.test.ts
+++ b/packages/stylelint-plugin-meteor/src/rules/no-primitive-token/no-primitive-token.test.ts
@@ -1,0 +1,136 @@
+import { testRule } from "stylelint-test-rule-node";
+import stylelint from "stylelint";
+import { makeNoPrimitiveRule } from "./index.js";
+import { InMemoryTokenGateway } from "./infrastructure/InMemoryTokenGateway.js";
+
+const { createPlugin } = stylelint;
+
+const rule = makeNoPrimitiveRule({
+  tokenGateway: new InMemoryTokenGateway([
+    "green-500",
+    "slate-300",
+    "scale-size-4",
+  ]),
+});
+
+const plugin = createPlugin(rule.ruleName, rule);
+
+testRule({
+  plugins: [plugin],
+  ruleName: rule.ruleName,
+  config: true,
+
+  accept: [
+    {
+      code: "a { background-color: var(--color-interaction-primary-default); }",
+    },
+    {
+      code: "a { background-color: currentcolor; }",
+    },
+    {
+      code: "a { background-color: unset; }",
+    },
+    {
+      code: "a { background-color: initial; }",
+    },
+    {
+      code: "a { background-color: transparent; }",
+    },
+    {
+      code: "a { background-color: red; }",
+    },
+    {
+      code: "a { background-color: #fff; }",
+    },
+    {
+      code: "a { background-color: rgb(1, 56, 56); }",
+    },
+    {
+      code: "a { background-color: hsl(254, 45%, 60%); }",
+    },
+    {
+      code: "a { background-color: var(--some-custom-property); }",
+    },
+    {
+      code: "a { background-color: var(--scale-size-4); }",
+    },
+    {
+      code: "a { margin: var(--scale-size-4) var(--scale-size-8); }",
+    },
+    {
+      code: "a { border: 1px solid var(--color-border-brand-selected); }",
+    },
+    {
+      code: "a { --foo: var(--scale-size-4); }",
+    },
+  ],
+
+  reject: [
+    {
+      code: "a { background: var(--green-500); }",
+      message:
+        'Unexpected primitve token "green-500" for background, use a semantic token instead (meteor/no-primitive-token)',
+      line: 1,
+      endLine: 1,
+      column: 5,
+      endColumn: 34,
+    },
+    {
+      code: "a { color: var(--slate-300); }",
+      message:
+        'Unexpected primitve token "slate-300" for color, use a semantic token instead (meteor/no-primitive-token)',
+      line: 1,
+      endLine: 1,
+      column: 5,
+      endColumn: 29,
+    },
+    {
+      code: "a { border: 1px solid var(--green-500); }",
+      message:
+        'Unexpected primitve token "green-500" for border, use a semantic token instead (meteor/no-primitive-token)',
+      line: 1,
+      endLine: 1,
+      column: 5,
+      endColumn: 40,
+    },
+    {
+      code: "a { margin: var(--scale-size-4) var(--green-500); }",
+      message:
+        'Unexpected primitve token "green-500" for margin, use a semantic token instead (meteor/no-primitive-token)',
+      line: 1,
+      endLine: 1,
+      column: 5,
+      endColumn: 50,
+    },
+    {
+      code: "a { padding: var(--slate-300) var(--green-500); }",
+      warnings: [
+        {
+          message:
+            'Unexpected primitve token "slate-300" for padding, use a semantic token instead (meteor/no-primitive-token)',
+          line: 1,
+          column: 5,
+          endLine: 1,
+          endColumn: 48,
+        },
+        {
+          message:
+            'Unexpected primitve token "green-500" for padding, use a semantic token instead (meteor/no-primitive-token)',
+          line: 1,
+          column: 5,
+          endLine: 1,
+          endColumn: 48,
+        },
+      ],
+    },
+    {
+      code: "a { --foo: var(--green-500); }",
+      message:
+        'Unexpected primitve token "green-500" for --foo, use a semantic token instead (meteor/no-primitive-token)',
+      line: 1,
+      endLine: 1,
+      column: 5,
+      endColumn: 29,
+    },
+  ],
+});

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -12,7 +12,8 @@
   "exports": {
     "./primitives.css": "./deliverables/foundation/primitives.css",
     "./administration/light.css": "./deliverables/administration/light.css",
-    "./administration/dark.css": "./deliverables/administration/dark.css"
+    "./administration/dark.css": "./deliverables/administration/dark.css",
+    "./foundation/primitives.json": "./dictionaries/foundation/primitives.tokens.json"
   },
   "main": "index.js",
   "files": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -296,7 +296,7 @@ importers:
         version: 8.1.10
       '@testing-library/jest-dom':
         specifier: ^6.4.6
-        version: 6.4.6(@jest/globals@29.7.0)(jest@29.7.0(@types/node@18.19.36)(ts-node@10.9.2(@swc/core@1.6.1)(@types/node@18.19.36)(typescript@5.2.2)))(vitest@1.6.0(@types/node@18.19.36)(@vitest/ui@1.6.0)(jsdom@22.1.0)(sass@1.77.6)(terser@5.31.1))
+        version: 6.4.6(@jest/globals@29.7.0)(jest@29.7.0(@types/node@18.19.36)(ts-node@10.9.2(@swc/core@1.6.1)(@types/node@18.19.36)(typescript@5.2.2)))(vitest@1.6.0)
       '@testing-library/vue':
         specifier: ^8.1.0
         version: 8.1.0(@vue/compiler-sfc@3.4.29)(vue@3.4.21(typescript@5.2.2))
@@ -348,7 +348,7 @@ importers:
         version: 8.1.10(@types/react@18.3.3)(encoding@0.1.13)(prettier@3.2.5)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@storybook/addon-interactions':
         specifier: ^8.0.4
-        version: 8.1.10(@jest/globals@29.7.0)(jest@29.7.0(@types/node@18.19.36)(ts-node@10.9.2(@swc/core@1.6.1)(@types/node@18.19.36)(typescript@5.2.2)))(vitest@1.6.0(@types/node@18.19.36)(@vitest/ui@1.6.0)(jsdom@22.1.0)(sass@1.77.6)(terser@5.31.1))
+        version: 8.1.10(@jest/globals@29.7.0)(jest@29.7.0(@types/node@18.19.36)(ts-node@10.9.2(@swc/core@1.6.1)(@types/node@18.19.36)(typescript@5.2.2)))(vitest@1.6.0)
       '@storybook/addon-links':
         specifier: ^8.0.4
         version: 8.1.10(react@17.0.2)
@@ -360,7 +360,7 @@ importers:
         version: 8.1.10(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@storybook/test':
         specifier: ^8.0.4
-        version: 8.1.10(@jest/globals@29.7.0)(jest@29.7.0(@types/node@18.19.36)(ts-node@10.9.2(@swc/core@1.6.1)(@types/node@18.19.36)(typescript@5.2.2)))(vitest@1.6.0(@types/node@18.19.36)(@vitest/ui@1.6.0)(jsdom@22.1.0)(sass@1.77.6)(terser@5.31.1))
+        version: 8.1.10(@jest/globals@29.7.0)(jest@29.7.0(@types/node@18.19.36)(ts-node@10.9.2(@swc/core@1.6.1)(@types/node@18.19.36)(typescript@5.2.2)))(vitest@1.6.0)
       '@storybook/test-runner':
         specifier: ^0.17.0
         version: 0.17.0(@types/node@18.19.36)(encoding@0.1.13)(prettier@3.2.5)(ts-node@10.9.2(@swc/core@1.6.1)(@types/node@18.19.36)(typescript@5.2.2))
@@ -414,7 +414,7 @@ importers:
         version: 0.8.0(eslint@8.57.0)(typescript@5.2.2)
       eslint-plugin-vitest:
         specifier: ^0.3.20
-        version: 0.3.26(eslint@8.57.0)(typescript@5.2.2)(vitest@1.6.0(@types/node@18.19.36)(@vitest/ui@1.6.0)(jsdom@22.1.0)(sass@1.77.6)(terser@5.31.1))
+        version: 0.3.26(eslint@8.57.0)(typescript@5.2.2)(vitest@1.6.0)
       eslint-plugin-vitest-globals:
         specifier: ^1.4.0
         version: 1.5.0
@@ -548,6 +548,9 @@ importers:
 
   packages/stylelint-plugin-meteor:
     dependencies:
+      '@shopware-ag/meteor-tokens':
+        specifier: workspace:*
+        version: link:../tokens
       stylelint:
         specifier: ^16.10.0
         version: 16.10.0(typescript@5.6.2)
@@ -591,7 +594,7 @@ importers:
         version: 8.57.0
       eslint-plugin-vitest:
         specifier: ^0.3.20
-        version: 0.3.26(@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.6.2))(eslint@8.57.0)(typescript@5.6.2))(eslint@8.57.0)(typescript@5.6.2)(vitest@1.6.0(@types/node@20.14.5)(@vitest/ui@1.6.0)(jsdom@22.1.0)(sass@1.77.6)(terser@5.31.1))
+        version: 0.3.26(@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.6.2))(eslint@8.57.0)(typescript@5.6.2))(eslint@8.57.0)(typescript@5.6.2)(vitest@1.6.0)
       msw:
         specifier: ^2.1.5
         version: 2.3.1(typescript@5.6.2)
@@ -6807,6 +6810,7 @@ packages:
   eslint@8.57.0:
     resolution: {integrity: sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
 
   esm-resolve@1.0.11:
@@ -17425,11 +17429,11 @@ snapshots:
     dependencies:
       '@storybook/global': 5.0.0
 
-  '@storybook/addon-interactions@8.1.10(@jest/globals@29.7.0)(jest@29.7.0(@types/node@18.19.36)(ts-node@10.9.2(@swc/core@1.6.1)(@types/node@18.19.36)(typescript@5.2.2)))(vitest@1.6.0(@types/node@18.19.36)(@vitest/ui@1.6.0)(jsdom@22.1.0)(sass@1.77.6)(terser@5.31.1))':
+  '@storybook/addon-interactions@8.1.10(@jest/globals@29.7.0)(jest@29.7.0(@types/node@18.19.36)(ts-node@10.9.2(@swc/core@1.6.1)(@types/node@18.19.36)(typescript@5.2.2)))(vitest@1.6.0)':
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/instrumenter': 8.1.10
-      '@storybook/test': 8.1.10(@jest/globals@29.7.0)(jest@29.7.0(@types/node@18.19.36)(ts-node@10.9.2(@swc/core@1.6.1)(@types/node@18.19.36)(typescript@5.2.2)))(vitest@1.6.0(@types/node@18.19.36)(@vitest/ui@1.6.0)(jsdom@22.1.0)(sass@1.77.6)(terser@5.31.1))
+      '@storybook/test': 8.1.10(@jest/globals@29.7.0)(jest@29.7.0(@types/node@18.19.36)(ts-node@10.9.2(@swc/core@1.6.1)(@types/node@18.19.36)(typescript@5.2.2)))(vitest@1.6.0)
       '@storybook/types': 8.1.10
       polished: 4.3.1
       ts-dedent: 2.2.0
@@ -18039,14 +18043,14 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@storybook/test@8.1.10(@jest/globals@29.7.0)(jest@29.7.0(@types/node@18.19.36)(ts-node@10.9.2(@swc/core@1.6.1)(@types/node@18.19.36)(typescript@5.2.2)))(vitest@1.6.0(@types/node@18.19.36)(@vitest/ui@1.6.0)(jsdom@22.1.0)(sass@1.77.6)(terser@5.31.1))':
+  '@storybook/test@8.1.10(@jest/globals@29.7.0)(jest@29.7.0(@types/node@18.19.36)(ts-node@10.9.2(@swc/core@1.6.1)(@types/node@18.19.36)(typescript@5.2.2)))(vitest@1.6.0)':
     dependencies:
       '@storybook/client-logger': 8.1.10
       '@storybook/core-events': 8.1.10
       '@storybook/instrumenter': 8.1.10
       '@storybook/preview-api': 8.1.10
       '@testing-library/dom': 9.3.4
-      '@testing-library/jest-dom': 6.4.6(@jest/globals@29.7.0)(jest@29.7.0(@types/node@18.19.36)(ts-node@10.9.2(@swc/core@1.6.1)(@types/node@18.19.36)(typescript@5.2.2)))(vitest@1.6.0(@types/node@18.19.36)(@vitest/ui@1.6.0)(jsdom@22.1.0)(sass@1.77.6)(terser@5.31.1))
+      '@testing-library/jest-dom': 6.4.6(@jest/globals@29.7.0)(jest@29.7.0(@types/node@18.19.36)(ts-node@10.9.2(@swc/core@1.6.1)(@types/node@18.19.36)(typescript@5.2.2)))(vitest@1.6.0)
       '@testing-library/user-event': 14.5.2(@testing-library/dom@9.3.4)
       '@vitest/expect': 1.3.1
       '@vitest/spy': 1.6.0
@@ -18351,7 +18355,7 @@ snapshots:
       lz-string: 1.5.0
       pretty-format: 27.5.1
 
-  '@testing-library/jest-dom@6.4.6(@jest/globals@29.7.0)(jest@29.7.0(@types/node@18.19.36)(ts-node@10.9.2(@swc/core@1.6.1)(@types/node@18.19.36)(typescript@5.2.2)))(vitest@1.6.0(@types/node@18.19.36)(@vitest/ui@1.6.0)(jsdom@22.1.0)(sass@1.77.6)(terser@5.31.1))':
+  '@testing-library/jest-dom@6.4.6(@jest/globals@29.7.0)(jest@29.7.0(@types/node@18.19.36)(ts-node@10.9.2(@swc/core@1.6.1)(@types/node@18.19.36)(typescript@5.2.2)))(vitest@1.6.0)':
     dependencies:
       '@adobe/css-tools': 4.4.0
       '@babel/runtime': 7.24.7
@@ -22410,7 +22414,7 @@ snapshots:
 
   eslint-plugin-vitest-globals@1.5.0: {}
 
-  eslint-plugin-vitest@0.3.26(@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.6.2))(eslint@8.57.0)(typescript@5.6.2))(eslint@8.57.0)(typescript@5.6.2)(vitest@1.6.0(@types/node@20.14.5)(@vitest/ui@1.6.0)(jsdom@22.1.0)(sass@1.77.6)(terser@5.31.1)):
+  eslint-plugin-vitest@0.3.26(@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.6.2))(eslint@8.57.0)(typescript@5.6.2))(eslint@8.57.0)(typescript@5.6.2)(vitest@1.6.0):
     dependencies:
       '@typescript-eslint/utils': 7.13.1(eslint@8.57.0)(typescript@5.6.2)
       eslint: 8.57.0
@@ -22421,7 +22425,7 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-vitest@0.3.26(eslint@8.57.0)(typescript@5.2.2)(vitest@1.6.0(@types/node@18.19.36)(@vitest/ui@1.6.0)(jsdom@22.1.0)(sass@1.77.6)(terser@5.31.1)):
+  eslint-plugin-vitest@0.3.26(eslint@8.57.0)(typescript@5.2.2)(vitest@1.6.0):
     dependencies:
       '@typescript-eslint/utils': 7.13.1(eslint@8.57.0)(typescript@5.2.2)
       eslint: 8.57.0


### PR DESCRIPTION
## What?

I've added a rule that reports any usage of primitive tokens.

## Why?

Primitive tokens provide much less value compared to semantic design tokens. To prevent devs from using primitive tokens we report that to them in their IDE.

## How?

This rule gets the dictionary of the `@shopware-ag/meteor-tokens` package. And checks a forbidden primitive token is used.

## Testing?

I've written a handful of test to make sure the rule works as expected. The only thing that is not possible/very hard to test is the `TokenGatewayUsingImport` as there is much more setup involved.

## Anything Else?

This rule makes an exception for spacing tokens, those are primitive tokens and they're allowed to be used.
