### PR TITLE
feat: add compare Shopware Version logic directly in the SDK

### DIFF
--- a/.changeset/little-moose-accept.md
+++ b/.changeset/little-moose-accept.md
@@ -1,0 +1,6 @@
+---
+"@shopware-ag/meteor-admin-sdk": minor
+---
+
+- Changed name of `context.compareShopwareVersion` to `context.compareIsShopwareVersion` 
+- Changed order of parameters of `context.compareIsShopwareVersion`

--- a/docs/admin-sdk/docs/guide/2_api-reference/context.md
+++ b/docs/admin-sdk/docs/guide/2_api-reference/context.md
@@ -188,22 +188,31 @@ string
 '6.4.0.0'
 ```
 
-
-## Shopware compare version
-
 ### Compare current Shopware version with a given version
+
+In many cases you have to make sure that the shop you are communicating with has a certain Shopware version. For this purpose the Meteor Admin SDK provides the `context.compareIsShopwareVersion` function.
+
+The function always treats the current Shopware version of a shop as the left hand operator of the comparison. That means a call like `context.compareIsShopwareVersion('>=', '7.0.0')` can be read as "*Compare: is Shopware version equal or greater than 7.0.0*"
 
 #### Usage:  
 ```ts
-const isRightVersion = await sw.context.compareShopwareVersion({version:'6.4.0', comparator: '>='})
+const isRightVersion = await sw.context.compareShopwareVersion('>=', '7.0.0')
 ```
 
 #### Parameters
 | Name         | Description                                                                                                       |
 |:-------------|:------------------------------------------------------------------------------------------------------------------|
-| `version`    | The string with the version to compare                                                                            |
-| `comparator` | The operator to compare. Possible values: `'='` `'>'` `'<'` `'<='` `'>='`<br/> If not provided `'='` will be used |
+| `comparator` | The operator to compare. Possible values: `'='` `'!='` `'>'` `'<'` `'<='` `'>='`|
+| `version`    | The string with the version to compare
 
+
+The function supports both, Shopware's four-digit version number and semver versions. The following calls are equivalent:
+
+```ts
+await sw.context.compareShopwareVersion('>=', '6.6.4.0');
+
+await sw.context.compareShopwareVersion('>=', '6.4.0');
+```
 
 #### Return value:
 

--- a/packages/admin-sdk/package.json
+++ b/packages/admin-sdk/package.json
@@ -88,6 +88,7 @@
   "dependencies": {
     "localforage": "^1.10.0",
     "lodash": "^4.17.21",
+    "semver": "^7.7.1",
     "@shopware-ag/meteor-component-library": "workspace:*"
   },
   "devDependencies": {

--- a/packages/admin-sdk/src/context/compare-version.spec.ts
+++ b/packages/admin-sdk/src/context/compare-version.spec.ts
@@ -1,113 +1,67 @@
-import getCompareShopwareVersion from './compare-version';
+import getCompareIsShopwareVersion from './compare-version';
+
+type Comparator = '=' | '!=' | '<' | '>' | '<=' | '>=';
 
 describe('getCompareShopwareVersion', () => {
   const mock = (version: string) => () => Promise.resolve(version);
 
-  it(`should return true for equal versions with '=' comparator`, async () => {
-    expect(
-      await getCompareShopwareVersion(mock('1.0.0.0'))('1.0.0.0', '=')
-    ).toBe(true);
+  describe('It works with shopware versions and semver versions', () => {
+    it.each<[boolean, string, Comparator, string]>([
+      [true, '6.6.8.2', '=', '6.6.8.2'],
+      [true, '6.6.8.2', '=', '6.8.2'],
+      [true, '6.8.2', '=', '6.6.8.2'],
+      [true, '6.8.2', '=', '6.8.2'],
+  
+      [false, '6.6.8.2', '=', '6.6.9.2'],
+      [false, '6.6.8.2', '=', '6.9.2'],
+      [false, '6.8.2', '=', '6.6.9.2'],
+      [false, '6.8.2', '=', '6.9.2'],
+    ])("returns %s for '%s %s %s'", async (exptectedResult, shopwareVersion, comparator, comparedVersion) => {
+      const compareIsShopwareVersion = getCompareIsShopwareVersion(mock(shopwareVersion));
+
+      expect(await compareIsShopwareVersion(comparator, comparedVersion)).toBe(exptectedResult)
+    });
   });
 
-  it(`should return false for different versions with '=' comparator`, async () => {
-    expect(await getCompareShopwareVersion(mock('1.0.0.0'))('1.0.0.1', '=')).toBe(
-      false
-    );
-  });
+  describe('It works like semver package', () => {
+    it.each<[boolean, string, Comparator, string]>([
+      [true, '6.6.8.2', '=', '6.6.8.2'],
+      [false, '6.6.8.2', '=', '6.6.9.2'],
+    
+      [true, '6.6.8.2', '!=', '6.7.8.2'],
+      [false, '6.6.8.2', '!=', '6.6.8.2'],
+  
+      [true, '6.6.8.2', '>', '6.6.7.2'],
+      [false, '6.6.8.2', '>', '6.6.8.2'],
+      [false, '6.6.8.2', '>', '6.6.9.2'],
+  
+      [true, '6.6.8.2', '<', '6.6.9.2'],
+      [false, '6.6.8.2', '<', '6.6.8.2'],
+      [false, '6.6.8.2', '<', '6.6.7.2'],
+  
+      [true, '6.6.8.2', '>=', '6.6.8.2'],
+      [true, '6.6.8.2', '>=', '6.6.7.2'],
+      [false, '6.6.8.2', '>=', '6.6.9.2'],
+  
+      [true, '6.6.8.2', '<=', '6.6.8.2'],
+      [true, '6.6.8.2', '<=', '6.6.9.2'],
+      [false, '6.6.8.2', '<=', '6.6.6.2'],
 
-  it(`should return false for equal versions with '!=' comparator`, async () => {
-    expect(
-      await getCompareShopwareVersion(mock('1.0.0.0'))('1.0.0.0', '!=')
-    ).toBe(false);
-  });
+      [true, '6.7.0.0-rc-1', '<', '6.7.0.0'],
+      [true, '6.7.0.0', '>', '6.7.0.0-rc-1'],
 
-  it(`should return false for different versions with '=' comparator`, async () => {
-    expect(await getCompareShopwareVersion(mock('1.0.0.0'))('1.0.0.1', '!=')).toBe(
-      true
-    );
-  });
+      [true, '6.7.0.0-rc-1', '<', '6.7.0.0-rc-2'],
+      [true, '6.7.0.0-rc-2', '>', '6.7.0.0-rc-1'],
+      [true, '6.7.0.0-rc-2', '<', '6.7.0.0-rc-3'],
+      [true, '6.7.0.0-rc-3', '>', '6.7.0.0-rc-2'],
 
-  it(`should return true for greater version with '>' comparator`, async () => {
-    expect(await getCompareShopwareVersion(mock('1.0.0.0'))('1.0.0.1', '>')).toBe(
-      true
-    );
-  });
+      [true, '6.7.0.0-alpha', '=', '6.7.0.0-alpha'],
+      [true, '6.7.0.0-alpha', '<', '6.7.0.0-beta'],
+      [true, '6.7.0.0-beta', '>', '6.7.0.0-alpha'],
+    ])("returns %s for '%s %s %s'", async (exptectedResult, shopwareVersion, comparator, comparedVersion) => {
+      const compareIsShopwareVersion = getCompareIsShopwareVersion(mock(shopwareVersion));
 
-  it(`should return false for lesser version with '>' comparator`, async () => {
-    expect(await getCompareShopwareVersion(mock('1.0.0.1'))('1.0.0.0', '>')).toBe(
-      false
-    );
-  });
-
-  it(`should return true for lesser version with '<' comparator`, async () => {
-    expect(await getCompareShopwareVersion(mock('1.0.0.1'))('1.0.0.0', '<')).toBe(
-      true
-    );
-  });
-
-  it(`should return false for greater version with '<' comparator`, async () => {
-    expect(await getCompareShopwareVersion(mock('1.0.0.0'))('1.0.0.1', '<')).toBe(
-      false
-    );
-  });
-
-  it(`should return true for equal or greater version with '>=' comparator`, async () => {
-    expect(
-      await getCompareShopwareVersion(mock('1.0.0.0'))('1.0.0.1', '>=')
-    ).toBe(true);
-    expect(
-      await getCompareShopwareVersion(mock('1.0.0.0'))('1.0.0.0', '>=')
-    ).toBe(true);
-  });
-
-  it(`should return false for lesser version with '>=' comparator`, async () => {
-    expect(
-      await getCompareShopwareVersion(mock('1.0.0.1'))('1.0.0.0', '>=')
-    ).toBe(false);
-  });
-
-  it(`should return true for equal or lesser version with '<=' comparator`, async () => {
-    expect(
-      await getCompareShopwareVersion(mock('1.0.0.1'))('1.0.0.1', '<=')
-    ).toBe(true);
-    expect(
-      await getCompareShopwareVersion(mock('1.0.0.1'))('1.0.0.0', '<=')
-    ).toBe(true);
-  });
-
-  it(`should return false for greater version with '<=' comparator`, async () => {
-    expect(
-      await getCompareShopwareVersion(mock('1.0.0.0'))('1.0.0.1', '<=')
-    ).toBe(false);
-  });
-
-  it(`should handle versions with suffixes correctly`, async () => {
-    expect(
-      await getCompareShopwareVersion(mock('1.0.0.0-beta'))(
-        '1.0.0.0-alpha',
-        '<'
-      )
-    ).toBe(true);
-    expect(
-      await getCompareShopwareVersion(mock('1.0.0.0-alpha'))(
-        '1.0.0.0-beta',
-        '>'
-      )
-    ).toBe(true);
-    expect(
-      await getCompareShopwareVersion(mock('1.0.0.0-alpha'))(
-        '1.0.0.0-alpha',
-        '='
-      )
-    ).toBe(true);
-  });
-
-  it(`should consider versions without suffixes as greater`, async () => {
-    expect(
-      await getCompareShopwareVersion(mock('1.0.0.0'))('1.0.0.0-alpha', '<')
-    ).toBe(true);
-    expect(
-      await getCompareShopwareVersion(mock('1.0.0.0-alpha'))('1.0.0.0', '>')
-    ).toBe(true);
+      expect(await compareIsShopwareVersion(comparator, comparedVersion)).toBe(exptectedResult)
+    });
   });
 });

--- a/packages/admin-sdk/src/context/compare-version.spec.ts
+++ b/packages/admin-sdk/src/context/compare-version.spec.ts
@@ -1,0 +1,113 @@
+import getCompareShopwareVersion from './compare-version';
+
+describe('getCompareShopwareVersion', () => {
+  const mock = (version: string) => () => Promise.resolve(version);
+
+  it(`should return true for equal versions with '=' comparator`, async () => {
+    expect(
+      await getCompareShopwareVersion(mock('1.0.0.0'))('1.0.0.0', '=')
+    ).toBe(true);
+  });
+
+  it(`should return false for different versions with '=' comparator`, async () => {
+    expect(await getCompareShopwareVersion(mock('1.0.0.0'))('1.0.0.1', '=')).toBe(
+      false
+    );
+  });
+
+  it(`should return false for equal versions with '!=' comparator`, async () => {
+    expect(
+      await getCompareShopwareVersion(mock('1.0.0.0'))('1.0.0.0', '!=')
+    ).toBe(false);
+  });
+
+  it(`should return false for different versions with '=' comparator`, async () => {
+    expect(await getCompareShopwareVersion(mock('1.0.0.0'))('1.0.0.1', '!=')).toBe(
+      true
+    );
+  });
+
+  it(`should return true for greater version with '>' comparator`, async () => {
+    expect(await getCompareShopwareVersion(mock('1.0.0.0'))('1.0.0.1', '>')).toBe(
+      true
+    );
+  });
+
+  it(`should return false for lesser version with '>' comparator`, async () => {
+    expect(await getCompareShopwareVersion(mock('1.0.0.1'))('1.0.0.0', '>')).toBe(
+      false
+    );
+  });
+
+  it(`should return true for lesser version with '<' comparator`, async () => {
+    expect(await getCompareShopwareVersion(mock('1.0.0.1'))('1.0.0.0', '<')).toBe(
+      true
+    );
+  });
+
+  it(`should return false for greater version with '<' comparator`, async () => {
+    expect(await getCompareShopwareVersion(mock('1.0.0.0'))('1.0.0.1', '<')).toBe(
+      false
+    );
+  });
+
+  it(`should return true for equal or greater version with '>=' comparator`, async () => {
+    expect(
+      await getCompareShopwareVersion(mock('1.0.0.0'))('1.0.0.1', '>=')
+    ).toBe(true);
+    expect(
+      await getCompareShopwareVersion(mock('1.0.0.0'))('1.0.0.0', '>=')
+    ).toBe(true);
+  });
+
+  it(`should return false for lesser version with '>=' comparator`, async () => {
+    expect(
+      await getCompareShopwareVersion(mock('1.0.0.1'))('1.0.0.0', '>=')
+    ).toBe(false);
+  });
+
+  it(`should return true for equal or lesser version with '<=' comparator`, async () => {
+    expect(
+      await getCompareShopwareVersion(mock('1.0.0.1'))('1.0.0.1', '<=')
+    ).toBe(true);
+    expect(
+      await getCompareShopwareVersion(mock('1.0.0.1'))('1.0.0.0', '<=')
+    ).toBe(true);
+  });
+
+  it(`should return false for greater version with '<=' comparator`, async () => {
+    expect(
+      await getCompareShopwareVersion(mock('1.0.0.0'))('1.0.0.1', '<=')
+    ).toBe(false);
+  });
+
+  it(`should handle versions with suffixes correctly`, async () => {
+    expect(
+      await getCompareShopwareVersion(mock('1.0.0.0-beta'))(
+        '1.0.0.0-alpha',
+        '<'
+      )
+    ).toBe(true);
+    expect(
+      await getCompareShopwareVersion(mock('1.0.0.0-alpha'))(
+        '1.0.0.0-beta',
+        '>'
+      )
+    ).toBe(true);
+    expect(
+      await getCompareShopwareVersion(mock('1.0.0.0-alpha'))(
+        '1.0.0.0-alpha',
+        '='
+      )
+    ).toBe(true);
+  });
+
+  it(`should consider versions without suffixes as greater`, async () => {
+    expect(
+      await getCompareShopwareVersion(mock('1.0.0.0'))('1.0.0.0-alpha', '<')
+    ).toBe(true);
+    expect(
+      await getCompareShopwareVersion(mock('1.0.0.0-alpha'))('1.0.0.0', '>')
+    ).toBe(true);
+  });
+});

--- a/packages/admin-sdk/src/context/compare-version.ts
+++ b/packages/admin-sdk/src/context/compare-version.ts
@@ -1,0 +1,19 @@
+
+import semverCmp from 'semver/functions/cmp';
+
+type Comparator = '=' | '!=' | '<' | '>' | '<=' | '>=';
+
+export default function getCompareShopwareVersion(
+  getShopwareVersion: () => Promise<string>
+) {
+  return async (versionToCompare: string, comparator: Comparator): Promise<boolean> => {
+    const shopwareVersion = await getShopwareVersion();
+    const shopwareSemverVersion = convertToSemver(shopwareVersion);
+    const versionSemverToCompare = convertToSemver(versionToCompare);
+    return semverCmp(versionSemverToCompare, comparator, shopwareSemverVersion);
+  };
+}
+
+function convertToSemver(version: string): string {
+  return version.replace(/^\d\./, '');
+}

--- a/packages/admin-sdk/src/context/compare-version.ts
+++ b/packages/admin-sdk/src/context/compare-version.ts
@@ -1,19 +1,26 @@
 
 import semverCmp from 'semver/functions/cmp';
+import valid from 'semver/functions/valid';
 
 type Comparator = '=' | '!=' | '<' | '>' | '<=' | '>=';
 
-export default function getCompareShopwareVersion(
+export default function getCompareIsShopwareVersion(
   getShopwareVersion: () => Promise<string>
 ) {
-  return async (versionToCompare: string, comparator: Comparator): Promise<boolean> => {
+  return async (comparator: Comparator, versionToCompare: string): Promise<boolean> => {
     const shopwareVersion = await getShopwareVersion();
     const shopwareSemverVersion = convertToSemver(shopwareVersion);
     const versionSemverToCompare = convertToSemver(versionToCompare);
-    return semverCmp(versionSemverToCompare, comparator, shopwareSemverVersion);
+
+    return semverCmp(shopwareSemverVersion, comparator, versionSemverToCompare);
   };
 }
 
 function convertToSemver(version: string): string {
-  return version.replace(/^\d\./, '');
+  // Test if version is a 4 digit shopware version with leading 6.
+  if (!valid(version) && /6\.[\d]+\.[\d]+\.[\d]+/.test(version)) {
+    return version.substring(2);
+  }
+
+  return version;
 }

--- a/packages/admin-sdk/src/context/index.ts
+++ b/packages/admin-sdk/src/context/index.ts
@@ -1,5 +1,5 @@
 import { createSender, createSubscriber } from '../channel';
-import getCompareShopwareVersion from './compare-version';
+import getCompareIsShopwareVersion from './compare-version';
 
 export const getLanguage = createSender('contextLanguage', {});
 export const subscribeLanguage = createSubscriber('contextLanguage');
@@ -8,7 +8,7 @@ export const getLocale = createSender('contextLocale', {});
 export const subscribeLocale = createSubscriber('contextLocale');
 export const getCurrency = createSender('contextCurrency', {});
 export const getShopwareVersion = createSender('contextShopwareVersion', {});
-export const compareShopwareVersion = getCompareShopwareVersion(getShopwareVersion);
+export const compareIsShopwareVersion = getCompareIsShopwareVersion(getShopwareVersion);
 export const getUserInformation = createSender('contextUserInformation', {});
 export const getUserTimezone = createSender('contextUserTimezone', {});
 export const getAppInformation = createSender('contextAppInformation', {});

--- a/packages/admin-sdk/src/context/index.ts
+++ b/packages/admin-sdk/src/context/index.ts
@@ -1,4 +1,5 @@
 import { createSender, createSubscriber } from '../channel';
+import getCompareShopwareVersion from './compare-version';
 
 export const getLanguage = createSender('contextLanguage', {});
 export const subscribeLanguage = createSubscriber('contextLanguage');
@@ -7,7 +8,7 @@ export const getLocale = createSender('contextLocale', {});
 export const subscribeLocale = createSubscriber('contextLocale');
 export const getCurrency = createSender('contextCurrency', {});
 export const getShopwareVersion = createSender('contextShopwareVersion', {});
-export const compareShopwareVersion = createSender('contextCompareShopwareVersion', {});
+export const compareShopwareVersion = getCompareShopwareVersion(getShopwareVersion);
 export const getUserInformation = createSender('contextUserInformation', {});
 export const getUserTimezone = createSender('contextUserTimezone', {});
 export const getAppInformation = createSender('contextAppInformation', {});
@@ -56,14 +57,6 @@ export type contextCurrency = {
 export type contextShopwareVersion = {
   responseType: string,
 }
-/**
- * Get the current Shopware version comparison
- */
-export type contextCompareShopwareVersion = {
-  responseType: boolean,
-  version: string,
-  comparator?: '=' | '>'| '<'|'<=' | '>=',
-};
 
 /**
  * Get the current app information

--- a/packages/admin-sdk/src/message-types.ts
+++ b/packages/admin-sdk/src/message-types.ts
@@ -11,7 +11,6 @@ import type {
   contextModuleInformation,
   contextUserInformation,
   contextUserTimezone,
-  contextCompareShopwareVersion,
 } from './context';
 import type { uiComponentSectionRenderer } from './ui/component-section/index';
 import type { uiTabsAddTabItem } from './ui/tabs';
@@ -57,7 +56,6 @@ export interface ShopwareMessageTypes {
   contextLocale: contextLocale,
   contextCurrency: contextCurrency,
   contextShopwareVersion: contextShopwareVersion,
-  contextCompareShopwareVersion: contextCompareShopwareVersion,
   contextUserInformation: contextUserInformation,
   contextUserTimezone: contextUserTimezone,
   contextAppInformation: contextAppInformation,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,13 +20,13 @@ importers:
     dependencies:
       '@docusaurus/core':
         specifier: ^2.2.0
-        version: 2.4.3(@docusaurus/types@2.4.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(eslint@9.21.0(jiti@1.21.7))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)
+        version: 2.4.3(@docusaurus/types@2.4.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(eslint@9.21.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)
       '@docusaurus/preset-classic':
         specifier: ^2.2.0
-        version: 2.4.3(@algolia/client-search@4.23.3)(@types/react@18.3.3)(encoding@0.1.13)(eslint@9.21.0(jiti@1.21.7))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(search-insights@2.14.0)(typescript@4.9.5)(vue-template-compiler@2.7.16)
+        version: 2.4.3(@algolia/client-search@4.23.3)(@types/react@18.3.3)(encoding@0.1.13)(eslint@9.21.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(search-insights@2.14.0)(typescript@4.9.5)(vue-template-compiler@2.7.16)
       '@docusaurus/theme-search-algolia':
         specifier: ^2.2.0
-        version: 2.4.3(@algolia/client-search@4.23.3)(@docusaurus/types@2.4.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(@types/react@18.3.3)(eslint@9.21.0(jiti@1.21.7))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(search-insights@2.14.0)(typescript@4.9.5)(vue-template-compiler@2.7.16)
+        version: 2.4.3(@algolia/client-search@4.23.3)(@docusaurus/types@2.4.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(@types/react@18.3.3)(eslint@9.21.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(search-insights@2.14.0)(typescript@4.9.5)(vue-template-compiler@2.7.16)
       '@mdx-js/react':
         specifier: ^1.6.21
         version: 1.6.22(react@17.0.2)
@@ -180,7 +180,7 @@ importers:
         version: link:../../packages/component-library
       nuxt:
         specifier: ^3.10.3
-        version: 3.12.2(@opentelemetry/api@1.9.0)(@parcel/watcher@2.4.1)(@types/node@20.14.5)(@unocss/reset@0.61.0)(axios@1.7.2)(change-case@4.1.2)(encoding@0.1.13)(eslint@9.21.0(jiti@1.21.7))(floating-vue@5.2.2(@nuxt/kit@3.12.2(magicast@0.3.4)(rollup@4.18.0))(vue@3.5.0(typescript@5.7.3)))(ioredis@5.4.1)(magicast@0.3.4)(nprogress@0.2.0)(optionator@0.9.4)(rollup@4.18.0)(sass@1.77.6)(stylelint@16.10.0(typescript@5.7.3))(terser@5.31.1)(typescript@5.7.3)(unocss@0.61.0(postcss@8.4.49)(rollup@4.18.0)(vite@5.3.1(@types/node@20.14.5)(sass@1.77.6)(terser@5.31.1)))(vite@5.3.1(@types/node@20.14.5)(sass@1.77.6)(terser@5.31.1))(vue-tsc@2.2.4(typescript@5.7.3))
+        version: 3.12.2(@opentelemetry/api@1.9.0)(@parcel/watcher@2.4.1)(@types/node@20.14.5)(@unocss/reset@0.61.0)(axios@1.7.2)(change-case@4.1.2)(encoding@0.1.13)(eslint@9.21.0)(floating-vue@5.2.2(@nuxt/kit@3.12.2(magicast@0.3.4)(rollup@4.18.0))(vue@3.5.0(typescript@5.7.3)))(ioredis@5.4.1)(magicast@0.3.4)(nprogress@0.2.0)(optionator@0.9.4)(rollup@4.18.0)(sass@1.77.6)(stylelint@16.10.0(typescript@5.7.3))(terser@5.31.1)(typescript@5.7.3)(unocss@0.61.0(postcss@8.4.49)(rollup@4.18.0)(vite@5.3.1(@types/node@20.14.5)(sass@1.77.6)(terser@5.31.1)))(vite@5.3.1(@types/node@20.14.5)(sass@1.77.6)(terser@5.31.1))(vue-tsc@2.2.4(typescript@5.7.3))
       vue:
         specifier: ^3.5.0
         version: 3.5.0(typescript@5.7.3)
@@ -209,6 +209,9 @@ importers:
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
+      semver:
+        specifier: ^7.7.1
+        version: 7.7.1
     devDependencies:
       '@playwright/test':
         specifier: ^1.45.0
@@ -251,7 +254,7 @@ importers:
         version: 14.1.1
       jest:
         specifier: ^27.5.1
-        version: 27.5.1(ts-node@10.9.2(@swc/core@1.6.1)(@types/node@18.19.36)(typescript@4.9.5))
+        version: 27.5.1(ts-node@10.9.2(@types/node@18.19.36)(typescript@4.9.5))
       jest-fail-on-console:
         specifier: ^2.2.3
         version: 2.5.0
@@ -260,7 +263,7 @@ importers:
         version: 5.0.2
       ts-jest:
         specifier: ^27.1.3
-        version: 27.1.5(@babel/core@7.24.7)(@types/jest@27.5.2)(babel-jest@27.5.1(@babel/core@7.24.7))(jest@27.5.1(ts-node@10.9.2(@swc/core@1.6.1)(@types/node@18.19.36)(typescript@4.9.5)))(typescript@4.9.5)
+        version: 27.1.5(@babel/core@7.24.7)(@types/jest@27.5.2)(babel-jest@27.5.1(@babel/core@7.24.7))(jest@27.5.1(ts-node@10.9.2(@types/node@18.19.36)(typescript@4.9.5)))(typescript@4.9.5)
       typescript:
         specifier: ^4.9.4
         version: 4.9.5
@@ -486,7 +489,7 @@ importers:
         version: 0.11.3(eslint@9.21.0(jiti@1.21.7))(typescript@5.7.3)
       eslint-plugin-vitest:
         specifier: ^0.5.4
-        version: 0.5.4(eslint@9.21.0(jiti@1.21.7))(typescript@5.7.3)(vitest@3.0.5)
+        version: 0.5.4(eslint@9.21.0(jiti@1.21.7))(typescript@5.7.3)(vitest@3.0.5(@types/node@18.19.36)(@vitest/ui@3.0.5)(jsdom@22.1.0)(msw@2.7.1(@types/node@18.19.36)(typescript@5.7.3))(sass@1.77.6)(terser@5.31.1))
       eslint-plugin-vue:
         specifier: ^9.32.0
         version: 9.32.0(eslint@9.21.0(jiti@1.21.7))
@@ -15512,7 +15515,7 @@ snapshots:
       outdent: 0.5.0
       prettier: 2.8.8
       resolve-from: 5.0.0
-      semver: 7.6.2
+      semver: 7.7.1
 
   '@changesets/assemble-release-plan@6.0.2':
     dependencies:
@@ -15522,7 +15525,7 @@ snapshots:
       '@changesets/should-skip-package': 0.1.0
       '@changesets/types': 6.0.0
       '@manypkg/get-packages': 1.1.3
-      semver: 7.6.2
+      semver: 7.7.1
 
   '@changesets/changelog-git@0.2.0':
     dependencies:
@@ -15559,7 +15562,7 @@ snapshots:
       p-limit: 2.3.0
       preferred-pm: 3.1.3
       resolve-from: 5.0.0
-      semver: 7.6.2
+      semver: 7.7.1
       spawndamnit: 2.0.0
       term-size: 2.2.1
       tty-table: 4.2.3
@@ -15584,7 +15587,7 @@ snapshots:
       '@manypkg/get-packages': 1.1.3
       chalk: 2.4.2
       fs-extra: 7.0.1
-      semver: 7.6.2
+      semver: 7.7.1
 
   '@changesets/get-release-plan@4.0.2':
     dependencies:
@@ -15781,7 +15784,7 @@ snapshots:
     transitivePeerDependencies:
       - '@algolia/client-search'
 
-  '@docusaurus/core@2.4.3(@docusaurus/types@2.4.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(eslint@9.21.0(jiti@1.21.7))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)':
+  '@docusaurus/core@2.4.3(@docusaurus/types@2.4.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(eslint@9.21.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)':
     dependencies:
       '@babel/core': 7.24.7
       '@babel/generator': 7.24.7
@@ -15834,7 +15837,7 @@ snapshots:
       postcss-loader: 7.3.4(postcss@8.4.38)(typescript@4.9.5)(webpack@5.92.0)
       prompts: 2.4.2
       react: 17.0.2
-      react-dev-utils: 12.0.1(eslint@9.21.0(jiti@1.21.7))(typescript@4.9.5)(vue-template-compiler@2.7.16)(webpack@5.92.0)
+      react-dev-utils: 12.0.1(eslint@9.21.0)(typescript@4.9.5)(vue-template-compiler@2.7.16)(webpack@5.92.0)
       react-dom: 17.0.2(react@17.0.2)
       react-helmet-async: 1.3.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       react-loadable: '@docusaurus/react-loadable@5.5.2(react@17.0.2)'
@@ -15934,9 +15937,9 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/plugin-content-blog@2.4.3(eslint@9.21.0(jiti@1.21.7))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)':
+  '@docusaurus/plugin-content-blog@2.4.3(eslint@9.21.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)':
     dependencies:
-      '@docusaurus/core': 2.4.3(@docusaurus/types@2.4.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(eslint@9.21.0(jiti@1.21.7))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)
+      '@docusaurus/core': 2.4.3(@docusaurus/types@2.4.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(eslint@9.21.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)
       '@docusaurus/logger': 2.4.3
       '@docusaurus/mdx-loader': 2.4.3(@docusaurus/types@2.4.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@docusaurus/types': 2.4.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
@@ -15972,9 +15975,9 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-content-docs@2.4.3(eslint@9.21.0(jiti@1.21.7))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)':
+  '@docusaurus/plugin-content-docs@2.4.3(eslint@9.21.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)':
     dependencies:
-      '@docusaurus/core': 2.4.3(@docusaurus/types@2.4.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(eslint@9.21.0(jiti@1.21.7))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)
+      '@docusaurus/core': 2.4.3(@docusaurus/types@2.4.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(eslint@9.21.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)
       '@docusaurus/logger': 2.4.3
       '@docusaurus/mdx-loader': 2.4.3(@docusaurus/types@2.4.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@docusaurus/module-type-aliases': 2.4.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
@@ -16010,9 +16013,9 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-content-pages@2.4.3(eslint@9.21.0(jiti@1.21.7))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)':
+  '@docusaurus/plugin-content-pages@2.4.3(eslint@9.21.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)':
     dependencies:
-      '@docusaurus/core': 2.4.3(@docusaurus/types@2.4.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(eslint@9.21.0(jiti@1.21.7))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)
+      '@docusaurus/core': 2.4.3(@docusaurus/types@2.4.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(eslint@9.21.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)
       '@docusaurus/mdx-loader': 2.4.3(@docusaurus/types@2.4.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@docusaurus/types': 2.4.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@docusaurus/utils': 2.4.3(@docusaurus/types@2.4.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2))
@@ -16040,9 +16043,9 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-debug@2.4.3(@types/react@18.3.3)(encoding@0.1.13)(eslint@9.21.0(jiti@1.21.7))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)':
+  '@docusaurus/plugin-debug@2.4.3(@types/react@18.3.3)(encoding@0.1.13)(eslint@9.21.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)':
     dependencies:
-      '@docusaurus/core': 2.4.3(@docusaurus/types@2.4.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(eslint@9.21.0(jiti@1.21.7))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)
+      '@docusaurus/core': 2.4.3(@docusaurus/types@2.4.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(eslint@9.21.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)
       '@docusaurus/types': 2.4.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@docusaurus/utils': 2.4.3(@docusaurus/types@2.4.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2))
       fs-extra: 10.1.0
@@ -16070,9 +16073,9 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-google-analytics@2.4.3(eslint@9.21.0(jiti@1.21.7))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)':
+  '@docusaurus/plugin-google-analytics@2.4.3(eslint@9.21.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)':
     dependencies:
-      '@docusaurus/core': 2.4.3(@docusaurus/types@2.4.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(eslint@9.21.0(jiti@1.21.7))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)
+      '@docusaurus/core': 2.4.3(@docusaurus/types@2.4.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(eslint@9.21.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)
       '@docusaurus/types': 2.4.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@docusaurus/utils-validation': 2.4.3(@docusaurus/types@2.4.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2))
       react: 17.0.2
@@ -16096,9 +16099,9 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-google-gtag@2.4.3(eslint@9.21.0(jiti@1.21.7))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)':
+  '@docusaurus/plugin-google-gtag@2.4.3(eslint@9.21.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)':
     dependencies:
-      '@docusaurus/core': 2.4.3(@docusaurus/types@2.4.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(eslint@9.21.0(jiti@1.21.7))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)
+      '@docusaurus/core': 2.4.3(@docusaurus/types@2.4.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(eslint@9.21.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)
       '@docusaurus/types': 2.4.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@docusaurus/utils-validation': 2.4.3(@docusaurus/types@2.4.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2))
       react: 17.0.2
@@ -16122,9 +16125,9 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-google-tag-manager@2.4.3(eslint@9.21.0(jiti@1.21.7))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)':
+  '@docusaurus/plugin-google-tag-manager@2.4.3(eslint@9.21.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)':
     dependencies:
-      '@docusaurus/core': 2.4.3(@docusaurus/types@2.4.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(eslint@9.21.0(jiti@1.21.7))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)
+      '@docusaurus/core': 2.4.3(@docusaurus/types@2.4.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(eslint@9.21.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)
       '@docusaurus/types': 2.4.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@docusaurus/utils-validation': 2.4.3(@docusaurus/types@2.4.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2))
       react: 17.0.2
@@ -16148,9 +16151,9 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-sitemap@2.4.3(eslint@9.21.0(jiti@1.21.7))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)':
+  '@docusaurus/plugin-sitemap@2.4.3(eslint@9.21.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)':
     dependencies:
-      '@docusaurus/core': 2.4.3(@docusaurus/types@2.4.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(eslint@9.21.0(jiti@1.21.7))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)
+      '@docusaurus/core': 2.4.3(@docusaurus/types@2.4.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(eslint@9.21.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)
       '@docusaurus/logger': 2.4.3
       '@docusaurus/types': 2.4.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@docusaurus/utils': 2.4.3(@docusaurus/types@2.4.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2))
@@ -16179,20 +16182,20 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/preset-classic@2.4.3(@algolia/client-search@4.23.3)(@types/react@18.3.3)(encoding@0.1.13)(eslint@9.21.0(jiti@1.21.7))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(search-insights@2.14.0)(typescript@4.9.5)(vue-template-compiler@2.7.16)':
+  '@docusaurus/preset-classic@2.4.3(@algolia/client-search@4.23.3)(@types/react@18.3.3)(encoding@0.1.13)(eslint@9.21.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(search-insights@2.14.0)(typescript@4.9.5)(vue-template-compiler@2.7.16)':
     dependencies:
-      '@docusaurus/core': 2.4.3(@docusaurus/types@2.4.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(eslint@9.21.0(jiti@1.21.7))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)
-      '@docusaurus/plugin-content-blog': 2.4.3(eslint@9.21.0(jiti@1.21.7))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)
-      '@docusaurus/plugin-content-docs': 2.4.3(eslint@9.21.0(jiti@1.21.7))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)
-      '@docusaurus/plugin-content-pages': 2.4.3(eslint@9.21.0(jiti@1.21.7))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)
-      '@docusaurus/plugin-debug': 2.4.3(@types/react@18.3.3)(encoding@0.1.13)(eslint@9.21.0(jiti@1.21.7))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)
-      '@docusaurus/plugin-google-analytics': 2.4.3(eslint@9.21.0(jiti@1.21.7))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)
-      '@docusaurus/plugin-google-gtag': 2.4.3(eslint@9.21.0(jiti@1.21.7))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)
-      '@docusaurus/plugin-google-tag-manager': 2.4.3(eslint@9.21.0(jiti@1.21.7))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)
-      '@docusaurus/plugin-sitemap': 2.4.3(eslint@9.21.0(jiti@1.21.7))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)
-      '@docusaurus/theme-classic': 2.4.3(eslint@9.21.0(jiti@1.21.7))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)
-      '@docusaurus/theme-common': 2.4.3(@docusaurus/types@2.4.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(eslint@9.21.0(jiti@1.21.7))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)
-      '@docusaurus/theme-search-algolia': 2.4.3(@algolia/client-search@4.23.3)(@docusaurus/types@2.4.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(@types/react@18.3.3)(eslint@9.21.0(jiti@1.21.7))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(search-insights@2.14.0)(typescript@4.9.5)(vue-template-compiler@2.7.16)
+      '@docusaurus/core': 2.4.3(@docusaurus/types@2.4.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(eslint@9.21.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)
+      '@docusaurus/plugin-content-blog': 2.4.3(eslint@9.21.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)
+      '@docusaurus/plugin-content-docs': 2.4.3(eslint@9.21.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)
+      '@docusaurus/plugin-content-pages': 2.4.3(eslint@9.21.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)
+      '@docusaurus/plugin-debug': 2.4.3(@types/react@18.3.3)(encoding@0.1.13)(eslint@9.21.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)
+      '@docusaurus/plugin-google-analytics': 2.4.3(eslint@9.21.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)
+      '@docusaurus/plugin-google-gtag': 2.4.3(eslint@9.21.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)
+      '@docusaurus/plugin-google-tag-manager': 2.4.3(eslint@9.21.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)
+      '@docusaurus/plugin-sitemap': 2.4.3(eslint@9.21.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)
+      '@docusaurus/theme-classic': 2.4.3(eslint@9.21.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)
+      '@docusaurus/theme-common': 2.4.3(@docusaurus/types@2.4.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(eslint@9.21.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)
+      '@docusaurus/theme-search-algolia': 2.4.3(@algolia/client-search@4.23.3)(@docusaurus/types@2.4.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(@types/react@18.3.3)(eslint@9.21.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(search-insights@2.14.0)(typescript@4.9.5)(vue-template-compiler@2.7.16)
       '@docusaurus/types': 2.4.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -16224,15 +16227,15 @@ snapshots:
       prop-types: 15.8.1
       react: 17.0.2
 
-  '@docusaurus/theme-classic@2.4.3(eslint@9.21.0(jiti@1.21.7))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)':
+  '@docusaurus/theme-classic@2.4.3(eslint@9.21.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)':
     dependencies:
-      '@docusaurus/core': 2.4.3(@docusaurus/types@2.4.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(eslint@9.21.0(jiti@1.21.7))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)
+      '@docusaurus/core': 2.4.3(@docusaurus/types@2.4.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(eslint@9.21.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)
       '@docusaurus/mdx-loader': 2.4.3(@docusaurus/types@2.4.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@docusaurus/module-type-aliases': 2.4.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@docusaurus/plugin-content-blog': 2.4.3(eslint@9.21.0(jiti@1.21.7))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)
-      '@docusaurus/plugin-content-docs': 2.4.3(eslint@9.21.0(jiti@1.21.7))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)
-      '@docusaurus/plugin-content-pages': 2.4.3(eslint@9.21.0(jiti@1.21.7))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)
-      '@docusaurus/theme-common': 2.4.3(@docusaurus/types@2.4.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(eslint@9.21.0(jiti@1.21.7))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)
+      '@docusaurus/plugin-content-blog': 2.4.3(eslint@9.21.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)
+      '@docusaurus/plugin-content-docs': 2.4.3(eslint@9.21.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)
+      '@docusaurus/plugin-content-pages': 2.4.3(eslint@9.21.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)
+      '@docusaurus/theme-common': 2.4.3(@docusaurus/types@2.4.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(eslint@9.21.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)
       '@docusaurus/theme-translations': 2.4.3
       '@docusaurus/types': 2.4.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@docusaurus/utils': 2.4.3(@docusaurus/types@2.4.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2))
@@ -16271,13 +16274,13 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/theme-common@2.4.3(@docusaurus/types@2.4.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(eslint@9.21.0(jiti@1.21.7))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)':
+  '@docusaurus/theme-common@2.4.3(@docusaurus/types@2.4.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(eslint@9.21.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)':
     dependencies:
       '@docusaurus/mdx-loader': 2.4.3(@docusaurus/types@2.4.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@docusaurus/module-type-aliases': 2.4.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@docusaurus/plugin-content-blog': 2.4.3(eslint@9.21.0(jiti@1.21.7))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)
-      '@docusaurus/plugin-content-docs': 2.4.3(eslint@9.21.0(jiti@1.21.7))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)
-      '@docusaurus/plugin-content-pages': 2.4.3(eslint@9.21.0(jiti@1.21.7))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)
+      '@docusaurus/plugin-content-blog': 2.4.3(eslint@9.21.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)
+      '@docusaurus/plugin-content-docs': 2.4.3(eslint@9.21.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)
+      '@docusaurus/plugin-content-pages': 2.4.3(eslint@9.21.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)
       '@docusaurus/utils': 2.4.3(@docusaurus/types@2.4.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2))
       '@docusaurus/utils-common': 2.4.3(@docusaurus/types@2.4.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2))
       '@types/history': 4.7.11
@@ -16310,13 +16313,13 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/theme-search-algolia@2.4.3(@algolia/client-search@4.23.3)(@docusaurus/types@2.4.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(@types/react@18.3.3)(eslint@9.21.0(jiti@1.21.7))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(search-insights@2.14.0)(typescript@4.9.5)(vue-template-compiler@2.7.16)':
+  '@docusaurus/theme-search-algolia@2.4.3(@algolia/client-search@4.23.3)(@docusaurus/types@2.4.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(@types/react@18.3.3)(eslint@9.21.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(search-insights@2.14.0)(typescript@4.9.5)(vue-template-compiler@2.7.16)':
     dependencies:
       '@docsearch/react': 3.6.0(@algolia/client-search@4.23.3)(@types/react@18.3.3)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(search-insights@2.14.0)
-      '@docusaurus/core': 2.4.3(@docusaurus/types@2.4.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(eslint@9.21.0(jiti@1.21.7))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)
+      '@docusaurus/core': 2.4.3(@docusaurus/types@2.4.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(eslint@9.21.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)
       '@docusaurus/logger': 2.4.3
-      '@docusaurus/plugin-content-docs': 2.4.3(eslint@9.21.0(jiti@1.21.7))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)
-      '@docusaurus/theme-common': 2.4.3(@docusaurus/types@2.4.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(eslint@9.21.0(jiti@1.21.7))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)
+      '@docusaurus/plugin-content-docs': 2.4.3(eslint@9.21.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)
+      '@docusaurus/theme-common': 2.4.3(@docusaurus/types@2.4.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(eslint@9.21.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)(vue-template-compiler@2.7.16)
       '@docusaurus/theme-translations': 2.4.3
       '@docusaurus/utils': 2.4.3(@docusaurus/types@2.4.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2))
       '@docusaurus/utils-validation': 2.4.3(@docusaurus/types@2.4.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2))
@@ -16722,6 +16725,12 @@ snapshots:
       eslint: 9.21.0(jiti@1.21.7)
       eslint-visitor-keys: 3.4.3
 
+  '@eslint-community/eslint-utils@4.4.0(eslint@9.21.0)':
+    dependencies:
+      eslint: 9.21.0
+      eslint-visitor-keys: 3.4.3
+    optional: true
+
   '@eslint-community/regexpp@4.10.1': {}
 
   '@eslint-community/regexpp@4.12.1': {}
@@ -16982,7 +16991,7 @@ snapshots:
       jest-util: 29.7.0
       slash: 3.0.0
 
-  '@jest/core@27.5.1(ts-node@10.9.2(@swc/core@1.6.1)(@types/node@18.19.36)(typescript@4.9.5))':
+  '@jest/core@27.5.1(ts-node@10.9.2(@types/node@18.19.36)(typescript@4.9.5))':
     dependencies:
       '@jest/console': 27.5.1
       '@jest/reporters': 27.5.1
@@ -16996,7 +17005,7 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 27.5.1
-      jest-config: 27.5.1(ts-node@10.9.2(@swc/core@1.6.1)(@types/node@18.19.36)(typescript@4.9.5))
+      jest-config: 27.5.1(ts-node@10.9.2(@types/node@18.19.36)(typescript@4.9.5))
       jest-haste-map: 27.5.1
       jest-message-util: 27.5.1
       jest-regex-util: 27.5.1
@@ -17617,7 +17626,7 @@ snapshots:
       nopt: 5.0.0
       npmlog: 5.0.1
       rimraf: 3.0.2
-      semver: 7.6.2
+      semver: 7.7.1
       tar: 6.2.1
     transitivePeerDependencies:
       - encoding
@@ -17749,7 +17758,7 @@ snapshots:
 
   '@npmcli/fs@3.1.1':
     dependencies:
-      semver: 7.6.2
+      semver: 7.7.1
 
   '@npmcli/git@5.0.7':
     dependencies:
@@ -17759,7 +17768,7 @@ snapshots:
       proc-log: 4.2.0
       promise-inflight: 1.0.1
       promise-retry: 2.0.1
-      semver: 7.6.2
+      semver: 7.7.1
       which: 4.0.0
     transitivePeerDependencies:
       - bluebird
@@ -17779,7 +17788,7 @@ snapshots:
       json-parse-even-better-errors: 3.0.2
       normalize-package-data: 6.0.1
       proc-log: 4.2.0
-      semver: 7.6.2
+      semver: 7.7.1
     transitivePeerDependencies:
       - bluebird
 
@@ -17803,12 +17812,12 @@ snapshots:
 
   '@nuxt/devalue@2.0.2': {}
 
-  '@nuxt/devtools-kit@1.3.3(magicast@0.3.4)(nuxt@3.12.2(@opentelemetry/api@1.9.0)(@parcel/watcher@2.4.1)(@types/node@20.14.5)(@unocss/reset@0.61.0)(axios@1.7.2)(change-case@4.1.2)(encoding@0.1.13)(eslint@9.21.0(jiti@1.21.7))(floating-vue@5.2.2(@nuxt/kit@3.12.2(magicast@0.3.4)(rollup@4.18.0))(vue@3.5.0(typescript@5.7.3)))(ioredis@5.4.1)(magicast@0.3.4)(nprogress@0.2.0)(optionator@0.9.4)(rollup@4.18.0)(sass@1.77.6)(stylelint@16.10.0(typescript@5.7.3))(terser@5.31.1)(typescript@5.7.3)(unocss@0.61.0(postcss@8.4.49)(rollup@4.18.0)(vite@5.3.1(@types/node@20.14.5)(sass@1.77.6)(terser@5.31.1)))(vite@5.3.1(@types/node@20.14.5)(sass@1.77.6)(terser@5.31.1))(vue-tsc@2.2.4(typescript@5.7.3)))(rollup@4.18.0)(vite@5.3.1(@types/node@20.14.5)(sass@1.77.6)(terser@5.31.1))':
+  '@nuxt/devtools-kit@1.3.3(magicast@0.3.4)(nuxt@3.12.2(@opentelemetry/api@1.9.0)(@parcel/watcher@2.4.1)(@types/node@20.14.5)(@unocss/reset@0.61.0)(axios@1.7.2)(change-case@4.1.2)(encoding@0.1.13)(eslint@9.21.0)(floating-vue@5.2.2(@nuxt/kit@3.12.2(magicast@0.3.4)(rollup@4.18.0))(vue@3.5.0(typescript@5.7.3)))(ioredis@5.4.1)(magicast@0.3.4)(nprogress@0.2.0)(optionator@0.9.4)(rollup@4.18.0)(sass@1.77.6)(stylelint@16.10.0(typescript@5.7.3))(terser@5.31.1)(typescript@5.7.3)(unocss@0.61.0(postcss@8.4.49)(rollup@4.18.0)(vite@5.3.1(@types/node@20.14.5)(sass@1.77.6)(terser@5.31.1)))(vite@5.3.1(@types/node@20.14.5)(sass@1.77.6)(terser@5.31.1))(vue-tsc@2.2.4(typescript@5.7.3)))(rollup@4.18.0)(vite@5.3.1(@types/node@20.14.5)(sass@1.77.6)(terser@5.31.1))':
     dependencies:
       '@nuxt/kit': 3.12.2(magicast@0.3.4)(rollup@4.18.0)
       '@nuxt/schema': 3.12.2(rollup@4.18.0)
       execa: 7.2.0
-      nuxt: 3.12.2(@opentelemetry/api@1.9.0)(@parcel/watcher@2.4.1)(@types/node@20.14.5)(@unocss/reset@0.61.0)(axios@1.7.2)(change-case@4.1.2)(encoding@0.1.13)(eslint@9.21.0(jiti@1.21.7))(floating-vue@5.2.2(@nuxt/kit@3.12.2(magicast@0.3.4)(rollup@4.18.0))(vue@3.5.0(typescript@5.7.3)))(ioredis@5.4.1)(magicast@0.3.4)(nprogress@0.2.0)(optionator@0.9.4)(rollup@4.18.0)(sass@1.77.6)(stylelint@16.10.0(typescript@5.7.3))(terser@5.31.1)(typescript@5.7.3)(unocss@0.61.0(postcss@8.4.49)(rollup@4.18.0)(vite@5.3.1(@types/node@20.14.5)(sass@1.77.6)(terser@5.31.1)))(vite@5.3.1(@types/node@20.14.5)(sass@1.77.6)(terser@5.31.1))(vue-tsc@2.2.4(typescript@5.7.3))
+      nuxt: 3.12.2(@opentelemetry/api@1.9.0)(@parcel/watcher@2.4.1)(@types/node@20.14.5)(@unocss/reset@0.61.0)(axios@1.7.2)(change-case@4.1.2)(encoding@0.1.13)(eslint@9.21.0)(floating-vue@5.2.2(@nuxt/kit@3.12.2(magicast@0.3.4)(rollup@4.18.0))(vue@3.5.0(typescript@5.7.3)))(ioredis@5.4.1)(magicast@0.3.4)(nprogress@0.2.0)(optionator@0.9.4)(rollup@4.18.0)(sass@1.77.6)(stylelint@16.10.0(typescript@5.7.3))(terser@5.31.1)(typescript@5.7.3)(unocss@0.61.0(postcss@8.4.49)(rollup@4.18.0)(vite@5.3.1(@types/node@20.14.5)(sass@1.77.6)(terser@5.31.1)))(vite@5.3.1(@types/node@20.14.5)(sass@1.77.6)(terser@5.31.1))(vue-tsc@2.2.4(typescript@5.7.3))
       vite: 5.3.1(@types/node@20.14.5)(sass@1.77.6)(terser@5.31.1)
     transitivePeerDependencies:
       - magicast
@@ -17826,12 +17835,12 @@ snapshots:
       pkg-types: 1.1.1
       prompts: 2.4.2
       rc9: 2.1.2
-      semver: 7.6.2
+      semver: 7.7.1
 
-  '@nuxt/devtools@1.3.3(9aa219af8d0c59a00be3beb6650423f6)':
+  '@nuxt/devtools@1.3.3(ekinsx4bek3qrdtj23vmx22npy)':
     dependencies:
       '@antfu/utils': 0.7.8
-      '@nuxt/devtools-kit': 1.3.3(magicast@0.3.4)(nuxt@3.12.2(@opentelemetry/api@1.9.0)(@parcel/watcher@2.4.1)(@types/node@20.14.5)(@unocss/reset@0.61.0)(axios@1.7.2)(change-case@4.1.2)(encoding@0.1.13)(eslint@9.21.0(jiti@1.21.7))(floating-vue@5.2.2(@nuxt/kit@3.12.2(magicast@0.3.4)(rollup@4.18.0))(vue@3.5.0(typescript@5.7.3)))(ioredis@5.4.1)(magicast@0.3.4)(nprogress@0.2.0)(optionator@0.9.4)(rollup@4.18.0)(sass@1.77.6)(stylelint@16.10.0(typescript@5.7.3))(terser@5.31.1)(typescript@5.7.3)(unocss@0.61.0(postcss@8.4.49)(rollup@4.18.0)(vite@5.3.1(@types/node@20.14.5)(sass@1.77.6)(terser@5.31.1)))(vite@5.3.1(@types/node@20.14.5)(sass@1.77.6)(terser@5.31.1))(vue-tsc@2.2.4(typescript@5.7.3)))(rollup@4.18.0)(vite@5.3.1(@types/node@20.14.5)(sass@1.77.6)(terser@5.31.1))
+      '@nuxt/devtools-kit': 1.3.3(magicast@0.3.4)(nuxt@3.12.2(@opentelemetry/api@1.9.0)(@parcel/watcher@2.4.1)(@types/node@20.14.5)(@unocss/reset@0.61.0)(axios@1.7.2)(change-case@4.1.2)(encoding@0.1.13)(eslint@9.21.0)(floating-vue@5.2.2(@nuxt/kit@3.12.2(magicast@0.3.4)(rollup@4.18.0))(vue@3.5.0(typescript@5.7.3)))(ioredis@5.4.1)(magicast@0.3.4)(nprogress@0.2.0)(optionator@0.9.4)(rollup@4.18.0)(sass@1.77.6)(stylelint@16.10.0(typescript@5.7.3))(terser@5.31.1)(typescript@5.7.3)(unocss@0.61.0(postcss@8.4.49)(rollup@4.18.0)(vite@5.3.1(@types/node@20.14.5)(sass@1.77.6)(terser@5.31.1)))(vite@5.3.1(@types/node@20.14.5)(sass@1.77.6)(terser@5.31.1))(vue-tsc@2.2.4(typescript@5.7.3)))(rollup@4.18.0)(vite@5.3.1(@types/node@20.14.5)(sass@1.77.6)(terser@5.31.1))
       '@nuxt/devtools-wizard': 1.3.3
       '@nuxt/kit': 3.12.2(magicast@0.3.4)(rollup@4.18.0)
       '@vue/devtools-applet': 7.1.3(@unocss/reset@0.61.0)(axios@1.7.2)(change-case@4.1.2)(floating-vue@5.2.2(@nuxt/kit@3.12.2(magicast@0.3.4)(rollup@4.18.0))(vue@3.5.0(typescript@5.7.3)))(nprogress@0.2.0)(unocss@0.61.0(postcss@8.4.49)(rollup@4.18.0)(vite@5.3.1(@types/node@20.14.5)(sass@1.77.6)(terser@5.31.1)))(vite@5.3.1(@types/node@20.14.5)(sass@1.77.6)(terser@5.31.1))(vue@3.5.13(typescript@5.7.3))
@@ -17852,7 +17861,7 @@ snapshots:
       launch-editor: 2.7.0
       local-pkg: 0.5.0
       magicast: 0.3.4
-      nuxt: 3.12.2(@opentelemetry/api@1.9.0)(@parcel/watcher@2.4.1)(@types/node@20.14.5)(@unocss/reset@0.61.0)(axios@1.7.2)(change-case@4.1.2)(encoding@0.1.13)(eslint@9.21.0(jiti@1.21.7))(floating-vue@5.2.2(@nuxt/kit@3.12.2(magicast@0.3.4)(rollup@4.18.0))(vue@3.5.0(typescript@5.7.3)))(ioredis@5.4.1)(magicast@0.3.4)(nprogress@0.2.0)(optionator@0.9.4)(rollup@4.18.0)(sass@1.77.6)(stylelint@16.10.0(typescript@5.7.3))(terser@5.31.1)(typescript@5.7.3)(unocss@0.61.0(postcss@8.4.49)(rollup@4.18.0)(vite@5.3.1(@types/node@20.14.5)(sass@1.77.6)(terser@5.31.1)))(vite@5.3.1(@types/node@20.14.5)(sass@1.77.6)(terser@5.31.1))(vue-tsc@2.2.4(typescript@5.7.3))
+      nuxt: 3.12.2(@opentelemetry/api@1.9.0)(@parcel/watcher@2.4.1)(@types/node@20.14.5)(@unocss/reset@0.61.0)(axios@1.7.2)(change-case@4.1.2)(encoding@0.1.13)(eslint@9.21.0)(floating-vue@5.2.2(@nuxt/kit@3.12.2(magicast@0.3.4)(rollup@4.18.0))(vue@3.5.0(typescript@5.7.3)))(ioredis@5.4.1)(magicast@0.3.4)(nprogress@0.2.0)(optionator@0.9.4)(rollup@4.18.0)(sass@1.77.6)(stylelint@16.10.0(typescript@5.7.3))(terser@5.31.1)(typescript@5.7.3)(unocss@0.61.0(postcss@8.4.49)(rollup@4.18.0)(vite@5.3.1(@types/node@20.14.5)(sass@1.77.6)(terser@5.31.1)))(vite@5.3.1(@types/node@20.14.5)(sass@1.77.6)(terser@5.31.1))(vue-tsc@2.2.4(typescript@5.7.3))
       nypm: 0.3.8
       ohash: 1.1.3
       pacote: 18.0.6
@@ -17861,7 +17870,7 @@ snapshots:
       pkg-types: 1.1.1
       rc9: 2.1.2
       scule: 1.3.0
-      semver: 7.6.2
+      semver: 7.7.1
       simple-git: 3.25.0
       sirv: 2.0.4
       unimport: 3.7.2(rollup@4.18.0)
@@ -17910,7 +17919,7 @@ snapshots:
       pathe: 1.1.2
       pkg-types: 1.1.1
       scule: 1.3.0
-      semver: 7.6.2
+      semver: 7.7.1
       ufo: 1.5.3
       unctx: 2.3.1
       unimport: 3.7.2(rollup@4.18.0)
@@ -17962,7 +17971,7 @@ snapshots:
       - rollup
       - supports-color
 
-  '@nuxt/vite-builder@3.12.2(@types/node@20.14.5)(eslint@9.21.0(jiti@1.21.7))(magicast@0.3.4)(optionator@0.9.4)(rollup@4.18.0)(sass@1.77.6)(stylelint@16.10.0(typescript@5.7.3))(terser@5.31.1)(typescript@5.7.3)(vue-tsc@2.2.4(typescript@5.7.3))(vue@3.5.13(typescript@5.7.3))':
+  '@nuxt/vite-builder@3.12.2(@types/node@20.14.5)(eslint@9.21.0)(magicast@0.3.4)(optionator@0.9.4)(rollup@4.18.0)(sass@1.77.6)(stylelint@16.10.0(typescript@5.7.3))(terser@5.31.1)(typescript@5.7.3)(vue-tsc@2.2.4(typescript@5.7.3))(vue@3.5.13(typescript@5.7.3))':
     dependencies:
       '@nuxt/kit': 3.12.2(magicast@0.3.4)(rollup@4.18.0)
       '@rollup/plugin-replace': 5.0.7(rollup@4.18.0)
@@ -17996,7 +18005,7 @@ snapshots:
       unplugin: 1.10.1
       vite: 5.3.1(@types/node@20.14.5)(sass@1.77.6)(terser@5.31.1)
       vite-node: 1.6.0(@types/node@20.14.5)(sass@1.77.6)(terser@5.31.1)
-      vite-plugin-checker: 0.6.4(eslint@9.21.0(jiti@1.21.7))(optionator@0.9.4)(stylelint@16.10.0(typescript@5.7.3))(typescript@5.7.3)(vite@5.3.1(@types/node@20.14.5)(sass@1.77.6)(terser@5.31.1))(vue-tsc@2.2.4(typescript@5.7.3))
+      vite-plugin-checker: 0.6.4(eslint@9.21.0)(optionator@0.9.4)(stylelint@16.10.0(typescript@5.7.3))(typescript@5.7.3)(vite@5.3.1(@types/node@20.14.5)(sass@1.77.6)(terser@5.31.1))(vue-tsc@2.2.4(typescript@5.7.3))
       vue: 3.5.13(typescript@5.7.3)
       vue-bundle-renderer: 2.1.0
     transitivePeerDependencies:
@@ -18652,7 +18661,7 @@ snapshots:
       prettier-fallback: prettier@3.5.2
       pretty-hrtime: 1.0.3
       resolve-from: 5.0.0
-      semver: 7.6.2
+      semver: 7.7.1
       tempy: 3.1.0
       tiny-invariant: 1.3.3
       ts-dedent: 2.2.0
@@ -18678,7 +18687,7 @@ snapshots:
       jsdoc-type-pratt-parser: 4.1.0
       process: 0.11.10
       recast: 0.23.9
-      semver: 7.6.2
+      semver: 7.7.1
       util: 0.12.5
       ws: 8.17.1
     optionalDependencies:
@@ -19674,7 +19683,7 @@ snapshots:
       graphemer: 1.4.0
       ignore: 5.3.1
       natural-compare-lite: 1.4.0
-      semver: 7.6.2
+      semver: 7.7.1
       tsutils: 3.21.0(typescript@4.9.5)
     optionalDependencies:
       typescript: 4.9.5
@@ -19855,7 +19864,7 @@ snapshots:
       debug: 4.4.0
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.6.2
+      semver: 7.7.1
       tsutils: 3.21.0(typescript@3.9.10)
     optionalDependencies:
       typescript: 3.9.10
@@ -19869,7 +19878,7 @@ snapshots:
       debug: 4.4.0
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.6.2
+      semver: 7.7.1
       tsutils: 3.21.0(typescript@4.9.5)
     optionalDependencies:
       typescript: 4.9.5
@@ -19884,7 +19893,7 @@ snapshots:
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.4
-      semver: 7.6.2
+      semver: 7.7.1
       ts-api-utils: 1.3.0(typescript@5.7.3)
     optionalDependencies:
       typescript: 5.7.3
@@ -19899,7 +19908,7 @@ snapshots:
       fast-glob: 3.3.2
       is-glob: 4.0.3
       minimatch: 9.0.4
-      semver: 7.6.2
+      semver: 7.7.1
       ts-api-utils: 2.0.1(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
@@ -19913,7 +19922,7 @@ snapshots:
       fast-glob: 3.3.2
       is-glob: 4.0.3
       minimatch: 9.0.4
-      semver: 7.6.2
+      semver: 7.7.1
       ts-api-utils: 2.0.1(typescript@5.7.3)
       typescript: 5.7.3
     transitivePeerDependencies:
@@ -19929,7 +19938,7 @@ snapshots:
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@4.9.5)
       eslint: 8.57.0
       eslint-scope: 5.1.1
-      semver: 7.6.2
+      semver: 7.7.1
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -22193,7 +22202,7 @@ snapshots:
       postcss-modules-scope: 3.2.0(postcss@8.4.49)
       postcss-modules-values: 4.0.0(postcss@8.4.49)
       postcss-value-parser: 4.2.0
-      semver: 7.6.2
+      semver: 7.7.1
     optionalDependencies:
       webpack: 5.92.0
 
@@ -22863,7 +22872,7 @@ snapshots:
       '@one-ini/wasm': 0.1.1
       commander: 10.0.1
       minimatch: 9.0.1
-      semver: 7.6.2
+      semver: 7.7.1
 
   ee-first@1.1.1: {}
 
@@ -23320,7 +23329,7 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-vitest@0.5.4(eslint@9.21.0(jiti@1.21.7))(typescript@5.7.3)(vitest@3.0.5):
+  eslint-plugin-vitest@0.5.4(eslint@9.21.0(jiti@1.21.7))(typescript@5.7.3)(vitest@3.0.5(@types/node@18.19.36)(@vitest/ui@3.0.5)(jsdom@22.1.0)(msw@2.7.1(@types/node@18.19.36)(typescript@5.7.3))(sass@1.77.6)(terser@5.31.1)):
     dependencies:
       '@typescript-eslint/utils': 7.13.1(eslint@9.21.0(jiti@1.21.7))(typescript@5.7.3)
       eslint: 9.21.0(jiti@1.21.7)
@@ -23448,6 +23457,46 @@ snapshots:
       jiti: 1.21.7
     transitivePeerDependencies:
       - supports-color
+
+  eslint@9.21.0:
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.0(eslint@9.21.0)
+      '@eslint-community/regexpp': 4.12.1
+      '@eslint/config-array': 0.19.2
+      '@eslint/core': 0.12.0
+      '@eslint/eslintrc': 3.3.0
+      '@eslint/js': 9.21.0
+      '@eslint/plugin-kit': 0.2.7
+      '@humanfs/node': 0.16.6
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.2
+      '@types/estree': 1.0.6
+      '@types/json-schema': 7.0.15
+      ajv: 6.12.6
+      chalk: 4.1.2
+      cross-spawn: 7.0.6
+      debug: 4.4.0
+      escape-string-regexp: 4.0.0
+      eslint-scope: 8.2.0
+      eslint-visitor-keys: 4.2.0
+      espree: 10.3.0
+      esquery: 1.5.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.1
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      lodash.merge: 4.6.2
+      minimatch: 3.1.2
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
 
   eslint@9.21.0(jiti@1.21.7):
     dependencies:
@@ -23945,7 +23994,7 @@ snapshots:
       cross-spawn: 7.0.3
       signal-exit: 4.1.0
 
-  fork-ts-checker-webpack-plugin@6.5.3(eslint@9.21.0(jiti@1.21.7))(typescript@4.9.5)(vue-template-compiler@2.7.16)(webpack@5.92.0):
+  fork-ts-checker-webpack-plugin@6.5.3(eslint@9.21.0)(typescript@4.9.5)(vue-template-compiler@2.7.16)(webpack@5.92.0):
     dependencies:
       '@babel/code-frame': 7.24.7
       '@types/json-schema': 7.0.15
@@ -23958,12 +24007,12 @@ snapshots:
       memfs: 3.5.3
       minimatch: 3.1.2
       schema-utils: 2.7.0
-      semver: 7.6.2
+      semver: 7.7.1
       tapable: 1.1.3
       typescript: 4.9.5
       webpack: 5.92.0
     optionalDependencies:
-      eslint: 9.21.0(jiti@1.21.7)
+      eslint: 9.21.0
       vue-template-compiler: 2.7.16
 
   form-data@3.0.1:
@@ -25111,7 +25160,7 @@ snapshots:
       '@babel/parser': 7.26.3
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
-      semver: 7.6.2
+      semver: 7.7.1
     transitivePeerDependencies:
       - supports-color
 
@@ -25215,16 +25264,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@27.5.1(ts-node@10.9.2(@swc/core@1.6.1)(@types/node@18.19.36)(typescript@4.9.5)):
+  jest-cli@27.5.1(ts-node@10.9.2(@types/node@18.19.36)(typescript@4.9.5)):
     dependencies:
-      '@jest/core': 27.5.1(ts-node@10.9.2(@swc/core@1.6.1)(@types/node@18.19.36)(typescript@4.9.5))
+      '@jest/core': 27.5.1(ts-node@10.9.2(@types/node@18.19.36)(typescript@4.9.5))
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
       import-local: 3.1.0
-      jest-config: 27.5.1(ts-node@10.9.2(@swc/core@1.6.1)(@types/node@18.19.36)(typescript@4.9.5))
+      jest-config: 27.5.1(ts-node@10.9.2(@types/node@18.19.36)(typescript@4.9.5))
       jest-util: 27.5.1
       jest-validate: 27.5.1
       prompts: 2.4.2
@@ -25255,7 +25304,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@27.5.1(ts-node@10.9.2(@swc/core@1.6.1)(@types/node@18.19.36)(typescript@4.9.5)):
+  jest-config@27.5.1(ts-node@10.9.2(@types/node@18.19.36)(typescript@4.9.5)):
     dependencies:
       '@babel/core': 7.24.7
       '@jest/test-sequencer': 27.5.1
@@ -25282,7 +25331,7 @@ snapshots:
       slash: 3.0.0
       strip-json-comments: 3.1.1
     optionalDependencies:
-      ts-node: 10.9.2(@swc/core@1.6.1)(@types/node@18.19.36)(typescript@4.9.5)
+      ts-node: 10.9.2(@types/node@18.19.36)(typescript@4.9.5)
     transitivePeerDependencies:
       - bufferutil
       - canvas
@@ -25758,7 +25807,7 @@ snapshots:
       jest-util: 27.5.1
       natural-compare: 1.4.0
       pretty-format: 27.5.1
-      semver: 7.6.2
+      semver: 7.7.1
     transitivePeerDependencies:
       - supports-color
 
@@ -25783,7 +25832,7 @@ snapshots:
       jest-util: 29.7.0
       natural-compare: 1.4.0
       pretty-format: 29.7.0
-      semver: 7.6.2
+      semver: 7.7.1
     transitivePeerDependencies:
       - supports-color
 
@@ -25868,11 +25917,11 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@27.5.1(ts-node@10.9.2(@swc/core@1.6.1)(@types/node@18.19.36)(typescript@4.9.5)):
+  jest@27.5.1(ts-node@10.9.2(@types/node@18.19.36)(typescript@4.9.5)):
     dependencies:
-      '@jest/core': 27.5.1(ts-node@10.9.2(@swc/core@1.6.1)(@types/node@18.19.36)(typescript@4.9.5))
+      '@jest/core': 27.5.1(ts-node@10.9.2(@types/node@18.19.36)(typescript@4.9.5))
       import-local: 3.1.0
-      jest-cli: 27.5.1(ts-node@10.9.2(@swc/core@1.6.1)(@types/node@18.19.36)(typescript@4.9.5))
+      jest-cli: 27.5.1(ts-node@10.9.2(@types/node@18.19.36)(typescript@4.9.5))
     transitivePeerDependencies:
       - bufferutil
       - canvas
@@ -26342,7 +26391,7 @@ snapshots:
 
   make-dir@4.0.0:
     dependencies:
-      semver: 7.6.2
+      semver: 7.7.1
 
   make-error@1.3.6: {}
 
@@ -26908,7 +26957,7 @@ snapshots:
       rollup: 4.18.0
       rollup-plugin-visualizer: 5.12.0(rollup@4.18.0)
       scule: 1.3.0
-      semver: 7.6.2
+      semver: 7.7.1
       serve-placeholder: 2.0.2
       serve-static: 1.15.0
       std-env: 3.7.0
@@ -26979,7 +27028,7 @@ snapshots:
       make-fetch-happen: 13.0.1
       nopt: 7.2.1
       proc-log: 3.0.0
-      semver: 7.6.2
+      semver: 7.7.1
       tar: 6.2.1
       which: 4.0.0
     transitivePeerDependencies:
@@ -27029,7 +27078,7 @@ snapshots:
     dependencies:
       hosted-git-info: 7.0.2
       is-core-module: 2.13.1
-      semver: 7.6.2
+      semver: 7.7.1
       validate-npm-package-license: 3.0.4
 
   normalize-path@3.0.0: {}
@@ -27046,7 +27095,7 @@ snapshots:
 
   npm-install-checks@6.3.0:
     dependencies:
-      semver: 7.6.2
+      semver: 7.7.1
 
   npm-normalize-package-bin@3.0.1: {}
 
@@ -27054,7 +27103,7 @@ snapshots:
     dependencies:
       hosted-git-info: 7.0.2
       proc-log: 4.2.0
-      semver: 7.6.2
+      semver: 7.7.1
       validate-npm-package-name: 5.0.1
 
   npm-packlist@8.0.2:
@@ -27066,7 +27115,7 @@ snapshots:
       npm-install-checks: 6.3.0
       npm-normalize-package-bin: 3.0.1
       npm-package-arg: 11.0.2
-      semver: 7.6.2
+      semver: 7.7.1
 
   npm-registry-fetch@17.1.0:
     dependencies:
@@ -27120,14 +27169,14 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  nuxt@3.12.2(@opentelemetry/api@1.9.0)(@parcel/watcher@2.4.1)(@types/node@20.14.5)(@unocss/reset@0.61.0)(axios@1.7.2)(change-case@4.1.2)(encoding@0.1.13)(eslint@9.21.0(jiti@1.21.7))(floating-vue@5.2.2(@nuxt/kit@3.12.2(magicast@0.3.4)(rollup@4.18.0))(vue@3.5.0(typescript@5.7.3)))(ioredis@5.4.1)(magicast@0.3.4)(nprogress@0.2.0)(optionator@0.9.4)(rollup@4.18.0)(sass@1.77.6)(stylelint@16.10.0(typescript@5.7.3))(terser@5.31.1)(typescript@5.7.3)(unocss@0.61.0(postcss@8.4.49)(rollup@4.18.0)(vite@5.3.1(@types/node@20.14.5)(sass@1.77.6)(terser@5.31.1)))(vite@5.3.1(@types/node@20.14.5)(sass@1.77.6)(terser@5.31.1))(vue-tsc@2.2.4(typescript@5.7.3)):
+  nuxt@3.12.2(@opentelemetry/api@1.9.0)(@parcel/watcher@2.4.1)(@types/node@20.14.5)(@unocss/reset@0.61.0)(axios@1.7.2)(change-case@4.1.2)(encoding@0.1.13)(eslint@9.21.0)(floating-vue@5.2.2(@nuxt/kit@3.12.2(magicast@0.3.4)(rollup@4.18.0))(vue@3.5.0(typescript@5.7.3)))(ioredis@5.4.1)(magicast@0.3.4)(nprogress@0.2.0)(optionator@0.9.4)(rollup@4.18.0)(sass@1.77.6)(stylelint@16.10.0(typescript@5.7.3))(terser@5.31.1)(typescript@5.7.3)(unocss@0.61.0(postcss@8.4.49)(rollup@4.18.0)(vite@5.3.1(@types/node@20.14.5)(sass@1.77.6)(terser@5.31.1)))(vite@5.3.1(@types/node@20.14.5)(sass@1.77.6)(terser@5.31.1))(vue-tsc@2.2.4(typescript@5.7.3)):
     dependencies:
       '@nuxt/devalue': 2.0.2
-      '@nuxt/devtools': 1.3.3(9aa219af8d0c59a00be3beb6650423f6)
+      '@nuxt/devtools': 1.3.3(ekinsx4bek3qrdtj23vmx22npy)
       '@nuxt/kit': 3.12.2(magicast@0.3.4)(rollup@4.18.0)
       '@nuxt/schema': 3.12.2(rollup@4.18.0)
       '@nuxt/telemetry': 2.5.4(magicast@0.3.4)(rollup@4.18.0)
-      '@nuxt/vite-builder': 3.12.2(@types/node@20.14.5)(eslint@9.21.0(jiti@1.21.7))(magicast@0.3.4)(optionator@0.9.4)(rollup@4.18.0)(sass@1.77.6)(stylelint@16.10.0(typescript@5.7.3))(terser@5.31.1)(typescript@5.7.3)(vue-tsc@2.2.4(typescript@5.7.3))(vue@3.5.13(typescript@5.7.3))
+      '@nuxt/vite-builder': 3.12.2(@types/node@20.14.5)(eslint@9.21.0)(magicast@0.3.4)(optionator@0.9.4)(rollup@4.18.0)(sass@1.77.6)(stylelint@16.10.0(typescript@5.7.3))(terser@5.31.1)(typescript@5.7.3)(vue-tsc@2.2.4(typescript@5.7.3))(vue@3.5.13(typescript@5.7.3))
       '@unhead/dom': 1.9.13
       '@unhead/ssr': 1.9.13
       '@unhead/vue': 1.9.13(vue@3.5.13(typescript@5.7.3))
@@ -27867,7 +27916,7 @@ snapshots:
       cosmiconfig: 8.3.6(typescript@4.9.5)
       jiti: 1.21.6
       postcss: 8.4.38
-      semver: 7.6.2
+      semver: 7.7.1
       webpack: 5.92.0
     transitivePeerDependencies:
       - typescript
@@ -28702,7 +28751,7 @@ snapshots:
       lodash.flow: 3.5.0
       pure-color: 1.3.0
 
-  react-dev-utils@12.0.1(eslint@9.21.0(jiti@1.21.7))(typescript@4.9.5)(vue-template-compiler@2.7.16)(webpack@5.92.0):
+  react-dev-utils@12.0.1(eslint@9.21.0)(typescript@4.9.5)(vue-template-compiler@2.7.16)(webpack@5.92.0):
     dependencies:
       '@babel/code-frame': 7.24.7
       address: 1.2.2
@@ -28713,7 +28762,7 @@ snapshots:
       escape-string-regexp: 4.0.0
       filesize: 8.0.7
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 6.5.3(eslint@9.21.0(jiti@1.21.7))(typescript@4.9.5)(vue-template-compiler@2.7.16)(webpack@5.92.0)
+      fork-ts-checker-webpack-plugin: 6.5.3(eslint@9.21.0)(typescript@4.9.5)(vue-template-compiler@2.7.16)(webpack@5.92.0)
       global-modules: 2.0.0
       globby: 11.1.0
       gzip-size: 6.0.0
@@ -30273,16 +30322,16 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-jest@27.1.5(@babel/core@7.24.7)(@types/jest@27.5.2)(babel-jest@27.5.1(@babel/core@7.24.7))(jest@27.5.1(ts-node@10.9.2(@swc/core@1.6.1)(@types/node@18.19.36)(typescript@4.9.5)))(typescript@4.9.5):
+  ts-jest@27.1.5(@babel/core@7.24.7)(@types/jest@27.5.2)(babel-jest@27.5.1(@babel/core@7.24.7))(jest@27.5.1(ts-node@10.9.2(@types/node@18.19.36)(typescript@4.9.5)))(typescript@4.9.5):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 27.5.1(ts-node@10.9.2(@swc/core@1.6.1)(@types/node@18.19.36)(typescript@4.9.5))
+      jest: 27.5.1(ts-node@10.9.2(@types/node@18.19.36)(typescript@4.9.5))
       jest-util: 27.5.1
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
-      semver: 7.6.2
+      semver: 7.7.1
       typescript: 4.9.5
       yargs-parser: 20.2.9
     optionalDependencies:
@@ -30301,27 +30350,6 @@ snapshots:
     dependencies:
       '@ts-morph/common': 0.21.0
       code-block-writer: 12.0.0
-
-  ts-node@10.9.2(@swc/core@1.6.1)(@types/node@18.19.36)(typescript@4.9.5):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.11
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 18.19.36
-      acorn: 8.12.0
-      acorn-walk: 8.3.3
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 4.9.5
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    optionalDependencies:
-      '@swc/core': 1.6.1
-    optional: true
 
   ts-node@10.9.2(@swc/core@1.6.1)(@types/node@18.19.36)(typescript@5.4.5):
     dependencies:
@@ -30383,6 +30411,25 @@ snapshots:
       yn: 3.1.1
     optionalDependencies:
       '@swc/core': 1.6.1
+
+  ts-node@10.9.2(@types/node@18.19.36)(typescript@4.9.5):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.11
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 18.19.36
+      acorn: 8.12.0
+      acorn-walk: 8.3.3
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 4.9.5
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optional: true
 
   tsconfig-paths@3.15.0:
     dependencies:
@@ -30904,7 +30951,7 @@ snapshots:
       is-yarn-global: 0.3.0
       latest-version: 5.1.0
       pupa: 2.1.1
-      semver: 7.6.2
+      semver: 7.7.1
       semver-diff: 3.1.1
       xdg-basedir: 4.0.0
 
@@ -31092,7 +31139,7 @@ snapshots:
       - supports-color
       - terser
 
-  vite-plugin-checker@0.6.4(eslint@9.21.0(jiti@1.21.7))(optionator@0.9.4)(stylelint@16.10.0(typescript@5.7.3))(typescript@5.7.3)(vite@5.3.1(@types/node@20.14.5)(sass@1.77.6)(terser@5.31.1))(vue-tsc@2.2.4(typescript@5.7.3)):
+  vite-plugin-checker@0.6.4(eslint@9.21.0)(optionator@0.9.4)(stylelint@16.10.0(typescript@5.7.3))(typescript@5.7.3)(vite@5.3.1(@types/node@20.14.5)(sass@1.77.6)(terser@5.31.1))(vue-tsc@2.2.4(typescript@5.7.3)):
     dependencies:
       '@babel/code-frame': 7.24.7
       ansi-escapes: 4.3.2
@@ -31102,7 +31149,7 @@ snapshots:
       fast-glob: 3.3.2
       fs-extra: 11.2.0
       npm-run-path: 4.0.1
-      semver: 7.6.2
+      semver: 7.7.1
       strip-ansi: 6.0.1
       tiny-invariant: 1.3.3
       vite: 5.3.1(@types/node@20.14.5)(sass@1.77.6)(terser@5.31.1)
@@ -31111,7 +31158,7 @@ snapshots:
       vscode-languageserver-textdocument: 1.0.11
       vscode-uri: 3.0.8
     optionalDependencies:
-      eslint: 9.21.0(jiti@1.21.7)
+      eslint: 9.21.0
       optionator: 0.9.4
       stylelint: 16.10.0(typescript@5.7.3)
       typescript: 5.7.3
@@ -31320,7 +31367,7 @@ snapshots:
   vscode-languageclient@7.0.0:
     dependencies:
       minimatch: 3.1.2
-      semver: 7.6.2
+      semver: 7.7.1
       vscode-languageserver-protocol: 3.16.0
 
   vscode-languageserver-protocol@3.16.0:
@@ -31401,7 +31448,7 @@ snapshots:
       espree: 9.6.1
       esquery: 1.5.0
       lodash: 4.17.21
-      semver: 7.6.2
+      semver: 7.7.1
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
## What?
This PR adds the logic for compare Shopware version directly in SDK

## Why?
To make it compatible with any version of Shopware

## How?
the comparison is done directly in the SDK

## Testing?
Added test for the comparison logic

