### PR TITLE
ci: clear snapshot directory before executing tests

### DIFF
--- a/.github/workflows/visual-tests.yml
+++ b/.github/workflows/visual-tests.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Build storybook
         run: pnpm --filter @shopware-ag/meteor-component-library run build:storybook --test
 
+      - name: Clear snapshot directory
+        run: rm -rf ./packages/component-library/__snapshots__/*
+
       - name: Run Tests
         if: ${{ github.event_name != 'workflow_dispatch' }}
         run: |


### PR DESCRIPTION
## What?

## Why?

It happened a lot that some screenshots were outdated. This is an attempt to fix the issue. By clearing all snapshots before executing the visual tests.

## How?

## Testing?

## Screenshots (optional)

## Anything Else?
