### PR TITLE
refactor(component-library): use spacing tokens in mt-progress-bar

### DIFF
--- a/.changeset/spotty-singers-notice.md
+++ b/.changeset/spotty-singers-notice.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": patch
+---
+
+Open the context menu when pressing space or enter

--- a/packages/component-library/src/components/context-menu/mt-context-button/mt-context-button.vue
+++ b/packages/component-library/src/components/context-menu/mt-context-button/mt-context-button.vue
@@ -105,24 +105,6 @@ export default defineComponent({
       default: () => [],
     },
   },
-
-  data() {
-    return {};
-  },
-
-  computed: {
-    contextClass(): {
-      "is--disabled": boolean;
-      "has--error": boolean;
-    } {
-      return {
-        "is--disabled": this.disabled,
-        "has--error": this.hasError,
-      };
-    },
-  },
-
-  methods: {},
 });
 </script>
 
@@ -133,23 +115,6 @@ $mt-context-button-color-border: var(--color-border-primary-default);
 $mt-context-button-color-disabled: var(--color-icon-primary-disabled);
 
 .mt-context-button {
-  &.is--disabled {
-    .mt-context-button__button {
-      color: var(--color-icon-primary-disabled);
-      cursor: initial;
-
-      &:hover {
-        border: none;
-      }
-    }
-  }
-
-  &.is--disabled.is--open {
-    .mt-context-button__button {
-      border: none;
-    }
-  }
-
   &.is--open .mt-context-button__button {
     border-color: $mt-context-button-color-border;
   }
@@ -169,16 +134,6 @@ $mt-context-button-color-disabled: var(--color-icon-primary-disabled);
 
     &:hover {
       border-color: $mt-context-button-color-border;
-    }
-  }
-
-  &.has--error {
-    .mt-context-button__button {
-      color: $color-crimson-300;
-
-      .mt-icon {
-        color: $mt-context-button-color-text;
-      }
     }
   }
 }

--- a/packages/component-library/src/components/context-menu/mt-context-button/mt-context-button.vue
+++ b/packages/component-library/src/components/context-menu/mt-context-button/mt-context-button.vue
@@ -50,23 +50,18 @@ withDefaults(
 );
 </script>
 
