### PR TITLE
fix(component-library): fix huge error badge in tabs component

### DIFF
--- a/.changeset/green-kangaroos-deny.md
+++ b/.changeset/green-kangaroos-deny.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": patch
+---
+
+Fix huge error badge in mt-tabs

--- a/packages/component-library/src/components/navigation/mt-tabs/mt-tabs.vue
+++ b/packages/component-library/src/components/navigation/mt-tabs/mt-tabs.vue
@@ -25,6 +25,8 @@
             v-if="item.hasError"
             class="mt-tabs__error-badge"
             name="solid-exclamation-circle"
+            size="var(--scale-size-12)"
+            color="var(--color-icon-critical-default)"
           />
 
           <mt-color-badge v-if="item.badge" :variant="item.badge" rounded />
@@ -474,13 +476,5 @@ export default defineComponent({
 
 .mt-tabs__error-badge {
   margin-left: var(--scale-size-2);
-  width: var(--scale-size-12);
-  height: var(--scale-size-12);
-  color: var(--color-icon-critical-default);
-
-  > svg {
-    width: 100% !important;
-    height: 100% !important;
-  }
 }
 </style>


### PR DESCRIPTION
## What?

I adjusted the size of the icon in `mt-tabs`

## Why?

It was a visual but, the icon was way to huge.

## How?

Instead of sizing the icon via css I did it by setting the `size` prop of the `mt-icon` component

## Testing?

If the visual tests pass everything works as expected.
