### PR TITLE
build(component-library): forbid using @vue/test-utils

### DIFF
--- a/packages/component-library/eslint.config.mjs
+++ b/packages/component-library/eslint.config.mjs
@@ -22,7 +22,7 @@ export default defineConfigWithVueTs([
     ],
   },
   {
-    files: ["**src/**/*.js", "**src/**/*.ts"],
+    files: ["**/src/**/*.{ts,js}"],
     languageOptions: {
       globals: globals.browser,
     },
@@ -47,8 +47,11 @@ export default defineConfigWithVueTs([
   },
   ...storybook.configs["flat/recommended"],
   {
-    files: ["**.spec.ts", "**.spec.js"],
+    files: ["**/*.spec.{ts,js}"],
     plugins: { vitest },
-    rules: vitest.configs.recommended.rules,
+    rules: {
+      ...vitest.configs.recommended.rules,
+      "no-restricted-imports": ["warn", "@vue/test-utils"],
+    },
   },
 ]);

--- a/packages/component-library/src/components/context-menu/mt-context-menu.spec.ts
+++ b/packages/component-library/src/components/context-menu/mt-context-menu.spec.ts
@@ -2,7 +2,7 @@ import { userEvent } from "@testing-library/user-event";
 import { render, screen } from "@testing-library/vue";
 import MtContextButton from "./mt-context-button/mt-context-button.vue";
 
-describe("mt-context-menu", async () => {
+describe("mt-context-menu", () => {
   it("is possible to focus the button that opens the context menu", async () => {
     // ARRANGE
     render(MtContextButton);

--- a/packages/component-library/src/components/form/mt-button/mt-button.spec.ts
+++ b/packages/component-library/src/components/form/mt-button/mt-button.spec.ts
@@ -187,7 +187,7 @@ describe("mt-button", () => {
     expect(screen.getByRole("link")).toHaveAttribute("href", "");
   });
 
-  it("is not possible to focus a disabled link button", async () => {
+  it("is not possible to focus a loading link button", async () => {
     // ARRANGE
     render(MtButton, {
       props: {

--- a/packages/component-library/src/components/form/mt-email-field/mt-email-field.spec.ts
+++ b/packages/component-library/src/components/form/mt-email-field/mt-email-field.spec.ts
@@ -437,7 +437,7 @@ describe("mt-email-field", () => {
     expect(screen.getByRole("textbox")).toHaveValue("");
   });
 
-  it("it is possible to edit the value when the inheritance is unlinked", async () => {
+  it("is possible to edit the value when the inheritance is unlinked", async () => {
     // ARRANGE
     const handler = vi.fn();
 

--- a/packages/component-library/src/components/form/mt-textarea/mt-textarea.spec.ts
+++ b/packages/component-library/src/components/form/mt-textarea/mt-textarea.spec.ts
@@ -3,7 +3,7 @@ import { render, screen } from "@testing-library/vue";
 import { expect, describe, it, vi } from "vitest";
 import MtTextarea from "./mt-textarea.vue";
 
-describe("mt-textarea", async () => {
+describe("mt-textarea", () => {
   it("focuses the text area when clicking on the label", async () => {
     // ARRANGE
     render(MtTextarea, {

--- a/packages/component-library/src/components/form/mt-url-field/mt-url-field.spec.ts
+++ b/packages/component-library/src/components/form/mt-url-field/mt-url-field.spec.ts
@@ -3,7 +3,7 @@ import MtUrlField from "./mt-url-field.vue";
 import { render, screen } from "@testing-library/vue";
 import userEvent from "@testing-library/user-event";
 
-describe("mt-url-field", async () => {
+describe("mt-url-field", () => {
   it("hides the protcol in the input when re-rendering", async () => {
     // ARRANGE
     const { rerender } = render(MtUrlField, {
@@ -286,26 +286,6 @@ describe("mt-url-field", async () => {
 
     // ASSERT
     expect(screen.getByRole("button")).toHaveTextContent("https://");
-  });
-
-  it("updates the domain when the user types and then focuses another element", async () => {
-    // ARRANGE
-    const handler = vi.fn();
-
-    render(MtUrlField, {
-      props: {
-        modelValue: "",
-        onChange: handler,
-      },
-    });
-
-    // ACT
-    await userEvent.type(screen.getByRole("textbox"), "www.shopware.com");
-    await userEvent.tab();
-
-    // ASSERT
-    expect(handler).toHaveBeenCalledOnce();
-    expect(handler).toHaveBeenCalledWith("www.shopware.com");
   });
 
   it("emits an inheritance-remove event when linking the inheritance", async () => {

--- a/packages/component-library/src/components/navigation/mt-link/mt-link.spec.ts
+++ b/packages/component-library/src/components/navigation/mt-link/mt-link.spec.ts
@@ -2,7 +2,7 @@ import { render, screen } from "@testing-library/vue";
 import MtLink from "./mt-link.vue";
 import { userEvent } from "@testing-library/user-event";
 
-describe("mt-link", async () => {
+describe("mt-link", () => {
   it("renders a link", async () => {
     // ARRANGE
     render(MtLink, {


### PR DESCRIPTION
## What?

Adding a linting rule to warn developers about using the Vue test utils

## Why?

The vue test utils make it very easy to test implementation details. Testing implementation details slows down development massively.

Instead of using the Vue test utils, use the Vue testing library. It's designed to encourage writing tests that speed up development instead of slowing it down.

## How?

I added a linting rule to warn user about not using the Vue Test Utils. I decided not to set the level to `error`, because then we would need to migrate all tests at once.