-<style lang="scss">
-$mt-context-button-color-text: var(--color-icon-primary-default);
-$mt-context-button-border-radius: var(--border-radius-xs);
-$mt-context-button-color-border: var(--color-border-primary-default);
-$mt-context-button-color-disabled: var(--color-icon-primary-disabled);
-
+<style>
 .mt-context-button {
   &.is--open .mt-context-button__button {
-    border-color: $mt-context-button-color-border;
+    border-color: var(--color-border-primary-default);
   }
 
-  .mt-context-button__button {
+  & .mt-context-button__button {
     position: relative;
-    color: $mt-context-button-color-text;
+    color: var(--color-icon-primary-default);
     background: 0 none;
     border: 1px solid transparent;
-    border-radius: $mt-context-button-border-radius;
+    border-radius: var(--border-radius-xs);
     cursor: pointer;
     height: var(--scale-size-24);
     line-height: 20px;
@@ -75,7 +70,7 @@ $mt-context-button-color-disabled: var(--color-icon-primary-disabled);
     font-family: var(--font-family-body);
 
     &:hover {
-      border-color: $mt-context-button-color-border;
+      border-color: var(--color-border-primary-default);
     }
   }
 }

--- a/packages/component-library/src/components/context-menu/mt-context-button/mt-context-button.vue
+++ b/packages/component-library/src/components/context-menu/mt-context-button/mt-context-button.vue
@@ -8,7 +8,6 @@
           aria-label="Context menu"
           class="mt-context-button__button"
           @click="toggleFloatingUi"
-          @keyup.enter="toggleFloatingUi"
         >
           <mt-icon :name="icon" small decorative />
 

--- a/packages/component-library/src/components/context-menu/mt-context-button/mt-context-button.vue
+++ b/packages/component-library/src/components/context-menu/mt-context-button/mt-context-button.vue
@@ -22,90 +22,32 @@
   </mt-popover>
 </template>
 
-<script lang="ts">
-import type { PropType } from "vue";
-
-import { defineComponent } from "vue";
+<script setup lang="ts">
 import MtIcon from "../../icons-media/mt-icon/mt-icon.vue";
 import type { View } from "../../overlay/mt-popover/mt-popover.interfaces";
 import MtPopover from "../../overlay/mt-popover/mt-popover.vue";
 
-export default defineComponent({
-  name: "MtContextButtonVue",
-
-  components: {
-    "mt-icon": MtIcon,
-    "mt-popover": MtPopover,
+withDefaults(
+  defineProps<{
+    menuWidth?: number;
+    menuHorizontalAlign?: "right" | "left";
+    menuVerticalAlign?: "bottom" | "top";
+    icon?: string;
+    disabled?: boolean;
+    hasError?: boolean;
+    autoClose?: boolean;
+    title?: string;
+    childViews?: View[];
+  }>(),
+  {
+    menuWidth: 220,
+    menuHorizontalAlign: "right",
+    menuVerticalAlign: "bottom",
+    icon: "solid-ellipsis-h-s",
+    title: "",
+    default: [],
   },
-
-  props: {
-    menuWidth: {
-      type: Number,
-      required: false,
-      default: 220,
-    },
-
-    menuHorizontalAlign: {
-      type: String as PropType<"right" | "left">,
-      required: false,
-      default: "right",
-      validator(value: string) {
-        if (!value.length) {
-          return true;
-        }
-        return ["right", "left"].includes(value);
-      },
-    },
-
-    menuVerticalAlign: {
-      type: String,
-      required: false,
-      default: "bottom",
-      validator(value: string) {
-        if (!value.length) {
-          return true;
-        }
-        return ["bottom", "top"].includes(value);
-      },
-    },
-
-    icon: {
-      type: String,
-      required: false,
-      default: "solid-ellipsis-h-s",
-    },
-
-    disabled: {
-      type: Boolean,
-      required: false,
-      default: false,
-    },
-
-    hasError: {
-      type: Boolean,
-      required: false,
-      default: false,
-    },
-
-    autoClose: {
-      type: Boolean,
-      required: false,
-      default: true,
-    },
-
-    title: {
-      type: String,
-      required: false,
-      default: "",
-    },
-
-    childViews: {
-      type: Array as PropType<View[]>,
-      required: false,
-      default: () => [],
-    },
-  },
-});
+);
 </script>
 
 <style lang="scss">

--- a/packages/component-library/src/components/context-menu/mt-context-menu.spec.ts
+++ b/packages/component-library/src/components/context-menu/mt-context-menu.spec.ts
@@ -1,0 +1,54 @@
+import { userEvent } from "@storybook/test";
+import { render, screen } from "@testing-library/vue";
+import { defineComponent } from "vue";
+import MtContextButton from "./mt-context-button/mt-context-button.vue";
+
+describe("mt-context-menu", async () => {
+  it("is possible to focus the button that opens the context menu", async () => {
+    // ARRANGE
+    render(
+      defineComponent({
+        template: `
+<mt-context-button>
+    <template #button-text>
+        Open context menu
+    </template>
+</mt-context-button>
+        `,
+        components: {
+          MtContextButton,
+        },
+      }),
+    );
+
+    // ACT
+    await userEvent.tab();
+
+    // ASSERT
+    expect(screen.getByRole("button")).toHaveFocus();
+  });
+
+  it("is possible to open the context menu by clicking on the button", async () => {
+    // ARRANGE
+    render(
+      defineComponent({
+        template: `
+<mt-context-button>
+    <template #button-text>
+        Open context menu
+    </template>
+</mt-context-button>
+        `,
+        components: {
+          MtContextButton,
+        },
+      }),
+    );
+
+    // ACT
+    await userEvent.click(screen.getByRole("button"));
+
+    // ASSERT
+    expect(screen.getByRole("dialog")).toBeVisible();
+  });
+});

--- a/packages/component-library/src/components/context-menu/mt-context-menu.spec.ts
+++ b/packages/component-library/src/components/context-menu/mt-context-menu.spec.ts
@@ -51,6 +51,16 @@ describe("mt-context-menu", async () => {
     expect(screen.getByRole("button")).toHaveTextContent("Open context menu");
   });
 
+  it("is possible to set a custom text for the button", async () => {
+    // ARRANGE
+    render(MtContextButton, {
+      slots: { "button-text": "Open context menu" },
+    });
+
+    // ASSERT
+    expect(screen.getByRole("button")).toHaveTextContent("Open context menu");
+  });
+
   it("shows the ellipsis icon by default", async () => {
     // ARRANGE
     render(MtContextButton);

--- a/packages/component-library/src/components/context-menu/mt-context-menu.spec.ts
+++ b/packages/component-library/src/components/context-menu/mt-context-menu.spec.ts
@@ -79,4 +79,26 @@ describe("mt-context-menu", async () => {
       expect(screen.getByRole("dialog")).toBeVisible();
     },
   );
+
+  it("is possible to set a custom element for the button", async () => {
+    // ARRANGE
+    render(
+      defineComponent({
+        template: `
+<mt-context-button>
+    <template #button>
+        <button>Open context menu</button> 
+    </template>
+</mt-context-button>
+`,
+        components: {
+          MtContextButton,
+        },
+      }),
+    );
+
+    // ASSERT
+    expect(screen.getByRole("button")).toBeVisible();
+    expect(screen.getByRole("button")).toHaveTextContent("Open context menu");
+  });
 });

--- a/packages/component-library/src/components/context-menu/mt-context-menu.spec.ts
+++ b/packages/component-library/src/components/context-menu/mt-context-menu.spec.ts
@@ -51,4 +51,32 @@ describe("mt-context-menu", async () => {
     // ASSERT
     expect(screen.getByRole("dialog")).toBeVisible();
   });
+
+  it.each([" ", "{Enter}"])(
+    'is possible to open the context menu by pressing "%s"',
+    async (key) => {
+      // ARRANGE
+      render(
+        defineComponent({
+          template: `
+<mt-context-button>
+    <template #button-text>
+        Open context menu
+    </template>
+</mt-context-button>
+        `,
+          components: {
+            MtContextButton,
+          },
+        }),
+      );
+
+      // ARRANGE
+      await userEvent.tab();
+      await userEvent.keyboard(key);
+
+      // ACT
+      expect(screen.getByRole("dialog")).toBeVisible();
+    },
+  );
 });

