### PR TITLE
do not show bottom shadow when content is not scrollable

### DIFF
--- a/.changeset/nine-cooks-clap.md
+++ b/.changeset/nine-cooks-clap.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": patch
+---
+
+Do not show bottom shadow in modal when content is not scrollable

--- a/packages/component-library/src/components/overlay/mt-modal/mt-modal.vue
+++ b/packages/component-library/src/components/overlay/mt-modal/mt-modal.vue
@@ -189,7 +189,7 @@ watch(
   async () => {
     const isModalClosed = !isOpen.value;
     if (isModalClosed) {
-      showShadows.value = "top";
+      showShadows.value = "none";
 
       if (!modalContentRef.value) return;
       modalContentRef.value.removeEventListener("scroll", handleScroll);


### PR DESCRIPTION
## What?

There was a bug where, when the user opened the modal they could see a shadow, indicating that they can scroll inside the modal, which they could not because there was nothing to scroll.

I changed this so that it is no longer the case. The modal no longer shows a scroll shadow if the user cannot scroll inside the modal.

## Why?

It does not make sense to show a scroll shadow. The job of it is to indicate that something is scrollable, but nothing is scrollable, show we should not show it.

## How?

When the modal gets closed we hide all scroll shadows. 

## Testing?

I did not write any unit tests as this is a visual feature and those are hard to test with unit tests.

So please do some manual testing:
1. Checkout the branch preview
2. Open a `mt-text-editor` story, click on the link icon in the toolbar
3. Check if the modal has a scroll shadow, if not everything is as it should be
