### PR TITLE
ci: enable corepack in npm preview build

### DIFF
--- a/.github/workflows/npm-preview-release.yml
+++ b/.github/workflows/npm-preview-release.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - run: corepack enable
+      - run: npm i -g --force corepack && corepack enable
       - uses: actions/setup-node@v4
         with:
           node-version: 20


### PR DESCRIPTION
## What?

This fixes the failing preview build job by installing corepack via npm

## Why?

The actions/setup-node@v4 action fails because it cannot correctly use corepack.

To fix that I implemented workaround. It installs corepack via npm and then enables it.

We cannot remove it, because pkg.pr.new needs corepack in order to work.

## How?

The job now installs `corepack` via npm and then enables it.

## Testing?

In order to test that, we need to create a preview build. To start that preview build
one person needs to approve this PR.

## Anything Else?

See: https://github.com/actions/setup-node/issues/1222#issuecomment-2631024706