--- a/packages/component-library/src/components/context-menu/mt-context-menu.spec.ts
+++ b/packages/component-library/src/components/context-menu/mt-context-menu.spec.ts
@@ -101,4 +101,46 @@ describe("mt-context-menu", async () => {
     expect(screen.getByRole("button")).toBeVisible();
     expect(screen.getByRole("button")).toHaveTextContent("Open context menu");
   });
+
+  it("shows the ellipsis icon by default", async () => {
+    // ARRANGE
+    render(
+      defineComponent({
+        template: `
+<mt-context-button>
+    <template #button-text>
+        Open context menu
+    </template>
+</mt-context-button>
+        `,
+        components: {
+          MtContextButton,
+        },
+      }),
+    );
+
+    // ASSERT
+    expect(screen.getByTestId("mt-icon__solid-ellipsis-h-s")).toBeVisible();
+  });
+
+  it("shows an icon when specified", async () => {
+    // ARRANGE
+    render(
+      defineComponent({
+        template: `
+<mt-context-button icon="solid-times-s">
+    <template #button-text>
+        Open context menu
+    </template>
+</mt-context-button>
+        `,
+        components: {
+          MtContextButton,
+        },
+      }),
+    );
+
+    // ASSERT
+    expect(screen.getByTestId("mt-icon__solid-times-s")).toBeVisible();
+  });
 });

--- a/packages/component-library/src/components/context-menu/mt-context-menu.spec.ts
+++ b/packages/component-library/src/components/context-menu/mt-context-menu.spec.ts
@@ -1,25 +1,11 @@
 import { userEvent } from "@storybook/test";
 import { render, screen } from "@testing-library/vue";
