### PR TITLE
build(component-library): get rid of node in storybook config

### DIFF
--- a/packages/component-library/.storybook/main.ts
+++ b/packages/component-library/.storybook/main.ts
@@ -1,23 +1,18 @@
-import { dirname, join } from "path";
 import type { StorybookConfig } from "@storybook/vue3-vite";
 
 const config: StorybookConfig = {
   stories: ["../src/**/*.mdx", "../src/**/*.stories.@(js|jsx|mjs|ts|tsx)"],
   addons: [
-    getAbsolutePath("@storybook/addon-links"),
-    getAbsolutePath("@storybook/addon-essentials"),
-    getAbsolutePath("@storybook/addon-interactions"),
-    getAbsolutePath("storybook-dark-mode"),
-    getAbsolutePath("@storybook/addon-a11y"),
+    "@storybook/addon-links",
+    "@storybook/addon-essentials",
+    "@storybook/addon-interactions",
+    "storybook-dark-mode",
+    "@storybook/addon-a11y",
   ],
   framework: {
-    name: getAbsolutePath("@storybook/vue3-vite"),
+    name: "@storybook/vue3-vite",
     options: {},
   },
   docs: {},
 };
 export default config;
-
-function getAbsolutePath(value: string): any {
-  return dirname(require.resolve(join(value, "package.json")));
-}


### PR DESCRIPTION
## What?

This PR simplifies the Storybook config.

## Why?

This simplifies the storybook configuration. Storybook is also able to load the Add-ons just by a string value.

Additionally, there's an issue when you're on node v23. When you want to start Storybook it fails because it can't find require

## How?

I just removed the `getAbsolutePath` function

## Testing?

I did some manual testing to make sure things work the same.
