### PR TITLE
Add custom instructions

### DIFF
--- a/.github/copilot/custom-instructions/test-style-guide.md
+++ b/.github/copilot/custom-instructions/test-style-guide.md
@@ -1,0 +1,53 @@
+Always use `it` as the method for test.
+
+Every test file must end with `.spec.ts`.
+
+Every test must follow the AAA pattern: ARRANGE, ACT & ASSERT.
+
+All tests use Vitest.
+
+Every component/vue test uses `@testing-library/vue` instead of `@vue/test-utils`.
+
+When rendering a component with `render` do not destructure the result. Always import
+the methods to retrieve DOM elements from the `@testing-library/vue` package
+at the top of the file.
+
+Use `userEvent` from `@testing-library/user-event` to simulate user interaction. Do
+not use `fireEvent` from `@testing-library/vue`.
+
+Never check implementation details like internal methods or classnames.
+
+If possible, prefer the assertion matchers of `@testing-library/jest-dom` and
+`jest-extended` over the default assertion matchers of vitest.
+
+Do not save a DOM element to a variable. When retrieving an DOM element
+always call the methods of `@testing-library/vue`. This way we always
+have the latest DOM state and never rely on old out-dated values.
+
+Here's an example of a test:
+
+```ts
+it("does not emit an event when clicking on a button", async () => {
+  // ARRANGE
+  const handler = vi.fn();
+
+  render(Button, {
+    props: { disabled: true, onClick: handler },
+  });
+
+  // ACT
+  await userEvent.click(screen.getByRole("button")).click();
+
+  // ASSERT
+  expect(handler).not.toHaveBeenCalled();
+  expect(screen.getByRole("button")).toBeDisabled();
+});
+```
+
+Write the names of the test in a user-facing / user-friendly way. Someone
+who has never written a single line of code should understand what is
+happening. Avoid mentioning things like function names or prop names or
+event handlers, only focus on the expected behaviour.
+
+Do not include the word "should" in a test title. Write test titles like
+they are a fact.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,8 @@
 {
-  "typescript.tsdk": "node_modules/typescript/lib"
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "github.copilot.chat.testGeneration.instructions": [
+    {
+      "file": ".github/copilot/custom-instructions/test-style-guide.md"
+    }
+  ]
 }

--- a/packages/component-library/package.json
+++ b/packages/component-library/package.json
@@ -96,6 +96,7 @@
     "@storybook/theming": "^8.4.5",
     "@storybook/vue3": "^8.4.5",
     "@storybook/vue3-vite": "^8.4.5",
+    "@testing-library/user-event": "^14.6.0",
     "@tsconfig/node18": "^18.2.2",
     "@types/jsdom": "^21.1.3",
     "@types/node": "^18.18.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -448,6 +448,9 @@ importers:
       '@storybook/vue3-vite':
         specifier: ^8.4.5
         version: 8.4.6(storybook@8.4.6(prettier@3.2.5))(vite@4.5.5(@types/node@18.19.36)(sass@1.77.6)(terser@5.31.1))(vue@3.5.13(typescript@5.7.3))
+      '@testing-library/user-event':
+        specifier: ^14.6.0
+        version: 14.6.0(@testing-library/dom@10.4.0)
       '@tsconfig/node18':
         specifier: ^18.2.2
         version: 18.2.4
