### PR TITLE
fix: Deprecated popover

### DIFF
--- a/.changeset/pretty-drinks-check.md
+++ b/.changeset/pretty-drinks-check.md
@@ -1,0 +1,6 @@
+---
+"@shopware-ag/meteor-component-library": patch
+---
+
+Fix mt-popover-deprecated
+- Previously the `mt-popover-deprecated` component was configured to have the name `MtPopover`. This caused issues with some compiler setups. Change the name to `MtPopoverDeprecated`.

--- a/packages/component-library/src/components/_internal/mt-popover-deprecated/mt-popover-deprecated.vue
+++ b/packages/component-library/src/components/_internal/mt-popover-deprecated/mt-popover-deprecated.vue
@@ -20,7 +20,7 @@ import MtPopoverDirective from "../../../directives/popover.directive";
  * @deprecated - Use `mt-floating-ui` instead
  */
 export default defineComponent({
-  name: "MtPopover",
+  name: "MtPopoverDeprecated",
 
   directives: {
     popover: MtPopoverDirective,


### PR DESCRIPTION
- Previously the `mt-popover-deprecated` component was configured to have the name `MtPopover`. This caused issues with some compiler setups. Change the name to `MtPopoverDeprecated`.