### PR TITLE
fix: remove duplicated remove-inheritance event

### DIFF
--- a/.changeset/fresh-geese-juggle.md
+++ b/.changeset/fresh-geese-juggle.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": patch
+---
+
+Remove duplicated event emit in sw-switch of remove-inheritance

--- a/packages/component-library/src/components/form/mt-switch/mt-switch.vue
+++ b/packages/component-library/src/components/form/mt-switch/mt-switch.vue
@@ -30,7 +30,6 @@
           :is-inheritance-field="isInheritanceField"
           :is-inherited="isInherited"
           @inheritance-restore="onInheritanceRestore($event)"
-          @inheritance-remove="$emit('inheritance-remove', $event)"
         >
           <template #label>
             {{ label }}


### PR DESCRIPTION
## What?

The `remove-inheritance` event gets triggered twice on click in `mt-switch` which leads to issues

## Why?

Because the original `remove-inheritance` gets already emitted with `$attrs`

## How?

Remove the other one

## Testing?

Tested it carefully in the Shopware platform