### PR TITLE
docs: update css import guide in docs

### DIFF
--- a/packages/component-library/README.md
+++ b/packages/component-library/README.md
@@ -19,10 +19,11 @@ Add this package to your project:
 npm i @shopware-ag/meteor-component-library
 ```
 
-Import the `style.css` for general styling like fonts, etc. in the root file of your application or in you root styling file.
+Import the `style.css` for general styling and `font.css` for the Inter font in the root file of your application or in you root styling file.
 
 ```js
-import "@shopware-ag/meteor-component-library/dist/style.css";
+import "@shopware-ag/meteor-component-library/style.css";
+import "@shopware-ag/meteot-component-library/font.css";
 ```
 
 Each component works independently and can be imported directly from the root like this:


### PR DESCRIPTION
I think the readme contains some old way of importing the styles of the component library. This should be correct now.