@@ -3808,6 +3811,12 @@ packages:
 
   '@testing-library/user-event@14.5.2':
     resolution: {integrity: sha512-YAh82Wh4TIrxYLmfGcixwD18oIjyC1pFQC2Y01F2lzV2HTMiYrI0nze0FD0ocB//CKS/7jIUgae+adPqxK5yCQ==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
+  '@testing-library/user-event@14.6.0':
+    resolution: {integrity: sha512-+jsfK7kVJbqnCYtLTln8Ja/NmVrZRwBJHmHR9IxIVccMWSOZ6Oy0FkDJNeyVu4QSpMNmRfy10Xb76ObRDlWWBQ==}
     engines: {node: '>=12', npm: '>=6'}
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
@@ -16949,7 +16958,7 @@ snapshots:
       rc9: 2.1.2
       semver: 7.6.2
 
-  '@nuxt/devtools@1.3.3(qp3ann6fzaegwpx42lfnuxbgim)':
+  '@nuxt/devtools@1.3.3(5905c37a0ab123defc9abd51d7cd6ed8)':
     dependencies:
       '@antfu/utils': 0.7.8
       '@nuxt/devtools-kit': 1.3.3(magicast@0.3.4)(nuxt@3.12.2(@opentelemetry/api@1.9.0)(@parcel/watcher@2.4.1)(@types/node@20.14.5)(@unocss/reset@0.61.0)(axios@1.7.2)(change-case@4.1.2)(encoding@0.1.13)(eslint@8.57.0)(floating-vue@5.2.2(@nuxt/kit@3.12.2(magicast@0.3.4)(rollup@4.18.0))(vue@3.5.0(typescript@5.7.3)))(ioredis@5.4.1)(magicast@0.3.4)(nprogress@0.2.0)(optionator@0.9.4)(rollup@4.18.0)(sass@1.77.6)(stylelint@16.10.0(typescript@5.7.3))(terser@5.31.1)(typescript@5.7.3)(unocss@0.61.0(postcss@8.4.49)(rollup@4.18.0)(vite@5.3.1(@types/node@20.14.5)(sass@1.77.6)(terser@5.31.1)))(vite@5.3.1(@types/node@20.14.5)(sass@1.77.6)(terser@5.31.1))(vue-tsc@2.2.0(typescript@5.7.3)))(rollup@4.18.0)(vite@5.3.1(@types/node@20.14.5)(sass@1.77.6)(terser@5.31.1))
@@ -18220,6 +18229,10 @@ snapshots:
       redent: 3.0.0
 
   '@testing-library/user-event@14.5.2(@testing-library/dom@10.4.0)':
+    dependencies:
+      '@testing-library/dom': 10.4.0
+
+  '@testing-library/user-event@14.6.0(@testing-library/dom@10.4.0)':
     dependencies:
       '@testing-library/dom': 10.4.0
 
@@ -26035,7 +26048,7 @@ snapshots:
   nuxt@3.12.2(@opentelemetry/api@1.9.0)(@parcel/watcher@2.4.1)(@types/node@20.14.5)(@unocss/reset@0.61.0)(axios@1.7.2)(change-case@4.1.2)(encoding@0.1.13)(eslint@8.57.0)(floating-vue@5.2.2(@nuxt/kit@3.12.2(magicast@0.3.4)(rollup@4.18.0))(vue@3.5.0(typescript@5.7.3)))(ioredis@5.4.1)(magicast@0.3.4)(nprogress@0.2.0)(optionator@0.9.4)(rollup@4.18.0)(sass@1.77.6)(stylelint@16.10.0(typescript@5.7.3))(terser@5.31.1)(typescript@5.7.3)(unocss@0.61.0(postcss@8.4.49)(rollup@4.18.0)(vite@5.3.1(@types/node@20.14.5)(sass@1.77.6)(terser@5.31.1)))(vite@5.3.1(@types/node@20.14.5)(sass@1.77.6)(terser@5.31.1))(vue-tsc@2.2.0(typescript@5.7.3)):
     dependencies:
       '@nuxt/devalue': 2.0.2
-      '@nuxt/devtools': 1.3.3(qp3ann6fzaegwpx42lfnuxbgim)
+      '@nuxt/devtools': 1.3.3(5905c37a0ab123defc9abd51d7cd6ed8)
       '@nuxt/kit': 3.12.2(magicast@0.3.4)(rollup@4.18.0)
       '@nuxt/schema': 3.12.2(rollup@4.18.0)
       '@nuxt/telemetry': 2.5.4(magicast@0.3.4)(rollup@4.18.0)


### PR DESCRIPTION
## What?

I added some custom instructions to improve the experience when generating tests with GitHub Copilot

## Why?

This drastically improves the quality of GitHub Copilot's suggestions when generating tests.

## How?

I added a Markdown file with instructions and mentioned that file in the `.vscode/settings.json` file

## Testing?

Try it out
