### PR TITLE
added label slot to the mt-checkbox component

### DIFF
--- a/.changeset/many-cars-join.md
+++ b/.changeset/many-cars-join.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": minor
+---
+
+Added label slot to mt-checkbox

--- a/packages/component-library/src/components/form/mt-checkbox/mt-checkbox.vue
+++ b/packages/component-library/src/components/form/mt-checkbox/mt-checkbox.vue
@@ -29,7 +29,9 @@
           @inheritance-remove="$emit('inheritance-remove', $event)"
         >
           <template #label>
-            {{ label }}
+            <slot name="label">
+              {{ label }}
+            </slot>
           </template>
         </mt-base-field>
       </div>


### PR DESCRIPTION
## What?

Added label slot to the mt-checkbox component to be able to provide complex templates where simple label is not enough.

## Why?

It's needed to fix https://github.com/shopware/shopware/issues/7471

## How?

## Testing?

```
<mt-checkbox ... >
    <template #label>
         <a href="#">Custom link</a>
    </template>
</mt-checkbox>
```

## Screenshots (optional)

## Anything Else?
