### PR TITLE
feat: add `contextCompareShopwareVersion` to SDK

### DIFF
--- a/.changeset/fluffy-teachers-complain.md
+++ b/.changeset/fluffy-teachers-complain.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-admin-sdk": minor
+---
+
+Add `contextCompareShopwareVersion` to sdk to compare the current Shopware version

--- a/docs/admin-sdk/docs/guide/2_api-reference/context.md
+++ b/docs/admin-sdk/docs/guide/2_api-reference/context.md
@@ -188,6 +188,34 @@ string
 '6.4.0.0'
 ```
 
+
+## Shopware compare version
+
+### Compare current Shopware version with a given version
+
+#### Usage:  
+```ts
+const isRightVersion = await sw.context.compareShopwareVersion({version:'6.4.0', comparator: '>='})
+```
+
+#### Parameters
+| Name         | Description                                                                                                       |
+|:-------------|:------------------------------------------------------------------------------------------------------------------|
+| `version`    | The string with the version to compare                                                                            |
+| `comparator` | The operator to compare. Possible values: `'='` `'>'` `'<'` `'<='` `'>='`<br/> If not provided `'='` will be used |
+
+
+#### Return value:
+
+```ts
+boolean
+```
+
+#### Example value:
+```ts
+true
+```
+
 ## App information
 
 ### Get app information
@@ -327,7 +355,7 @@ Promise<{
     id: string,
     locationId: string
   }>
-}}>
+}>
 ```
 
 #### Example value:

--- a/packages/admin-sdk/src/context/index.ts
+++ b/packages/admin-sdk/src/context/index.ts
@@ -7,6 +7,7 @@ export const getLocale = createSender('contextLocale', {});
 export const subscribeLocale = createSubscriber('contextLocale');
 export const getCurrency = createSender('contextCurrency', {});
 export const getShopwareVersion = createSender('contextShopwareVersion', {});
+export const compareShopwareVersion = createSender('contextCompareShopwareVersion', {});
 export const getUserInformation = createSender('contextUserInformation', {});
 export const getUserTimezone = createSender('contextUserTimezone', {});
 export const getAppInformation = createSender('contextAppInformation', {});
@@ -55,6 +56,14 @@ export type contextCurrency = {
 export type contextShopwareVersion = {
   responseType: string,
 }
+/**
+ * Get the current Shopware version comparison
+ */
+export type contextCompareShopwareVersion = {
+  responseType: boolean,
+  version: string,
+  comparator?: '=' | '>'| '<'|'<=' | '>=',
+};
 
 /**
  * Get the current app information

--- a/packages/admin-sdk/src/message-types.ts
+++ b/packages/admin-sdk/src/message-types.ts
@@ -11,7 +11,8 @@ import type {
   contextModuleInformation,
   contextUserInformation,
   contextUserTimezone,
-} from './context/index';
+  contextCompareShopwareVersion,
+} from './context';
 import type { uiComponentSectionRenderer } from './ui/component-section/index';
 import type { uiTabsAddTabItem } from './ui/tabs';
 import type { uiModulePaymentOverviewCard } from './ui/module/payment/overview-card';
@@ -55,6 +56,7 @@ export interface ShopwareMessageTypes {
   contextLocale: contextLocale,
   contextCurrency: contextCurrency,
   contextShopwareVersion: contextShopwareVersion,
+  contextCompareShopwareVersion: contextCompareShopwareVersion,
   contextUserInformation: contextUserInformation,
   contextUserTimezone: contextUserTimezone,
   contextAppInformation: contextAppInformation,


### PR DESCRIPTION
## What?
Added a new feature `contextShopwareVersion` to meteor SDK

## Why?
To enhance the version comparison functionality by supporting versions that have four numeric parts and suffixes.

## How?
- Added `contextShopwareVersion` sender to the context SDK.

