### PR TITLE
Migrate mt context menu divider

### DIFF
--- a/packages/component-library/src/components/context-menu/mt-context-menu-divider/mt-context-menu-divider.vue
+++ b/packages/component-library/src/components/context-menu/mt-context-menu-divider/mt-context-menu-divider.vue
@@ -11,11 +11,9 @@ export default defineComponent({
 </script>
 
 <style lang="scss">
-$mt-context-menu-color-border: $color-gray-300;
-
 .mt_context_menu_divider {
   border: none;
-  border-bottom: 1px solid $mt-context-menu-color-border;
+  border-bottom: 1px solid #d1d9e0;
   margin: 5px -10px;
 }
 </style>

--- a/packages/component-library/src/components/context-menu/mt-context-menu-divider/mt-context-menu-divider.vue
+++ b/packages/component-library/src/components/context-menu/mt-context-menu-divider/mt-context-menu-divider.vue
@@ -10,7 +10,7 @@ export default defineComponent({
 });
 </script>
 
-<style lang="scss">
+<style>
 .mt_context_menu_divider {
   border: none;
   border-bottom: 1px solid #d1d9e0;


### PR DESCRIPTION
## What?

This PR migrates the `mt-context-menu-divider` over to plain css.

## Why?

SCSS does not provide much, if even at all, value for us.

## How?

I migrated the SCSS to plain CSS.

## Testing?

If the visual tests pass everything is fine.