### PR TITLE
build(component-library): update tsconfig to include jest-dom types

### DIFF
--- a/packages/component-library/tsconfig.app.json
+++ b/packages/component-library/tsconfig.app.json
@@ -8,7 +8,7 @@
     "src/**/*.js",
     "src/**/*.json"
   ],
-  "exclude": ["src/**/__tests__/*"],
+  "exclude": ["src/**/__tests__/*", "**/*.spec.ts"],
   "compilerOptions": {
     "composite": true,
     "baseUrl": ".",

--- a/packages/component-library/tsconfig.vitest.json
+++ b/packages/component-library/tsconfig.vitest.json
@@ -12,7 +12,6 @@
   ],
   "compilerOptions": {
     "composite": true,
-    "lib": [],
     "types": ["node", "jsdom", "vitest/globals"]
   }
 }


### PR DESCRIPTION
## What?
This PR add the types for the jest-dom matchers.
## Why?
The types for the jest-dom matchers were missing. Typing `.toBeInTheDocument` resulted in an type-error.
## How?
I updated the tsconfig so they no longer are overriting each other.
## Testing?
Check out the branch and test it yourself