### PR TITLE
Allow dynamic content for slots

### DIFF
--- a/.changeset/angry-lies-grab.md
+++ b/.changeset/angry-lies-grab.md
@@ -1,0 +1,13 @@
+---
+"@shopware-ag/meteor-component-library": minor
+---
+
+Allow rendering HTML and Vue components in `mt-helptext`
+
+You can use the `default` slot to render dynamic content for helptexts.
+
+```html
+<mt-help-text>
+  <p style="text-decoration: underline">My content</p>
+</mt-help-text>
+```

--- a/.changeset/chilly-snails-sneeze.md
+++ b/.changeset/chilly-snails-sneeze.md
@@ -1,0 +1,19 @@
+---
+"@shopware-ag/meteor-component-library": minor
+---
+
+Add `content` slot to `mt-tooltip`
+
+You can now add HTML elements and Vue components to the mt-tooltip component.
+
+```html
+<mt-tooltip>
+    <template #default="props">
+        <button v-bind="props">Open tooltip</button>
+    </template>
+
+    <template #content>
+        <p style="text-decoration: underline">My custom content</p>
+    </template>
+</mt-toolip>
+```

--- a/.changeset/few-rats-swim.md
+++ b/.changeset/few-rats-swim.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": minor
+---
+
+Add helpText slot to mt-textarea

--- a/.changeset/new-feet-repair.md
+++ b/.changeset/new-feet-repair.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": minor
+---
+
+Add helpText slot to mt-url-field

--- a/.changeset/thick-ghosts-fold.md
+++ b/.changeset/thick-ghosts-fold.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": minor
+---
+
+Add helpText slot to mt-text-field

--- a/packages/component-library/src/components/form/_internal/mt-base-field/mt-base-field.vue
+++ b/packages/component-library/src/components/form/_internal/mt-base-field/mt-base-field.vue
@@ -26,11 +26,13 @@
       </label>
 
       <mt-help-text
-        v-if="helpText"
+        v-if="helpText || $slots.helpText"
         class="mt-field__help-text"
         :text="helpText"
         placement="right"
-      />
+      >
+        <slot name="helpText" />
+      </mt-help-text>
     </div>
 
     <div class="mt-block-field__block">

--- a/packages/component-library/src/components/form/mt-help-text/mt-help-text.spec.ts
+++ b/packages/component-library/src/components/form/mt-help-text/mt-help-text.spec.ts
@@ -61,4 +61,47 @@ describe("mt-help-text", () => {
     // ASSERT
     expect(screen.getByRole("button")).toHaveStyle("color: rgb(255, 0, 0)");
   });
+
+  it("prefers the text prop over the default slot", async () => {
+    // ARRANGE
+    render(MtHelpText, {
+      props: { text: "Some text" },
+      slots: {
+        default: "<p data-testid='tooltip-content'>My content</p>",
+      },
+    });
+
+    const user = userEvent.setup({
+      advanceTimers: vi.advanceTimersByTime,
+    });
+
+    // ACT
+    await user.tab();
+
+    // ASSERT
+    expect(screen.getByRole('tooltip')).toBeVisible();
+
+    expect(screen.queryByTestId("tooltip-content")).not.toBeInTheDocument();
+    expect(screen.getByRole("tooltip")).toHaveTextContent("Some text");
+  });
+
+  it("renders html content", async () => {
+    // ARRANGE
+    render(MtHelpText, {
+      slots: {
+        default: "<p data-testid='tooltip-content'>Some text</p>",
+      }
+    });
+
+    const user = userEvent.setup({
+      advanceTimers: vi.advanceTimersByTime,
+    });
+
+    // ACT
+    await user.tab();
+
+    // ASSERT
+    expect(screen.getByTestId("tooltip-content")).toBeVisible();
+    expect(screen.getByTestId("tooltip-content")).toHaveTextContent("Some text");
+  });
 });

--- a/packages/component-library/src/components/form/mt-help-text/mt-help-text.vue
+++ b/packages/component-library/src/components/form/mt-help-text/mt-help-text.vue
@@ -9,6 +9,10 @@
         />
       </button>
     </template>
+
+    <template #content>
+      <slot />
+    </template>
   </mt-tooltip>
 </template>
 
@@ -30,6 +34,10 @@ withDefaults(
     hideDelay: 100,
   },
 );
+
+defineSlots<{
+  default?(): any
+}>()
 </script>
 
 <style scoped>

