### PR TITLE
Improve text component

### DIFF
--- a/.changeset/smart-poems-remember.md
+++ b/.changeset/smart-poems-remember.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": patch
+---
+
+Add auto-completion for color prop of mt-text component

--- a/packages/component-library/src/components/content/mt-text/mt-text.spec.ts
+++ b/packages/component-library/src/components/content/mt-text/mt-text.spec.ts
@@ -1,0 +1,34 @@
+import { render, screen } from "@testing-library/vue";
+import { describe, it, expect } from "vitest";
+import MtText from "./mt-text.vue";
+
+describe("mt-text", () => {
+  it("renders a paragraph", async () => {
+    // ARRANGE
+    render(MtText, {
+      slots: {
+        default: "Hello, world!",
+      },
+    });
+
+    // ASSERT
+    expect(screen.getByText("Hello, world!")).toBeVisible();
+    expect(screen.getByText("Hello, world!").tagName).toBe("P");
+  });
+
+  it("renders as a span", () => {
+    // ARRANGE
+    render(MtText, {
+      props: {
+        as: "span",
+      },
+      slots: {
+        default: "Hello, world!",
+      },
+    });
+
+    // ASSERT
+    expect(screen.getByText("Hello, world!")).toBeVisible();
+    expect(screen.getByText("Hello, world!").tagName).toBe("SPAN");
+  });
+});

--- a/packages/component-library/src/components/content/mt-text/mt-text.vue
+++ b/packages/component-library/src/components/content/mt-text/mt-text.vue
@@ -1,6 +1,6 @@
 <template>
   <component
-    :is="as ?? 'p'"
+    :is="as"
     :class="[`mt-text--size-${size}`, `mt-text--weight-${weight}`]"
     :style="{ color: `var(--${color})` }"
   >
@@ -22,6 +22,7 @@ withDefaults(
     size: "s",
     weight: "regular",
     color: "color-text-primary-default",
+    as: "p",
   },
 );
 </script>

--- a/packages/component-library/src/components/content/mt-text/mt-text.vue
+++ b/packages/component-library/src/components/content/mt-text/mt-text.vue
@@ -9,29 +9,21 @@
 </template>
 
 <script setup lang="ts">
-import type { Component, PropType } from "vue";
+import type { Component } from "vue";
 
-defineProps({
-  size: {
-    type: String as PropType<"2xs" | "xs" | "s" | "m" | "l" | "xl" | "2xl" | "3xl">,
-    required: false,
-    default: "s",
+withDefaults(
+  defineProps<{
+    size?: "2xs" | "xs" | "s" | "m" | "l" | "xl" | "2xl" | "3xl";
+    weight?: "bold" | "semibold" | "medium" | "regular";
+    color?: string;
+    as?: string | Component;
+  }>(),
+  {
+    size: "s",
+    weight: "regular",
+    color: "color-text-primary-default",
   },
-  weight: {
-    type: String as PropType<"bold" | "semibold" | "medium" | "regular">,
-    required: false,
-    default: "regular",
-  },
-  color: {
-    type: String,
-    required: false,
-    default: "color-text-primary-default",
-  },
-  as: {
-    type: String as PropType<string | Component>,
-    required: false,
-  },
-});
+);
 </script>
 
 <style scoped>

--- a/packages/component-library/src/components/content/mt-text/mt-text.vue
+++ b/packages/component-library/src/components/content/mt-text/mt-text.vue
@@ -15,7 +15,23 @@ withDefaults(
   defineProps<{
     size?: "2xs" | "xs" | "s" | "m" | "l" | "xl" | "2xl" | "3xl";
     weight?: "bold" | "semibold" | "medium" | "regular";
-    color?: string;
+    color?:
+      | "color-text-primary-default"
+      | "color-text-primary-disabled"
+      | "color-text-secondary-default"
+      | "color-text-tertiary-default"
+      | "color-text-brand-default"
+      | "color-text-brand-hover"
+      | "color-text-brand-disabled"
+      | "color-text-critical-default"
+      | "color-text-critical-disabled"
+      | "color-text-critical-dark"
+      | "color-text-attention-default"
+      | "color-text-positive-default"
+      | "color-text-accent-default"
+      | "color-text-static-default"
+      | "color-text-inverse-default"
+      | string;
     as?: string | Component;
   }>(),
   {


### PR DESCRIPTION
## What?

I added some auto-completion for the `mt-text` component.

## Why?

Makes it easier for people to use the text component.

## How?

I updated the types to include the literal types for the color tokens.

## Testing?

Use the `mt-text` component and set a value of the `color` prop. If you get autocompletion, then everything works as expected.


