### PR TITLE
docs(tokens): remove early development warning for token package

### DIFF
--- a/.changeset/late-dots-shop.md
+++ b/.changeset/late-dots-shop.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-tokens": major
+---
+
+Mark tokens as stable

--- a/packages/tokens/README.md
+++ b/packages/tokens/README.md
@@ -1,9 +1,5 @@
 This repository contains the Design Tokens for the Meteor Design System at shopware.
 
-> ⚠️ This package is still in early development. It's possible that we release breaking
-> changes in minor or patch version. Once the package is stable we'll release a 1.0.0
-> version and conform to the semver versioning.
-
 ## Installation
 
 ```sh


### PR DESCRIPTION
## What?

I removed the early development warning for the token package.

## Why?

We now use it for a while and it's pretty stable.

## How?

I updated the `README.md` file