--- a/packages/component-library/src/components/form/mt-text-field/mt-text-field.spec.ts
+++ b/packages/component-library/src/components/form/mt-text-field/mt-text-field.spec.ts
@@ -18,4 +18,22 @@ describe("mt-text-field", () => {
     // ASSERT
     expect(screen.getByRole("tooltip")).toBeVisible();
   });
+
+  it("displays a helptext with html content", async () => {
+    // ARRANGE
+    render(MtTextField, {
+      slots: {
+        helpText: "<p data-testid='tooltip-content'>Some text</p>",
+      },
+    });
+
+    // ACT
+    await userEvent.tab();
+
+    // ASSERT
+    expect(screen.getByRole("tooltip")).toBeVisible();
+    expect(screen.getByRole("tooltip")).toHaveTextContent("Some text");
+
+    expect(screen.getByTestId("tooltip-content")).toBeVisible();
+  });
 });

--- a/packages/component-library/src/components/form/mt-text-field/mt-text-field.spec.ts
+++ b/packages/component-library/src/components/form/mt-text-field/mt-text-field.spec.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/vue";
+import MtTextField from "./mt-text-field.vue";
+import userEvent from "@testing-library/user-event";
+
+describe("mt-text-field", () => {
+  it("displays a helptext", async () => {
+    // ARRANGE
+    render(MtTextField, {
+      props: {
+        helpText: "Helptext",
+      },
+    });
+
+    // ACT
+    await userEvent.tab();
+
+    // ASSERT
+    expect(screen.getByRole("tooltip")).toBeVisible();
+  });
+});

--- a/packages/component-library/src/components/form/mt-text-field/mt-text-field.vue
+++ b/packages/component-library/src/components/form/mt-text-field/mt-text-field.vue
@@ -20,6 +20,10 @@
       {{ label }}
     </template>
 
+    <template #helpText>
+      <slot name="helpText" />
+    </template>
+
     <template #field-prefix>
       <slot name="prefix" />
     </template>

--- a/packages/component-library/src/components/form/mt-textarea/mt-textarea.spec.ts
+++ b/packages/component-library/src/components/form/mt-textarea/mt-textarea.spec.ts
@@ -176,6 +176,24 @@ describe("mt-textarea", () => {
     expect(screen.getByRole("tooltip")).toHaveTextContent("Helptext");
   });
 
