### PR TITLE
fix: password flickering on submit

### DIFF
--- a/.changeset/clear-suits-sneeze.md
+++ b/.changeset/clear-suits-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": minor
+---
+
+Fix password flickering and add submit event for `mt-password-field.vue` component.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ accessible experiences. There are no limits to your imagination.
 
 This repository contains all project related to the Meteor Design System used and maintained by shopware and it's contributors.
 
-```
+```shell
 meteor/
 ├── docs
 │   └── admin-sdk               # Documentation about the Meteor Admin SDK

--- a/packages/component-library/README.md
+++ b/packages/component-library/README.md
@@ -15,7 +15,7 @@ You need a working **Vue 3 application** with the **i18n plugin** for the transl
 
 Add this package to your project:
 
-```
+```cli
 npm i @shopware-ag/meteor-component-library
 ```
 
@@ -46,37 +46,37 @@ These guides are useful if you want to contribute this component library.
 
 ### Project setup
 
-```
+```shell
 pnpm install
 ```
 
 #### Compiles and hot-reloads for development
 
-```
+```shell
 pnpm run storybook
 ```
 
 #### Compiles and minifies for production
 
-```
+```shell
 pnpm run build:storybook
 ```
 
 #### Run your interaction tests (running Storybook instance is needed)
 
-```
+```shell
 pnpm run test:storybook
 ```
 
 #### Lints and fixes files
 
-```
+```shell
 pnpm run lint:all
 ```
 
 #### Build the bundled component library
 
-```
+```shell
 pnpm run build
 ```
 

--- a/packages/component-library/src/components/form/mt-password-field/mt-password-field.vue
+++ b/packages/component-library/src/components/form/mt-password-field/mt-password-field.vue
@@ -42,7 +42,7 @@
 
     <mt-field-error v-if="!!error" :error="error" />
 
-    <div class="mt-password-field__hint">
+    <div v-if="$slots.hint" class="mt-password-field__hint">
       <slot name="hint" />
     </div>
   </div>
@@ -81,9 +81,9 @@ defineEmits<{
 }>();
 
 defineSlots<{
-  prefix?;
-  suffix?;
-  hint?;
+  prefix?: unknown;
+  suffix?: unknown;
+  hint?: unknown;
 }>();
 
 const id = useId();

--- a/packages/component-library/src/components/form/mt-password-field/mt-password-field.vue
+++ b/packages/component-library/src/components/form/mt-password-field/mt-password-field.vue
@@ -13,6 +13,7 @@
         v-model="model"
         class="mt-password-field__input"
         @change="$emit('change', model)"
+        @keyup.enter="$emit('submit')"
         :type="showPassword ? 'text' : 'password'"
         :id="id"
         :placeholder="placeholder"
@@ -22,7 +23,8 @@
 
       <button
         v-if="toggable"
-        @click="showPassword = !showPassword"
+        type="button"
+        @click.prevent="showPassword = !showPassword"
         class="mt-password-field__visibility-toggle"
         :aria-label="showPassword ? t('hidePassword') : t('showPassword')"
         :disabled="disabled"
@@ -75,12 +77,13 @@ withDefaults(
 
 defineEmits<{
   (e: "change", value: string | undefined): void;
+  (e: "submit"): void;
 }>();
 
 defineSlots<{
-  prefix?: void;
-  suffix?: void;
-  hint?: void;
+  prefix?;
+  suffix?;
+  hint?;
 }>();
 
 const id = useId();


### PR DESCRIPTION
## What?
- Key ENTER will throw a submit event on the input password
- Added `click.prevent` to not toggle button on bubble

## Why?
https://github.com/shopware/shopware/issues/7523

## How?

## Testing?
- We need this PR merged
- And [the one](https://github.com/shopware/shopware/pull/7664) in the Platform to make everything work

## Screenshots (optional)

## Anything Else?
- I think it is a security issue to have all the JS (from every plugin/app) on the login page
