### PR TITLE
allow setting a margin on an mt-button component

### DIFF
--- a/.changeset/green-onions-accept.md
+++ b/.changeset/green-onions-accept.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": patch
+---
+
+Allow setting a margin on an `mt-button` component

--- a/packages/component-library/src/components/form/mt-button/mt-button.vue
+++ b/packages/component-library/src/components/form/mt-button/mt-button.vue
@@ -101,7 +101,6 @@ const isInsideTooltip = useIsInsideTooltip();
   text-decoration: none;
   cursor: pointer;
   user-select: none;
-  margin: 0;
   position: relative;
 }
 

--- a/packages/icon-kit/tsconfig.json
+++ b/packages/icon-kit/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "module": "ES2022",
+    "skipLibCheck": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "target": "es6",


### PR DESCRIPTION
## What?

This PR allows developers to position their buttons.

## Why?

It does not make sense to remove the margin of a button, because by default it does not have any.

It also causes issues when developers want to layout their buttons using margin.


## How?

I just removed the `margin: 0` declaration from the `mt-button` class.