### PR TITLE
ci: upgrade node version in preview release job

### DIFF
--- a/.github/workflows/npm-preview-release.yml
+++ b/.github/workflows/npm-preview-release.yml
@@ -11,13 +11,17 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+
       - run: corepack enable
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: "pnpm"
+
       - name: Install dependencies
         run: pnpm install
+
       - name: Build
         run: npx turbo run build
+
       - run: pnpx pkg-pr-new publish './packages/*'


### PR DESCRIPTION
## What?

This PR upgrades node to version 22 for the preview release job.

## Why?

Currently, the preview release job does not work.

## How?

I upgraded the node version to 22.

## Testing?

Approving the PR is needed to execute the job.
