### PR TITLE
feat(component-library): make mt-search component public

### DIFF
--- a/.changeset/beige-otters-protect.md
+++ b/.changeset/beige-otters-protect.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": minor
+---
+
+Make mt-search public

--- a/packages/component-library/src/index.ts
+++ b/packages/component-library/src/index.ts
@@ -39,6 +39,7 @@ import DeviceHelperPlugin from "./plugin/device-helper.plugin";
 import MtTooltip from "./components/overlay/mt-tooltip/mt-tooltip.vue";
 import MtTextEditor from "./components/form/mt-text-editor/mt-text-editor.vue";
 import MtTextEditorToolbarButton from "./components/form/mt-text-editor/_internal/mt-text-editor-toolbar-button.vue";
+import MtSearch from "./components/navigation/mt-search/mt-search.vue";
 
 // Import SCSS for styling
 import "./components/assets/scss/all.scss";
@@ -88,6 +89,7 @@ export {
   MtModalAction,
   MtText,
   MtInset,
+  MtSearch,
   MtThemeProvider,
   TooltipDirective,
   DeviceHelperPlugin,


### PR DESCRIPTION
## What?

I made the `mt-search` component public.

## Why?

This project is used in some components like the core Shopware 6, where it's used inside card headers a lot.

## How?

I exported the component in the `src/index.ts` file

## Testing?

Check out the branch and test it out yourself.
