### PR TITLE
ci: group tiptap packages when updating dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,7 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    groups:
+      tiptap: # Group all tiptap packages into a single PR
+        patterns:
+          - "@tiptap/*" # All official tiptap packages


### PR DESCRIPTION
## What?

Configure dependabot to upgrade all Tiptap packages at once.

## Why?

When the tiptap team releases a new version all packages have the same version number. Grouping all packages to the same version makes it much easier for us to update tiptap packages.

## How?

Dependabot now upgrades all official Tiptap packages in on single PR, instead of each package in a separate PR.

## Testing?

The only way to test that is to merge this PR and see if it really works.
