### PR TITLE
Migrate mt data table settings over to plain css

### DIFF
--- a/packages/component-library/src/components/table-and-list/mt-data-table/sub-components/mt-data-table-settings/mt-data-table-settings.vue
+++ b/packages/component-library/src/components/table-and-list/mt-data-table/sub-components/mt-data-table-settings/mt-data-table-settings.vue
@@ -234,7 +234,7 @@ export default defineComponent({
         return {
           id: column.property,
           label: column.label,
-          parentGroup: (column.visible ?? true) ? "visible" : "hidden",
+          parentGroup: column.visible ?? true ? "visible" : "hidden",
           position: column.position,
           isVisible: column.visible ?? true,
           isHidable: isPrimaryColumn(column) ? false : true,
@@ -302,8 +302,3 @@ export default defineComponent({
   },
 });
 </script>
-
-<style lang="scss">
-.mt-data-table-settings {
-}
-</style>


### PR DESCRIPTION
## What?

Removes the useless style tag from the `mt-data-table-settings` component.

## Why?

The styles for the component added some unnecessary size to the bundle output.

The component had a style tag with a single empty selector.

## How?

I just removed the style tag

## Testing?

If the visual tests pass, everything is ok.