### PR TITLE
Include dist in stylelint plugin

### DIFF
--- a/.changeset/plenty-drinks-exercise.md
+++ b/.changeset/plenty-drinks-exercise.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/stylelint-plugin-meteor": patch
+---
+
+Include dist directory in package

--- a/packages/stylelint-plugin-meteor/package.json
+++ b/packages/stylelint-plugin-meteor/package.json
@@ -6,6 +6,9 @@
     "url": "git+ssh://git@github.com:shopware/meteor.git"
   },
   "main": "./dist/commonjs/index.js",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tshy",
     "test:unit": "node --import tsx --test $(find . -name \"*.test.ts\")",


### PR DESCRIPTION
## What?

This PR includes the source code for the rules when releasing the package.

## Why?

Without this change, the plugin only works inside the monorepo. Teams weren't able to use this plugin outside of the monorepo. This was because the `dist` directory would not be published when releasing the package.

## How?

I included the `dist` directory in `files` option of the `package.json` file

## Testing?

I tested the changes using `yalc`. I was able to use the package inside another project.
