### PR TITLE
Add placeholder to colorpicker

### DIFF
--- a/.changeset/fifty-pugs-beam.md
+++ b/.changeset/fifty-pugs-beam.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": patch
+---
+
+Add missing placeholder to mt-colorpicker

--- a/.changeset/old-chicken-bathe.md
+++ b/.changeset/old-chicken-bathe.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": patch
+---
+
+Focus colorpicker when clicking on its label

--- a/packages/component-library/src/components/form/mt-colorpicker/mt-colorpicker.interactive.stories.ts
+++ b/packages/component-library/src/components/form/mt-colorpicker/mt-colorpicker.interactive.stories.ts
@@ -221,9 +221,9 @@ export const ResetsColorInApplyMode: MtColorpickerStory = {
     fireEvent.input(colorRange, { target: { value: 300 } });
     fireEvent.input(alphaRange, { target: { value: 0.5 } });
 
-    const colorpickerInputField = canvas.getByLabelText(
-      "colorpicker-color-value",
-    ) as HTMLInputElement;
+    const colorpickerInputField = canvas.getByRole("textbox", {
+      name: args.label,
+    });
 
     // Close popover without applying
     await userEvent.click(colorpickerInputField);
@@ -235,7 +235,7 @@ export const ResetsColorInApplyMode: MtColorpickerStory = {
 
     // Check if the color is resetted
     expect(args.updateModelValue).not.toHaveBeenCalled();
-    expect(colorpickerInputField.value).toEqual("rgba(72, 228, 37, 0.81)");
+    expect(colorpickerInputField).toHaveValue("rgba(72, 228, 37, 0.81)");
   },
 };
 
@@ -317,7 +317,7 @@ export const VisualTestChangeColorpickerOutputHex: MtColorpickerStory = {
     label: "Should output HEX",
     colorOutput: "hex",
   },
