### PR TITLE
ci: remove auto commit after static analysis

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,12 +58,6 @@ jobs:
       - name: Perform typecheck
         run: pnpx turbo run lint:types
 
-      - name: Commit changes
-        if: always() && ${{ github.event.pull_request.head.repo.full_name == 'shopware/meteor' }}
-        uses: stefanzweifel/git-auto-commit-action@v5
-        with:
-          commit_message: "Apply code formatting and fixable ESLint issues"
-
   unit-tests:
     name: Unit tests
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What?

Remove the auto-commit action in the static analysis job.

## Why?

It creates more issues that it tries to solve.

## How?

I just removed the auto-commit action.

## Testing?

To test that, we would need to add a fixable linting error to the codebase and see if the PR does not automatically add a new commit.
