### PR TITLE
feat(component-library): make mt-url-field component public

### DIFF
--- a/.changeset/pink-planets-taste.md
+++ b/.changeset/pink-planets-taste.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": minor
+---
+
+Make mt-url-field public

--- a/packages/component-library/src/index.ts
+++ b/packages/component-library/src/index.ts
@@ -40,6 +40,7 @@ import MtTooltip from "./components/overlay/mt-tooltip/mt-tooltip.vue";
 import MtTextEditor from "./components/form/mt-text-editor/mt-text-editor.vue";
 import MtTextEditorToolbarButton from "./components/form/mt-text-editor/_internal/mt-text-editor-toolbar-button.vue";
 import MtSearch from "./components/navigation/mt-search/mt-search.vue";
+import MtUrlField from "./components/form/mt-url-field/mt-url-field.vue";
 
 // Import SCSS for styling
 import "./components/assets/scss/all.scss";
@@ -90,6 +91,7 @@ export {
   MtText,
   MtInset,
   MtSearch,
+  MtUrlField,
   MtThemeProvider,
   TooltipDirective,
   DeviceHelperPlugin,


### PR DESCRIPTION
## What?

Made the `mt-url-field` component public, which is not exported by default currently.