### PR TITLE
fix(component-library): fix ts node_module resolution

### DIFF
--- a/packages/component-library/tsconfig.node.json
+++ b/packages/component-library/tsconfig.node.json
@@ -11,6 +11,13 @@
     "composite": true,
     "module": "ESNext",
     "moduleResolution": "Bundler",
-    "types": ["node"]
+    "types": ["node"],
+    "baseUrl": ".",
+    "paths": {
+      "*": [
+        "./node_modules/*",
+        "../../node_modlues/*"
+      ]
+    }
   }
 }


### PR DESCRIPTION
## What?
Added node_module paths for correct TS resolution for component-library.

## Why?
Desired packages in component-library don't have the correct resolution to root's node_modules-folder.

## How?
By adding both relevant node_modules-folders to the component-library's ts-config.

## Testing?
This change is only relevant for developing convenience so no testing is needed.

## Screenshots (optional)

## Anything Else?