-  play: async ({ canvasElement }) => {
+  play: async ({ canvasElement, args }) => {
     const canvas = within(canvasElement);
 
     const pickerToggle = canvas.getByLabelText("colorpicker-toggle");
@@ -333,9 +333,7 @@ export const VisualTestChangeColorpickerOutputHex: MtColorpickerStory = {
     expect(hexInput).toBeDefined();
     expect(hexInput.value).toEqual("#0fcff5");
 
-    const colorValue = canvas.getByLabelText("colorpicker-color-value") as HTMLInputElement;
-    expect(colorValue).toBeDefined();
-    expect(colorValue.value).toEqual("#0fcff5");
+    expect(canvas.getByRole("textbox", { name: args.label })).toHaveValue("#0fcff5");
   },
 };
 
@@ -345,7 +343,7 @@ export const VisualTestChangeColorpickerOutputHsl: MtColorpickerStory = {
     label: "Should output HSL",
     colorOutput: "hsl",
   },
-  play: async ({ canvasElement }) => {
+  play: async ({ canvasElement, args }) => {
     const canvas = within(canvasElement);
 
     const pickerToggle = canvas.getByLabelText("colorpicker-toggle");
@@ -361,9 +359,7 @@ export const VisualTestChangeColorpickerOutputHsl: MtColorpickerStory = {
     expect(hexInput).toBeDefined();
     expect(hexInput.value).toEqual("#0fcff5");
 
-    const colorValue = canvas.getByLabelText("colorpicker-color-value") as HTMLInputElement;
-    expect(colorValue).toBeDefined();
-    expect(colorValue.value).toEqual("hsl(190, 92%, 51%)");
+    expect(canvas.getByRole("textbox", { name: args.label })).toHaveValue("hsl(190, 92%, 51%)");
   },
 };
 
@@ -373,7 +369,7 @@ export const VisualTestChangeColorpickerOutputRgb: MtColorpickerStory = {
     label: "Should output RGB",
     colorOutput: "rgb",
   },
-  play: async ({ canvasElement }) => {
+  play: async ({ canvasElement, args }) => {
     const canvas = within(canvasElement);
 
     const pickerToggle = canvas.getByLabelText("colorpicker-toggle");
@@ -389,9 +385,7 @@ export const VisualTestChangeColorpickerOutputRgb: MtColorpickerStory = {
     expect(hexInput).toBeDefined();
     expect(hexInput.value).toEqual("#0fcff5");
 
-    const colorValue = canvas.getByLabelText("colorpicker-color-value") as HTMLInputElement;
-    expect(colorValue).toBeDefined();
-    expect(colorValue.value).toEqual("rgb(15, 207, 245)");
+    expect(canvas.getByRole("textbox", { name: args.label })).toHaveValue("rgb(15, 207, 245)");
   },
 };
 
@@ -402,7 +396,7 @@ export const VisualTestChangeColorpickerOutputHexAlpha: MtColorpickerStory = {
     label: "Should output HEX",
     colorOutput: "hex",
   },
-  play: async ({ canvasElement }) => {
+  play: async ({ canvasElement, args }) => {
     const canvas = within(canvasElement);
 
     const pickerToggle = canvas.getByLabelText("colorpicker-toggle");
@@ -418,9 +412,7 @@ export const VisualTestChangeColorpickerOutputHexAlpha: MtColorpickerStory = {
     expect(hexInput).toBeDefined();
     expect(hexInput.value).toEqual("#0fcff582");
 
-    const colorValue = canvas.getByLabelText("colorpicker-color-value") as HTMLInputElement;
-    expect(colorValue).toBeDefined();
-    expect(colorValue.value).toEqual("#0fcff582");
+    expect(canvas.getByRole("textbox", { name: args.label })).toHaveValue("#0fcff582");
   },
 };
 
@@ -431,7 +423,7 @@ export const VisualTestChangeColorpickerOutputHslAlpha: MtColorpickerStory = {
     label: "Should output HSL",
     colorOutput: "hsl",
   },
-  play: async ({ canvasElement }) => {
+  play: async ({ canvasElement, args }) => {
     const canvas = within(canvasElement);
 
     const pickerToggle = canvas.getByLabelText("colorpicker-toggle");
@@ -447,9 +439,9 @@ export const VisualTestChangeColorpickerOutputHslAlpha: MtColorpickerStory = {
     expect(hexInput).toBeDefined();
     expect(hexInput.value).toEqual("#0fcff582");
 
-    const colorValue = canvas.getByLabelText("colorpicker-color-value") as HTMLInputElement;
-    expect(colorValue).toBeDefined();
-    expect(colorValue.value).toEqual("hsla(190, 92%, 51%, 0.51)");
+    expect(canvas.getByRole("textbox", { name: args.label })).toHaveValue(
+      "hsla(190, 92%, 51%, 0.51)",
+    );
   },
 };
 
@@ -460,7 +452,7 @@ export const VisualTestChangeColorpickerOutputRgbAlpha: MtColorpickerStory = {
     modelValue: "#0fcff582",
     colorOutput: "rgb",
   },
-  play: async ({ canvasElement }) => {
+  play: async ({ canvasElement, args }) => {
     const canvas = within(canvasElement);
 
     const pickerToggle = canvas.getByLabelText("colorpicker-toggle");
@@ -476,9 +468,9 @@ export const VisualTestChangeColorpickerOutputRgbAlpha: MtColorpickerStory = {
     expect(hexInput).toBeDefined();
     expect(hexInput.value).toEqual("#0fcff582");
 
-    const colorValue = canvas.getByLabelText("colorpicker-color-value") as HTMLInputElement;
-    expect(colorValue).toBeDefined();
-    expect(colorValue.value).toEqual("rgba(15, 207, 245, 0.51)");
+    expect(canvas.getByRole("textbox", { name: args.label })).toHaveValue(
+      "rgba(15, 207, 245, 0.51)",
+    );
   },
 };
 
@@ -532,13 +524,13 @@ export const VisualTestColorpickerClearValue: MtColorpickerStory = {
   args: {
     label: "Should clear colorpicker value",
   },
-  play: async ({ canvasElement }) => {
+  play: async ({ canvasElement, args }) => {
     const canvas = within(canvasElement);
 
-    const colorValue = canvas.getByLabelText("colorpicker-color-value") as HTMLInputElement;
+    const colorValue = canvas.getByRole("textbox", { name: args.label });
     await userEvent.clear(colorValue);
 
-    expect(colorValue.value).toEqual("");
+    expect(colorValue).toHaveValue("");
   },
 };
 
@@ -551,11 +543,9 @@ export const VisualTestColorpickerReadonly: MtColorpickerStory = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    const colorValue = canvas.getByLabelText("colorpicker-color-value") as HTMLInputElement;
+    expect(canvas.getByRole("textbox")).toHaveAttribute("readonly");
 
-    expect(colorValue).toHaveAttribute("readonly");
-
-    await userEvent.click(colorValue);
+    await userEvent.click(canvas.getByRole("textbox"));
   },
 };
 

--- a/packages/component-library/src/components/form/mt-colorpicker/mt-colorpicker.spec.ts
+++ b/packages/component-library/src/components/form/mt-colorpicker/mt-colorpicker.spec.ts
@@ -1,23 +1,8 @@
-import { mount } from "@vue/test-utils";
 import userEvent from "@testing-library/user-event";
 import MtColorpicker from "./mt-colorpicker.vue";
 import { render, screen } from "@testing-library/vue";
 
-async function createWrapper(customOptions = {}) {
-  return mount(MtColorpicker, {
-    ...customOptions,
-  });
-}
-
 describe("mt-datepicker", () => {
-  let wrapper: undefined | Awaited<ReturnType<typeof createWrapper>>;
-
-  afterEach(() => {
-    if (wrapper) {
-      wrapper.unmount();
-    }
-  });
-
   it("opens with keyboard", async () => {
     // ARRANGE
     render(MtColorpicker, {

--- a/packages/component-library/src/components/form/mt-colorpicker/mt-colorpicker.spec.ts
+++ b/packages/component-library/src/components/form/mt-colorpicker/mt-colorpicker.spec.ts
@@ -8,7 +8,7 @@ async function createWrapper(customOptions = {}) {
   });
 }
 
-describe("src/app/component/form/mt-datepicker", () => {
+describe("mt-datepicker", () => {
   let wrapper: undefined | Awaited<ReturnType<typeof createWrapper>>;
 
   afterEach(() => {

--- a/packages/component-library/src/components/form/mt-colorpicker/mt-colorpicker.spec.ts
+++ b/packages/component-library/src/components/form/mt-colorpicker/mt-colorpicker.spec.ts
@@ -1,6 +1,7 @@
 import { mount } from "@vue/test-utils";
 import userEvent from "@testing-library/user-event";
 import MtColorpicker from "./mt-colorpicker.vue";
+import { render, screen } from "@testing-library/vue";
 
 async function createWrapper(customOptions = {}) {
   return mount(MtColorpicker, {
@@ -18,25 +19,21 @@ describe("mt-datepicker", () => {
   });
 
   it("opens with keyboard", async () => {
-    const user = userEvent.setup();
-    wrapper = await createWrapper({
+    // ARRANGE
+    render(MtColorpicker, {
       props: {
         modelValue: "#0fcff5",
       },
-      attachTo: document.body,
     });
 
-    // Simulate tabbing to focus the input element
+    const user = userEvent.setup();
+
+    // ACT
     await user.tab();
-    const colorPickerInput = wrapper.find(".mt-colorpicker__input");
-    const inputElement = colorPickerInput.element as HTMLInputElement;
-
-    expect(inputElement).toHaveFocus();
-
-    // Simulate pressing Enter to open modal
     await user.keyboard("{Enter}");
-    const dropdown = document.querySelector(".mt-floating-ui__content");
-    expect(dropdown).toBeDefined();
+
+    // ACT
+    expect(screen.getByTestId("mt-colorpicker-dialog")).toBeVisible();
   });
 
   it("allows value changes with keyboard", async () => {

--- a/packages/component-library/src/components/form/mt-colorpicker/mt-colorpicker.spec.ts
+++ b/packages/component-library/src/components/form/mt-colorpicker/mt-colorpicker.spec.ts
@@ -50,28 +50,26 @@ describe("mt-datepicker", () => {
   });
 
   it("allows value changes with keyboard", async () => {
-    const user = userEvent.setup();
-    wrapper = await createWrapper({
+    // ARRANGE
+    render(MtColorpicker, {
       props: {
+        label: "Some label",
         modelValue: "#0fcff5",
       },
-      attachTo: document.body,
     });
 
-    // Simulate tabbing to focus the input element
-    await user.tab();
-    const colorPickerInput = wrapper.find(".mt-colorpicker__input");
-    const inputElement = colorPickerInput.element as HTMLInputElement;
+    const user = userEvent.setup();
 
-    // Simulate pressing Enter to open modal
+    // ACT
+    await user.tab();
     await user.keyboard("{Enter}");
 
     // Focus color slider
     await userEvent.keyboard("{Tab}");
 
     // Change value with arrow key
-    await userEvent.keyboard("{arrowleft}");
+    await userEvent.keyboard("{Arrowleft}");
 
-    expect(inputElement.value).toBe("#10cef4");
+    expect(screen.getByRole("textbox", { name: "Some label" })).toHaveValue("#10cef4");
   });
 });

--- a/packages/component-library/src/components/form/mt-colorpicker/mt-colorpicker.spec.ts
+++ b/packages/component-library/src/components/form/mt-colorpicker/mt-colorpicker.spec.ts
@@ -34,6 +34,21 @@ describe("mt-datepicker", () => {
     expect(screen.getByTestId("mt-colorpicker-dialog")).toBeVisible();
   });
 
+  it("focuses the input when clicking on the label", async () => {
+    // ARRANGE
+    render(MtColorpicker, {
+      props: {
+        label: "Some label",
+      },
+    });
+
+    // ACT
+    await userEvent.click(screen.getByText("Some label"));
+
+    // ASSERT
+    expect(screen.getByRole("textbox")).toHaveFocus();
+  });
+
   it("allows value changes with keyboard", async () => {
     const user = userEvent.setup();
     wrapper = await createWrapper({

--- a/packages/component-library/src/components/form/mt-colorpicker/mt-colorpicker.spec.ts
+++ b/packages/component-library/src/components/form/mt-colorpicker/mt-colorpicker.spec.ts
@@ -26,11 +26,9 @@ describe("mt-datepicker", () => {
       },
     });
 
-    const user = userEvent.setup();
-
     // ACT
-    await user.tab();
-    await user.keyboard("{Enter}");
+    await userEvent.tab();
+    await userEvent.keyboard("{Enter}");
 
     // ACT
     expect(screen.getByTestId("mt-colorpicker-dialog")).toBeVisible();

--- a/packages/component-library/src/components/form/mt-colorpicker/mt-colorpicker.spec.ts
+++ b/packages/component-library/src/components/form/mt-colorpicker/mt-colorpicker.spec.ts
@@ -57,4 +57,16 @@ describe("mt-datepicker", () => {
 
     expect(screen.getByRole("textbox", { name: "Some label" })).toHaveValue("#10cef4");
   });
+
+  it("has a placeholder", async () => {
+    // ARRANGE
+    render(MtColorpicker, {
+      props: {
+        placeholder: "Some placeholder",
+      },
+    });
+
+    // ASSERT
+    expect(screen.getByRole("textbox")).toHaveAttribute("placeholder", "Some placeholder");
+  });
 });

--- a/packages/component-library/src/components/form/mt-colorpicker/mt-colorpicker.vue
+++ b/packages/component-library/src/components/form/mt-colorpicker/mt-colorpicker.vue
@@ -31,12 +31,13 @@
       </div>
     </template>
 
-    <template #element>
+    <template #element="{ identification }">
       <input
         v-model="colorValue"
         aria-label="colorpicker-color-value"
         class="mt-colorpicker__input"
         :spellcheck="false"
+        :id="identification"
         :disabled="disabled"
         :readonly="readonly"
         @click="onClickInput"

--- a/packages/component-library/src/components/form/mt-colorpicker/mt-colorpicker.vue
+++ b/packages/component-library/src/components/form/mt-colorpicker/mt-colorpicker.vue
@@ -34,7 +34,6 @@
     <template #element="{ identification }">
       <input
         v-model="colorValue"
-        aria-label="colorpicker-color-value"
         class="mt-colorpicker__input"
         :spellcheck="false"
         :id="identification"

--- a/packages/component-library/src/components/form/mt-colorpicker/mt-colorpicker.vue
+++ b/packages/component-library/src/components/form/mt-colorpicker/mt-colorpicker.vue
@@ -1561,7 +1561,8 @@ export default defineComponent({
       height: 150px;
       border: 1px solid var(--color-border-primary-default);
       border-radius: var(--border-radius-xs);
-      background-image: linear-gradient(180deg, #fff, rgba(255, 255, 255, 0) 50%),
+      background-image:
+        linear-gradient(180deg, #fff, rgba(255, 255, 255, 0) 50%),
         linear-gradient(0deg, #000, rgba(0, 0, 0, 0) 50%),
         linear-gradient(90deg, #808080, rgba(128, 128, 128, 0) 100%);
     }

--- a/packages/component-library/src/components/form/mt-colorpicker/mt-colorpicker.vue
+++ b/packages/component-library/src/components/form/mt-colorpicker/mt-colorpicker.vue
@@ -37,6 +37,7 @@
         class="mt-colorpicker__input"
         :spellcheck="false"
         :id="identification"
+        :placeholder="placeholder"
         :disabled="disabled"
         :readonly="readonly"
         @click="onClickInput"
@@ -342,6 +343,11 @@ export default defineComponent({
       type: Boolean,
       required: false,
       default: false,
+    },
+
+    placeholder: {
+      type: String,
+      required: false,
     },
 
     /**

--- a/packages/component-library/src/components/form/mt-colorpicker/mt-colorpicker.vue
+++ b/packages/component-library/src/components/form/mt-colorpicker/mt-colorpicker.vue
@@ -52,7 +52,12 @@
         :z-index="zIndex"
         :offset="-12"
       >
-        <div class="mt-colorpicker__colorpicker" ref="modal" @keyup.escape="outsideClick">
+        <div
+          class="mt-colorpicker__colorpicker"
+          data-testid="mt-colorpicker-dialog"
+          ref="modal"
+          @keyup.escape="outsideClick"
+        >
           <div
             ref="colorPicker"
             class="mt-colorpicker__colorpicker-selection"
@@ -1550,8 +1555,7 @@ export default defineComponent({
       height: 150px;
       border: 1px solid var(--color-border-primary-default);
       border-radius: var(--border-radius-xs);
-      background-image:
-        linear-gradient(180deg, #fff, rgba(255, 255, 255, 0) 50%),
+      background-image: linear-gradient(180deg, #fff, rgba(255, 255, 255, 0) 50%),
         linear-gradient(0deg, #000, rgba(0, 0, 0, 0) 50%),
         linear-gradient(90deg, #808080, rgba(128, 128, 128, 0) 100%);
     }


### PR DESCRIPTION
## What?

I added a placeholder prop to the `mt-colorpicker` component.

## Why?

Every input field can have a placeholder text. The same should be true for the colorpicker.

## How?

Before adding the feature I wrote a failing test. I then added the placeholder.

## Testing?

I've written a test to make sure the input field has the correct placeholder.

## Anything Else?

* I also added a missing link between the label and the input field. Now, when the user clicks on the label of the color picker the browser will focus the input field