### PR TITLE
Fix icon kit script

### DIFF
--- a/packages/icon-kit/package.json
+++ b/packages/icon-kit/package.json
@@ -15,6 +15,7 @@
     "type": "git",
     "url": "git+ssh://git@github.com:shopware/meteor.git"
   },
+  "type": "module",
   "license": "MIT",
   "author": "shopware AG",
   "main": "index.js",
@@ -55,7 +56,7 @@
     "svgo": "^2.8.0",
     "svgo-autocrop": "1.1.1",
     "ts-node": "^10.8.1",
-    "typescript": "^4.6.3",
+    "typescript": "^5.7.0",
     "typescript-eslint": "^8.24.1"
   }
 }

--- a/packages/icon-kit/src/figma/index.ts
+++ b/packages/icon-kit/src/figma/index.ts
@@ -56,6 +56,7 @@ export type Meta = {
 
 export default class FigmaApiClient {
   // @ts-expect-error -- TODO: add types for axios
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
   httpClient = Axios.create({
     baseURL: 'https://api.figma.com/v1',
   });
@@ -65,6 +66,7 @@ export default class FigmaApiClient {
       key = process.env.FIGMA_FILE;
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
     return this.httpClient.get<FigmaFileResponse>(
       `/files/${key}`,
       {
@@ -74,6 +76,7 @@ export default class FigmaApiClient {
   }
 
   public getImages(ids: string[]): Promise<AxiosResponse<FigmaImageResponse>> {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
     return this.httpClient.get<FigmaImageResponse>(
       `/images/${process.env.FIGMA_FILE}?format=svg&ids=${ids.join(',')}`,
       {
@@ -85,6 +88,7 @@ export default class FigmaApiClient {
   public downloadImage(url: string): AxiosPromise
   {
     // @ts-expect-error -- TODO: add types for axios
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
     return Axios({
       url,
       method: 'GET',
@@ -93,6 +97,7 @@ export default class FigmaApiClient {
   }
 
   public getNodeInfo(ids: string[]): Promise<AxiosPromise<FigmaNodeResponse>> {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
     return this.httpClient.get(
       `/files/${process.env.FIGMA_FILE}?ids=${ids.join(',')}`,
       {

--- a/packages/icon-kit/src/figma/index.ts
+++ b/packages/icon-kit/src/figma/index.ts
@@ -55,6 +55,7 @@ export type Meta = {
 }
 
 export default class FigmaApiClient {
+  // @ts-expect-error -- TODO: add types for axios
   httpClient = Axios.create({
     baseURL: 'https://api.figma.com/v1',
   });
@@ -83,6 +84,7 @@ export default class FigmaApiClient {
 
   public downloadImage(url: string): AxiosPromise
   {
+    // @ts-expect-error -- TODO: add types for axios
     return Axios({
       url,
       method: 'GET',
@@ -101,6 +103,7 @@ export default class FigmaApiClient {
 
   private getHeaders(): AxiosRequestHeaders {
     return {
+      // @ts-expect-error -- TODO: add types for axios
       'X-Figma-Token': process.env.FIGMA_TOKEN,
     };
   }

--- a/packages/icon-kit/src/figma/util/index.ts
+++ b/packages/icon-kit/src/figma/util/index.ts
@@ -1,5 +1,5 @@
-import type {Icon, IconMode, Meta, node} from '../index';
-import FigmaApiClient, {IconSize} from '../index';
+import type {Icon, IconMode, Meta, node} from '../index.js';
+import FigmaApiClient, {IconSize} from '../index.js';
 
 export default class FigmaUtil {
   public async buildIconMap(document: node): Promise<Map<string, Icon>> {
@@ -19,7 +19,9 @@ export default class FigmaUtil {
       Object.keys(svgs.images).forEach((nodeId) => {
         const node = chunk.find(n => n.id === nodeId);
 
+        // @ts-expect-error - we know that node is defined
         iconMap.set(node.name, {
+          // @ts-expect-error - we know that value is defined
           image: svgs.images[nodeId],
           nodeId: nodeId,
         });
@@ -30,6 +32,7 @@ export default class FigmaUtil {
 
     const components: node[] = (await client.getNodeInfo(nodeIds)).data.components;
     Object.values(components).forEach((component: node) => {
+      // @ts-expect-error - we know that value is defined
       iconMap.set(component.name, {
         ...iconMap.get(component.name),
         description: component.description,
@@ -44,7 +47,9 @@ export default class FigmaUtil {
     const sizes = ['s', 'xs', 'xxs'];
     const modes = ['regular', 'solid'];
     Array.from(iconMap.keys()).forEach(key => {
+      // @ts-expect-error - we know that key.split('/')[2] is defined
       const name: string = key.split('/')[2];
+      // @ts-expect-error - we know that key.split('/')[1] is defined
       const mode: string = key.split('/')[1];
       let size: string = IconSize.DEFAULT;
       let basename: string = name;
@@ -60,6 +65,7 @@ export default class FigmaUtil {
       });
 
       // Extract tags from the description
+      // @ts-expect-error -- we know that iconMap.get(key) is defined
       const description: string = (iconMap.get(key).description.split('🔎')[1] || '').split('\n')[0].trim();
       let tags: string[] = [];
       if (description.startsWith('[') && description.endsWith(']')) {
@@ -103,12 +109,15 @@ export default class FigmaUtil {
     metas.forEach((meta: Meta, key: number) => {
       meta.tags.forEach((tag: string) => {
         metas.forEach((secondMeta: Meta, secondKey: number) => {
+          // @ts-expect-error - we know that metas[key].tags is defined
           if (metas[secondKey].tags.includes(tag)) {
+            // @ts-expect-error - we know that metas[key].related is defined
             metas[key].related.push(secondMeta.name);
           }
         });
       });
       // Make unique items
+      // @ts-expect-error - we know that related is defined
       metas[key].related = [...new Set(metas[key].related)];
     });
 

--- a/packages/icon-kit/src/index.ts
+++ b/packages/icon-kit/src/index.ts
@@ -56,7 +56,7 @@ client.getFile().then(async (response) => {
 
       // Remove width/height from SVGs
       const optimizedSvgResult = optimize(svg, {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+         
         plugins: [
           {name: 'removeDimensions'},
           {

--- a/packages/icon-kit/src/index.ts
+++ b/packages/icon-kit/src/index.ts
@@ -1,12 +1,13 @@
-import type {Icon} from './figma';
-import FigmaApiClient from './figma';
-import FigmaUtil from './figma/util';
+import type {Icon} from './figma/index.js';
+import FigmaApiClient from './figma/index.js';
+import FigmaUtil from './figma/util/index.js';
 import * as fse from 'fs-extra';
 import chalk from 'chalk';
 import * as cliProgress from 'cli-progress';
 import type {OptimizedSvg} from 'svgo';
 import {optimize} from 'svgo';
 import md5 from 'js-md5';
+import fs from 'node:fs';
 import {PromisePool} from '@supercharge/promise-pool';
 // @ts-expect-error - this dependency has no type definitions
 import * as svgoAutocrop from 'svgo-autocrop';
@@ -19,14 +20,16 @@ const util = new FigmaUtil();
 
 console.log(chalk.green('Clean up...'));
 
-fse.removeSync(`${__dirname}/../icons`);
+fs.rmSync(`${import.meta.dirname}/../icons`, {recursive: true, force: true});
 
 console.log(chalk.green('Fetching Figma file stand by...'));
 
 client.getFile().then(async (response) => {
+  // @ts-expect-error -- TODO: add types for figma response
   const iconOverview = response.data.document.children.find(node => node.id === '217:6');
 
   console.log(chalk.green('Gathering icons...'));
+  // @ts-expect-error -- TODO: add types for iconMap
   const iconMap = await util.buildIconMap(iconOverview);
   const meta = util.buildMeta(iconMap);
 
@@ -45,6 +48,7 @@ client.getFile().then(async (response) => {
       bar.update(pool.processedItems().length);
     })
     .process(async (iconName: string) => {
+      // @ts-expect-error -- TODO: add types for iconMap
       const icon: Icon = iconMap.get(iconName);
 
       const result = await client.downloadImage(icon.image);
@@ -77,14 +81,16 @@ client.getFile().then(async (response) => {
 
         styling.push({
           name: className,
+          // @ts-expect-error - we know that viewBox is defined
           width,
+          // @ts-expect-error - we know that viewBox is defined
           height,
         });
       } else {
         console.log(chalk.red(`Could not find viewBox for ${iconName}`));
       }
 
-      fse.outputFileSync(`${__dirname}/../${iconName}.svg`, optimizedSvg);
+      fse.outputFileSync(`${import.meta.dirname}/../${iconName}.svg`, optimizedSvg);
     });
 
   bar.stop();
@@ -105,12 +111,12 @@ client.getFile().then(async (response) => {
   scssFileContent += '}\n';
 
    
-  fse.outputFileSync(`${__dirname}/../icons/meteor-icon-kit-${md5(styling)}.css`, cssFileContent);
+  fse.outputFileSync(`${import.meta.dirname}/../icons/meteor-icon-kit-${md5(styling)}.css`, cssFileContent);
    
-  fse.outputFileSync(`${__dirname}/../icons/meteor-icon-kit.scss`, scssFileContent);
+  fse.outputFileSync(`${import.meta.dirname}/../icons/meteor-icon-kit.scss`, scssFileContent);
 
   console.log(chalk.green('Writing metadata'));
-  fse.outputFileSync(`${__dirname}/../icons/meta.json`, JSON.stringify(meta));
+  fse.outputFileSync(`${import.meta.dirname}/../icons/meta.json`, JSON.stringify(meta));
 
   console.log(chalk.green('All done!'));
   //});

--- a/packages/icon-kit/tsconfig.json
+++ b/packages/icon-kit/tsconfig.json
@@ -6,7 +6,6 @@
     "allowSyntheticDefaultImports": true,
     "target": "es6",
     "noImplicitAny": true,
-    "skipLibCheck": true,
     "moduleResolution": "node",
     "outDir": "dist",
     "baseUrl": ".",

--- a/packages/icon-kit/tsconfig.json
+++ b/packages/icon-kit/tsconfig.json
@@ -1,15 +1,24 @@
 {
   "compilerOptions": {
-    "module": "ES2022",
-    "skipLibCheck": true,
+    /* Base Options: */
     "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true,
-    "target": "es6",
-    "noImplicitAny": true,
-    "moduleResolution": "node",
+    "skipLibCheck": true,
+    "target": "es2022",
+    "allowJs": true,
+    "resolveJsonModule": true,
+    "moduleDetection": "force",
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+
+    /* If transpiling with TypeScript: */
+    "module": "NodeNext",
     "outDir": "dist",
-    "baseUrl": ".",
-    "allowJs": true
+    "sourceMap": true,
+
+    "lib": ["es2022"]
   },
-  "include": ["src/**/*", "./eslint.config.mjs"]
+  "include": ["src/**/*"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -613,13 +613,13 @@ importers:
         version: 1.1.1
       ts-node:
         specifier: ^10.8.1
-        version: 10.9.2(@swc/core@1.6.1)(@types/node@20.17.19)(typescript@4.9.5)
+        version: 10.9.2(@swc/core@1.6.1)(@types/node@20.17.19)(typescript@5.7.3)
       typescript:
-        specifier: ^4.6.3
-        version: 4.9.5
+        specifier: ^5.7.0
+        version: 5.7.3
       typescript-eslint:
         specifier: ^8.24.1
-        version: 8.24.1(eslint@9.21.0(jiti@1.21.7))(typescript@4.9.5)
+        version: 8.24.1(eslint@9.21.0(jiti@1.21.7))(typescript@5.7.3)
 
   packages/prettier-config:
     devDependencies:
@@ -19698,23 +19698,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@8.24.1(@typescript-eslint/parser@8.24.1(eslint@9.21.0(jiti@1.21.7))(typescript@4.9.5))(eslint@9.21.0(jiti@1.21.7))(typescript@4.9.5)':
-    dependencies:
-      '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.24.1(eslint@9.21.0(jiti@1.21.7))(typescript@4.9.5)
-      '@typescript-eslint/scope-manager': 8.24.1
-      '@typescript-eslint/type-utils': 8.24.1(eslint@9.21.0(jiti@1.21.7))(typescript@4.9.5)
-      '@typescript-eslint/utils': 8.24.1(eslint@9.21.0(jiti@1.21.7))(typescript@4.9.5)
-      '@typescript-eslint/visitor-keys': 8.24.1
-      eslint: 9.21.0(jiti@1.21.7)
-      graphemer: 1.4.0
-      ignore: 5.3.1
-      natural-compare: 1.4.0
-      ts-api-utils: 2.0.1(typescript@4.9.5)
-      typescript: 4.9.5
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/eslint-plugin@8.24.1(@typescript-eslint/parser@8.24.1(eslint@9.21.0(jiti@1.21.7))(typescript@5.4.5))(eslint@9.21.0(jiti@1.21.7))(typescript@5.4.5)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
@@ -19770,18 +19753,6 @@ snapshots:
       debug: 4.4.0
       eslint: 9.20.1(jiti@1.21.7)
       typescript: 5.7.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/parser@8.24.1(eslint@9.21.0(jiti@1.21.7))(typescript@4.9.5)':
-    dependencies:
-      '@typescript-eslint/scope-manager': 8.24.1
-      '@typescript-eslint/types': 8.24.1
-      '@typescript-eslint/typescript-estree': 8.24.1(typescript@4.9.5)
-      '@typescript-eslint/visitor-keys': 8.24.1
-      debug: 4.4.0
-      eslint: 9.21.0(jiti@1.21.7)
-      typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
 
@@ -19844,17 +19815,6 @@ snapshots:
       eslint: 9.20.1(jiti@1.21.7)
       ts-api-utils: 2.0.1(typescript@5.7.3)
       typescript: 5.7.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/type-utils@8.24.1(eslint@9.21.0(jiti@1.21.7))(typescript@4.9.5)':
-    dependencies:
-      '@typescript-eslint/typescript-estree': 8.24.1(typescript@4.9.5)
-      '@typescript-eslint/utils': 8.24.1(eslint@9.21.0(jiti@1.21.7))(typescript@4.9.5)
-      debug: 4.4.0
-      eslint: 9.21.0(jiti@1.21.7)
-      ts-api-utils: 2.0.1(typescript@4.9.5)
-      typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
 
@@ -19931,20 +19891,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@8.24.1(typescript@4.9.5)':
-    dependencies:
-      '@typescript-eslint/types': 8.24.1
-      '@typescript-eslint/visitor-keys': 8.24.1
-      debug: 4.4.0
-      fast-glob: 3.3.2
-      is-glob: 4.0.3
-      minimatch: 9.0.4
-      semver: 7.6.2
-      ts-api-utils: 2.0.1(typescript@4.9.5)
-      typescript: 4.9.5
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/typescript-estree@8.24.1(typescript@5.4.5)':
     dependencies:
       '@typescript-eslint/types': 8.24.1
@@ -20018,17 +19964,6 @@ snapshots:
       '@typescript-eslint/typescript-estree': 8.24.1(typescript@5.7.3)
       eslint: 9.20.1(jiti@1.21.7)
       typescript: 5.7.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/utils@8.24.1(eslint@9.21.0(jiti@1.21.7))(typescript@4.9.5)':
-    dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@9.21.0(jiti@1.21.7))
-      '@typescript-eslint/scope-manager': 8.24.1
-      '@typescript-eslint/types': 8.24.1
-      '@typescript-eslint/typescript-estree': 8.24.1(typescript@4.9.5)
-      eslint: 9.21.0(jiti@1.21.7)
-      typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
 
@@ -30326,10 +30261,6 @@ snapshots:
     dependencies:
       typescript: 5.7.3
 
-  ts-api-utils@2.0.1(typescript@4.9.5):
-    dependencies:
-      typescript: 4.9.5
-
   ts-api-utils@2.0.1(typescript@5.4.5):
     dependencies:
       typescript: 5.4.5
@@ -30433,7 +30364,7 @@ snapshots:
       '@swc/core': 1.6.1
     optional: true
 
-  ts-node@10.9.2(@swc/core@1.6.1)(@types/node@20.17.19)(typescript@4.9.5):
+  ts-node@10.9.2(@swc/core@1.6.1)(@types/node@20.17.19)(typescript@5.7.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
@@ -30447,7 +30378,7 @@ snapshots:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 4.9.5
+      typescript: 5.7.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     optionalDependencies:
@@ -30477,7 +30408,7 @@ snapshots:
       resolve-import: 2.0.0
       rimraf: 6.0.1
       sync-content: 2.0.1
-      typescript: 5.7.2
+      typescript: 5.7.3
       walk-up-path: 4.0.0
 
   tslib@1.14.1: {}
@@ -30632,16 +30563,6 @@ snapshots:
       '@typescript-eslint/utils': 8.24.1(eslint@9.20.1(jiti@1.21.7))(typescript@5.7.3)
       eslint: 9.20.1(jiti@1.21.7)
       typescript: 5.7.3
-    transitivePeerDependencies:
-      - supports-color
-
-  typescript-eslint@8.24.1(eslint@9.21.0(jiti@1.21.7))(typescript@4.9.5):
-    dependencies:
-      '@typescript-eslint/eslint-plugin': 8.24.1(@typescript-eslint/parser@8.24.1(eslint@9.21.0(jiti@1.21.7))(typescript@4.9.5))(eslint@9.21.0(jiti@1.21.7))(typescript@4.9.5)
-      '@typescript-eslint/parser': 8.24.1(eslint@9.21.0(jiti@1.21.7))(typescript@4.9.5)
-      '@typescript-eslint/utils': 8.24.1(eslint@9.21.0(jiti@1.21.7))(typescript@4.9.5)
-      eslint: 9.21.0(jiti@1.21.7)
-      typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
## What?

This PR fixes the icon kit script.

## Why?

I changed the tsconfig.json while upgrading the icon kit to ESLint v9. That caused the icon kit to fail. 

## How?

I updated the tsconfig, so the build script works and we can execute the script.

## Testing?

I tested the script locally, once we merge it we can sync the new icons from Figma to this repo.

## Anything Else?

I also upgraded Typescript from v4 to v5 for the icon kit.
