### PR TITLE
ci: fix failing visual test workflow for forks

### DIFF
--- a/.github/workflows/visual-tests.yml
+++ b/.github/workflows/visual-tests.yml
@@ -24,8 +24,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref }}
 
       - uses: pnpm/action-setup@v3
         with:


### PR DESCRIPTION
## What?

This PR fixes the visual test pipeline when someone starts it by creating a fork.

## Why?

The pipeline failed because of the old configuration, this only happened with forks.

## How?

I just removed the `ref`

## Testing?

If the pipeline passes everything works.
