### PR TITLE
fix(component-library): change display mode of mt-button to inline-grid

### DIFF
--- a/.changeset/proud-worms-bake.md
+++ b/.changeset/proud-worms-bake.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": patch
+---
+
+Change display mode of mt-button to inline-grid

--- a/packages/component-library/src/components/form/mt-button/mt-button.vue
+++ b/packages/component-library/src/components/form/mt-button/mt-button.vue
@@ -95,7 +95,7 @@ const isInsideTooltip = useIsInsideTooltip();
 <style lang="css" scoped>
 .mt-button {
   transition: all 0.15s ease-out;
-  display: grid;
+  display: inline-grid;
   place-items: center;
   width: max-content;
   border-radius: var(--border-radius-button);


### PR DESCRIPTION
## What?

This PR fixes a regression regarding the button component.

## Why?

I implemented a change to center the content of buttons using display grid, but that broke things.

## How?

I changed the display mode from `grid` to `inline-grid`

## Testing?

