### PR TITLE
fix(component-library): turn scroll bar dark in dark mode

### DIFF
--- a/.changeset/khaki-bikes-smell.md
+++ b/.changeset/khaki-bikes-smell.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": patch
+---
+
+Turn scrollbar dark for dark mode

--- a/packages/component-library/src/components/assets/scss/global.scss
+++ b/packages/component-library/src/components/assets/scss/global.scss
@@ -6,6 +6,10 @@
   padding: 0;
 }
 
+[data-theme="dark"] {
+  color-scheme: dark;
+}
+
 body {
   font-family: $font-family-default;
   font-size: $font-size-default;


### PR DESCRIPTION
## What?

This PR turns the scrollbar dark when the dark mode is enabled.

## Why?

This makes makes the dark mode more visually pleasing

## How?

I just added a `color-scheme: dark` to the global css file.

## Testing?

Visit the branch preview, checkout the "Full Data Table" Story and enable the dark mode by clicking on the "Picture" icon from the Storybook toolbar, located at the top of the screen and select "Dark".

## Anything Else?