+  it("displays a helptext with html content", async () => {
+    // ARRANGE
+    render(MtTextarea, {
+      slots: {
+        helpText: "<p data-testid='tooltip-content'>Some text</p>",
+      },
+    });
+
+    // ACT
+    await userEvent.tab();
+
+    // ASSERT
+    expect(screen.getByRole("tooltip")).toBeVisible();
+    expect(screen.getByRole("tooltip")).toHaveTextContent("Some text");
+
+    expect(screen.getByTestId("tooltip-content")).toBeVisible();
+  });
+
   it("displays no helptext when none is specified", async () => {
     // ARRANGE
     render(MtTextarea);

--- a/packages/component-library/src/components/form/mt-textarea/mt-textarea.vue
+++ b/packages/component-library/src/components/form/mt-textarea/mt-textarea.vue
@@ -22,10 +22,12 @@
     </mt-field-label>
 
     <mt-help-text
-      v-if="!!helpText"
+      v-if="!!helpText || $slots.helpText"
       :text="helpText"
       :style="{ gridArea: 'help-text', justifySelf: 'end' }"
-    />
+    >
+      <slot name="helpText" />
+    </mt-help-text>
 
     <textarea
       v-model="model"
@@ -95,6 +97,11 @@ defineProps<{
   maxLength?: number;
   isInherited?: boolean;
   isInheritanceField?: boolean;
+}>();
+
+const slots = defineSlots<{
+  helpText?(): any;
+  hint?(): any;
 }>();
 </script>
 

--- a/packages/component-library/src/components/form/mt-url-field/mt-url-field.spec.ts
+++ b/packages/component-library/src/components/form/mt-url-field/mt-url-field.spec.ts
@@ -161,6 +161,24 @@ describe("mt-url-field", () => {
     expect(screen.getByRole("tooltip")).toHaveTextContent("This is a helptext");
   });
 
+  it("renders a helptext with html content", async () => {
+    // ARRANGE
+    render(MtUrlField, {
+      slots: {
+        helpText: "<p data-testid='tooltip-content'>Some text</p>",
+      },
+    });
+
+    // ACT
+    await userEvent.tab();
+
+    // ASSERT
+    expect(screen.getByRole("tooltip")).toBeVisible();
+    expect(screen.getByRole("tooltip")).toHaveTextContent("Some text");
+
+    expect(screen.getByTestId("tooltip-content")).toBeVisible();
+  });
+
   it("does not change the value when the field is disabled and the user types", async () => {
     // ARRANGE
     const handler = vi.fn();

--- a/packages/component-library/src/components/form/mt-url-field/mt-url-field.vue
+++ b/packages/component-library/src/components/form/mt-url-field/mt-url-field.vue
@@ -25,7 +25,9 @@
       {{ label }}
     </mt-field-label>
 
-    <mt-help-text v-if="!!helpText" :text="helpText" :style="{ gridArea: 'help-text' }" />
+    <mt-help-text v-if="!!helpText || $slots.helpText" :text="helpText" :style="{ gridArea: 'help-text' }">
+      <slot name="helpText" />
+    </mt-help-text>
 
     <div
       :class="[
@@ -149,9 +151,10 @@ defineEmits<{
   "inheritance-restore": [];
 }>();
 
-defineSlots<{
+const slots = defineSlots<{
   suffix?(): void;
   hint?(): void;
+  helpText?(): void;
 }>();
 
 const modelValue = defineModel({

--- a/packages/component-library/src/components/overlay/mt-tooltip/mt-tooltip.interactive.stories.ts
+++ b/packages/component-library/src/components/overlay/mt-tooltip/mt-tooltip.interactive.stories.ts
@@ -42,3 +42,10 @@ export const VisualTestTooltipLeft = {
     placement: "left",
   },
 };
+
+export const VisualTestTooltipCustomHTML = {
+  name: "Tooltip with custom HTML",
+  args: {
+    content: "<p style='text-decoration: underline;'>This is a custom tooltip</p>",
+  },
+};

--- a/packages/component-library/src/components/overlay/mt-tooltip/mt-tooltip.spec.ts
+++ b/packages/component-library/src/components/overlay/mt-tooltip/mt-tooltip.spec.ts
@@ -1121,4 +1121,69 @@ describe("mt-tooltip", () => {
     // ASSERT
     expect(screen.getByRole("tooltip", { name: "Tooltip" })).toBeVisible();
   });
+
+  it("shows the content via a slot", async () => {
+    // ARRANGE
+    render({
+      template: `
+<mt-tooltip>
+  <template #default="params">
+    <mt-button v-bind="params">Open tooltip</mt-button>
+  </template>
+
+  <template #content>
+    <p data-testid="tooltip-content">This is a custom tooltip</p>
+  </template>
+</mt-tooltip>`,
+      components: {
+        MtTooltip,
+        MtButton,
+      },
+    });
+
+    const user = userEvent.setup({
+      advanceTimers: vi.advanceTimersByTime,
+    });
+
+    // ACT
+    await user.tab();
+
+    // ASSERT
+    expect(screen.getByRole("tooltip")).toBeVisible();
+
+    expect(screen.getByTestId("tooltip-content")).toBeVisible();
+  });
+
+  it("shows prefers the content of the prop over the slot", async () => {
+    // ARRANGE
+    render({
+        template: `
+<mt-tooltip content="Tooltip">
+  <template #default="params">
+    <mt-button v-bind="params">Open tooltip</mt-button>
+  </template>
+
+  <template #content>
+    <p data-testid="tooltip-content">This is a custom tooltip</p>
+  </template>
+</mt-tooltip>`,
+      components: {
+        MtTooltip,
+        MtButton,
+      },
+    });
+
+    const user = userEvent.setup({
+      advanceTimers: vi.advanceTimersByTime,
+    });
+
+    // ACT
+    await user.tab();
+
+    // ASSERT
+    expect(screen.getByRole("tooltip")).toBeVisible();
+
+    expect(screen.queryByTestId("tooltip-content")).not.toBeInTheDocument();
+  });
 });
+

--- a/packages/component-library/src/components/overlay/mt-tooltip/mt-tooltip.vue
+++ b/packages/component-library/src/components/overlay/mt-tooltip/mt-tooltip.vue
@@ -34,7 +34,9 @@
         @mouseover="setState({ isHoveringTooltip: true })"
         @mouseleave="onMouseLeaveTooltip"
       >
-        <span>{{ content }}</span>
+        <span v-if="content">{{ content }}</span>
+
+        <slot v-else name="content" />
 
         <svg
           aria-hidden="true"


### PR DESCRIPTION
## What?

This makes it possible to render HTML elements or Vue.js components inside helptexts and tooltips.

## Why?

A lot of times we have more complex content inside our tooltips like links or formatted text.

## How?

I added slots for the `mt-tooltip`, `mt-helptext` and every other form component that has help texts

## Testing?

I've written quite a handful of unit tests to make sure the new slots works as intended.
