### PR TITLE
docs: Add minimum shopware version for ui.menu.collapseMenu

### DIFF
--- a/docs/admin-sdk/docs/guide/2_api-reference/ui/menu.md
+++ b/docs/admin-sdk/docs/guide/2_api-reference/ui/menu.md
@@ -2,6 +2,8 @@
 
 ### Toggle menu
 
+> Available since Shopware v6.6.2.0
+
 The Admin SDK allows you to manipulate the Admin menu of your application. One of the features it provides is the ability to toggle the Admin menu. This is done using the `collapseMenu` and `expandMenu` methods.
 
 #### Usage:


### PR DESCRIPTION
## What?

Added minimum Shopware version to `ui.menu.collapseMenu` and `ui.menu.expandMenu`

## Why?

The operation is not available since the first release of the SDK