### PR TITLE
UX-59 - add accessibility state labels to switch component

### DIFF
--- a/.changeset/slimy-cameras-joke.md
+++ b/.changeset/slimy-cameras-joke.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": patch
+---
+
+Add aria attributes to mt-switch

--- a/packages/component-library/src/components/form/mt-switch/mt-switch.spec.ts
+++ b/packages/component-library/src/components/form/mt-switch/mt-switch.spec.ts
@@ -21,10 +21,12 @@ describe("mt-switch", () => {
   it("should update checked state when checked", async () => {
     wrapper = await createWrapper();
     const checkbox = wrapper?.find('input[type="checkbox"]');
-    await wrapper?.setProps({ checked: true });
-    expect(checkbox?.element).toBeChecked();
-    await wrapper?.setProps({ checked: false });
-    expect(checkbox?.element).not.toBeChecked();
+
+    await wrapper.setProps({ checked: true });
+    expect(checkbox.element).toBeChecked();
+
+    await wrapper.setProps({ checked: false });
+    expect(checkbox.element).not.toBeChecked();
   });
 
   it("should have correct ARIA attributes", async () => {

--- a/packages/component-library/src/components/form/mt-switch/mt-switch.spec.ts
+++ b/packages/component-library/src/components/form/mt-switch/mt-switch.spec.ts
@@ -1,0 +1,41 @@
+import { mount } from "@vue/test-utils";
+import MtSwitch from "./mt-switch.vue";
+
+async function createWrapper(props = {}, options = {}) {
+  return mount(MtSwitch, {
+    propsData: {
+      label: "Test Switch",
+      ...props,
+    },
+    ...options,
+  });
+}
+
+describe("mt-switch", () => {
+  let wrapper: Awaited<ReturnType<typeof createWrapper>>;
+
+  afterEach(() => {
+    wrapper?.unmount();
+  });
+
+  it("should update checked state when checked", async () => {
+    wrapper = await createWrapper();
+    const checkbox = wrapper?.find('input[type="checkbox"]');
+    await wrapper?.setProps({ checked: true });
+    expect(checkbox?.element).toBeChecked();
+    await wrapper?.setProps({ checked: false });
+    expect(checkbox?.element).not.toBeChecked();
+  });
+
+  it("should have correct ARIA attributes", async () => {
+    wrapper = await createWrapper({
+      checked: true,
+      label: "Accessibility Test",
+    });
+    const checkbox = wrapper.find('input[type="checkbox"]');
+
+    expect(checkbox.attributes("role")).toBe("checkbox");
+    expect(checkbox.attributes("aria-checked")).toBe("true");
+    expect(checkbox.attributes("aria-label")).toBe("Accessibility Test");
+  });
+});

--- a/packages/component-library/src/components/form/mt-switch/mt-switch.vue
+++ b/packages/component-library/src/components/form/mt-switch/mt-switch.vue
@@ -10,6 +10,9 @@
             :name="formFieldName || identification"
             :checked="inputState"
             :disabled="isDisabled"
+            :aria-checked="inputState"
+            :aria-label="label"
+            role="switch"
             @change.stop="onChange"
           />
           <div class="mt-field__switch-state">

--- a/packages/component-library/src/components/form/mt-switch/mt-switch.vue
+++ b/packages/component-library/src/components/form/mt-switch/mt-switch.vue
@@ -12,7 +12,7 @@
             :disabled="isDisabled"
             :aria-checked="inputState"
             :aria-label="label"
-            role="switch"
+            role="checkbox"
             @change.stop="onChange"
           />
           <div class="mt-field__switch-state">


### PR DESCRIPTION
## What?
Add aria attributes to mt-switch 

## Why?
Mt-switch was lacking aria attributes which improve the accessibility experience for users 

## How?
Added aria-checked, aria-label and role to input element inside mt-switch