-import { defineComponent } from "vue";
 import MtContextButton from "./mt-context-button/mt-context-button.vue";
 
 describe("mt-context-menu", async () => {
   it("is possible to focus the button that opens the context menu", async () => {
     // ARRANGE
-    render(
-      defineComponent({
-        template: `
-<mt-context-button>
-    <template #button-text>
-        Open context menu
-    </template>
-</mt-context-button>
-        `,
-        components: {
-          MtContextButton,
-        },
-      }),
-    );
+    render(MtContextButton);
 
     // ACT
     await userEvent.tab();
@@ -30,20 +16,7 @@ describe("mt-context-menu", async () => {
 
   it("is possible to open the context menu by clicking on the button", async () => {
     // ARRANGE
-    render(
-      defineComponent({
-        template: `
-<mt-context-button>
-    <template #button-text>
-        Open context menu
-    </template>
-</mt-context-button>
-        `,
-        components: {
-          MtContextButton,
-        },
-      }),
-    );
+    render(MtContextButton);
 
     // ACT
     await userEvent.click(screen.getByRole("button"));
@@ -56,20 +29,7 @@ describe("mt-context-menu", async () => {
     'is possible to open the context menu by pressing "%s"',
     async (key) => {
       // ARRANGE
-      render(
-        defineComponent({
-          template: `
-<mt-context-button>
-    <template #button-text>
-        Open context menu
-    </template>
-</mt-context-button>
-        `,
-          components: {
-            MtContextButton,
-          },
-        }),
-      );
+      render(MtContextButton);
 
       // ARRANGE
       await userEvent.tab();
@@ -82,20 +42,9 @@ describe("mt-context-menu", async () => {
 
   it("is possible to set a custom element for the button", async () => {
     // ARRANGE
-    render(
-      defineComponent({
-        template: `
-<mt-context-button>
-    <template #button>
-        <button>Open context menu</button> 
-    </template>
-</mt-context-button>
-`,
-        components: {
-          MtContextButton,
-        },
-      }),
-    );
+    render(MtContextButton, {
+      slots: { button: "<button>Open context menu</button>" },
+    });
 
     // ASSERT
     expect(screen.getByRole("button")).toBeVisible();
@@ -104,20 +53,7 @@ describe("mt-context-menu", async () => {
 
   it("shows the ellipsis icon by default", async () => {
     // ARRANGE
-    render(
-      defineComponent({
-        template: `
-<mt-context-button>
-    <template #button-text>
-        Open context menu
-    </template>
-</mt-context-button>
-        `,
-        components: {
-          MtContextButton,
-        },
-      }),
-    );
+    render(MtContextButton);
 
     // ASSERT
     expect(screen.getByTestId("mt-icon__solid-ellipsis-h-s")).toBeVisible();
@@ -125,20 +61,11 @@ describe("mt-context-menu", async () => {
 
   it("shows an icon when specified", async () => {
     // ARRANGE
-    render(
-      defineComponent({
-        template: `
-<mt-context-button icon="solid-times-s">
-    <template #button-text>
-        Open context menu
-    </template>
-</mt-context-button>
-        `,
-        components: {
-          MtContextButton,
-        },
-      }),
-    );
+    render(MtContextButton, {
+      props: {
+        icon: "solid-times-s",
+      },
+    });
 
     // ASSERT
     expect(screen.getByTestId("mt-icon__solid-times-s")).toBeVisible();

--- a/packages/component-library/src/components/feedback-indicator/mt-progress-bar/mt-progress-bar.vue
+++ b/packages/component-library/src/components/feedback-indicator/mt-progress-bar/mt-progress-bar.vue
@@ -67,7 +67,7 @@ const fillWidth = computed<`${string}%`>(() => {
     "label progress"
     "track track"
     "error error";
-  row-gap: 0.5rem;
+  row-gap: var(--scale-size-8);
 }
 
 .mt-progress-bar__progress-label {
@@ -78,7 +78,7 @@ const fillWidth = computed<`${string}%`>(() => {
 
 .mt-progress-bar__track {
   border-radius: var(--border-radius-round);
-  height: 0.5rem;
+  height: var(--scale-size-8);
   width: 100%;
   background: var(--color-background-primary-disabled);
   grid-area: track;


### PR DESCRIPTION
## What?

This PR replaces the hard-coded spacing values with spacing tokens.

## Why?

Using spacing tokens helps us to use consistent spacing across all our products.

## How?

I replaced the hard-coded spacing values with spacing tokens.

## Testing?

If the visual tests pass everything is the same as before.
