### PR TITLE
Fix provenance for prettier config

### DIFF
--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -2,6 +2,10 @@
   "name": "@shopware-ag/meteor-prettier-config",
   "version": "1.0.0",
   "description": "Prettier configuration for Shopware projects",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/shopware/meteor"
+  },
   "type": "module",
   "exports": "./index.js",
   "license": "MIT",


### PR DESCRIPTION
## What?

This PR fixes the failing provenance check in our release pipeline.

## Why?

Provenance proofs that the package is really coming from us, and not a potentially malicious developer.

## How?

I updated the `repository.url` config for the `@shopware-ag/meteor-prettier-config` package.

## Testing?

The only wait to test it is to merge it and wait for the next release.
