### PR TITLE
Remove styling rules for eslint

### DIFF
--- a/examples/admin-sdk-plugin/tests/acceptance/.eslintrc.cjs
+++ b/examples/admin-sdk-plugin/tests/acceptance/.eslintrc.cjs
@@ -2,13 +2,13 @@ module.exports = {
     extends: [
         "eslint:recommended",
         "plugin:@typescript-eslint/recommended",
-        "plugin:playwright/recommended"
+        "plugin:playwright/recommended",
+        "prettier"
     ],
     parser: "@typescript-eslint/parser",
     plugins: ["@typescript-eslint"],
     root: true,
     rules: {
-        quotes: ["error", "single", { allowTemplateLiterals: true }],
         "no-console": ["error", { allow: ["warn", "error"] }],
         "comma-dangle": ["error", "always-multiline"],
         "no-unused-vars": "warn",

--- a/examples/admin-sdk-plugin/tests/acceptance/package.json
+++ b/examples/admin-sdk-plugin/tests/acceptance/package.json
@@ -25,6 +25,7 @@
     "@typescript-eslint/parser": "^5.47.0",
     "eslint": "^8.49.0",
     "eslint-plugin-playwright": "^1.6.2",
+    "eslint-config-prettier": "^9.1.0",
     "prettier": "3.3.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,6 +166,9 @@ importers:
       eslint:
         specifier: ^8.49.0
         version: 8.57.0
+      eslint-config-prettier:
+        specifier: ^9.1.0
+        version: 9.1.0(eslint@8.57.0)
       eslint-plugin-playwright:
         specifier: ^1.6.2
         version: 1.6.2(eslint@8.57.0)


### PR DESCRIPTION
## What?

This PR turns off all stylistic linting rules, like forcing single quotes, inside the `admin-sdk-plugin` package, off.

## Why?

Formatting is not the job a linter, that's the job of a formatter. ESLint even removed all stylistic rules in v9.

## How?

I disabled all styling rules inside the `admin-sdk-plugin` package.

## Testing?

If the pipeline passes then everything works as expected.
