### PR TITLE
announce email field as invalid to screen readers when input has error

### DIFF
--- a/.changeset/ten-dolls-film.md
+++ b/.changeset/ten-dolls-film.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": patch
+---
+
+Announce email field as invalid to screen readers when input has error

--- a/packages/component-library/src/components/form/_internal/mt-field-error/mt-field-error.vue
+++ b/packages/component-library/src/components/form/_internal/mt-field-error/mt-field-error.vue
@@ -8,7 +8,7 @@
   >
     <mt-icon name="solid-exclamation-circle" size="0.75rem" aria-hidden="true" />
 
-    <span>{{ errorMessage }}</span>
+    {{ errorMessage }}
   </mt-text>
 </template>
 

--- a/packages/component-library/src/components/form/mt-email-field/mt-email-field.spec.ts
+++ b/packages/component-library/src/components/form/mt-email-field/mt-email-field.spec.ts
@@ -480,4 +480,52 @@ describe("mt-email-field", () => {
     // ASSERT
     expect(screen.getByRole("tooltip")).toBeVisible();
   });
+
+  it("announces itself as invalid to screen readers when the value is invalid", async () => {
+    // ARRANGE
+    await render(MtEmailField, {
+      props: {
+        modelValue: "asdf@",
+      },
+    });
+
+    // ASSERT
+    expect(screen.getByRole("textbox")).toHaveAttribute("aria-invalid", "true");
+  });
+
+  it("announces itself as invalid to screen readers when the field has an error", async () => {
+    // ARRANGE
+    await render(MtEmailField, {
+      props: {
+        error: {
+          detail: "Some error",
+        },
+      },
+    });
+
+    // ASSERT
+    expect(screen.getByRole("textbox")).toHaveAttribute("aria-invalid", "true");
+  });
+
+  it("announces the error message to screen readers when the field has an error", async () => {
+    // ARRANGE
+    await render(MtEmailField, {
+      props: {
+        error: {
+          detail: "Some error",
+        },
+      },
+    });
+
+    // ASSERT
+    expect(screen.getByRole("textbox")).toHaveAttribute(
+      "aria-describedby",
+      screen.getByText("Some error").id,
+    );
+
+    expect(screen.getByText("Some error")).toHaveAttribute(
+      "id",
+      screen.getByRole("textbox").getAttribute("aria-describedby"),
+    );
+  });
 });

--- a/packages/component-library/src/components/form/mt-email-field/mt-email-field.vue
+++ b/packages/component-library/src/components/form/mt-email-field/mt-email-field.vue
@@ -51,6 +51,8 @@
         :disabled="disabled || isInherited"
         :name="name"
         :placeholder="placeholder"
+        :aria-invalid="!!errorMessage || !!error"
+        :aria-describedby="!!errorMessage || !!error ? errorId : undefined"
         @change="$emit('change', ($event.target as HTMLInputElement).value)"
         @focus="$emit('focus')"
         @blur="
@@ -93,6 +95,7 @@
 
     <mt-field-error
       v-if="error || errorMessage"
+      :id="errorId"
       :error="errorMessage || error"
       :style="{ gridArea: 'error' }"
     />
@@ -142,6 +145,8 @@ defineProps<{
 defineEmits(["change", "blur", "focus", "inheritance-restore", "inheritance-remove"]);
 
 const id = useId();
+
+const errorId = useId();
 
 onMounted(checkValidity);
 


### PR DESCRIPTION
## What?

This improves the a11y. When the user focuses the input field, the screen reader announces the error after it announces the label and the value of the input.

## Why?

This way, screen reader users know when an input field has en error.

## How?

I added an `aria-invalid` label to the input fields

## Testing?

This only works with manual testing:

1. Checkout the branch preview
2. Go to a story with an invalid input field
3. Start your screen reader and see if it tells you that the input field is a) invalid and b) it announces the text of the error
