### PR TITLE
feat: export mt-tooltip

### DIFF
--- a/.changeset/clever-glasses-film.md
+++ b/.changeset/clever-glasses-film.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": minor
+---
+
+Export mt-tooltip component

--- a/packages/component-library/src/index.ts
+++ b/packages/component-library/src/index.ts
@@ -36,6 +36,7 @@ import MtInset from "./components/layout/mt-inset/mt-inset.vue";
 import MtThemeProvider from "./components/theme/mt-theme-provider.vue";
 import TooltipDirective from "./directives/tooltip.directive";
 import DeviceHelperPlugin from "./plugin/device-helper.plugin";
+import MtTooltip from "./components/overlay/mt-tooltip/mt-tooltip.vue";
 
 // Import SCSS for styling
 import "./components/assets/scss/all.scss";
@@ -74,6 +75,7 @@ export {
   MtPopover,
   MtPopoverItem,
   MtPopoverItemResult,
+  MtTooltip,
   MtFloatingUi,
   MtModal,
   MtModalRoot,


### PR DESCRIPTION
## What?

I exported the `mt-tooltip` component so it's available to other projects.

## Why?

This component is needed by other projects.

## How?

I added it to the `src/index.ts` file

## Testing?

Just proof-read it
