### PR TITLE
feat(stylelint-plugin-meteor): add auto-fixer for font-weights

### DIFF
--- a/.changeset/serious-snails-accept.md
+++ b/.changeset/serious-snails-accept.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/stylelint-plugin-meteor": minor
+---
+
+Add auto-fixer for font-weight properties

--- a/packages/stylelint-plugin-meteor/src/rules/prefer-font-token/index.ts
+++ b/packages/stylelint-plugin-meteor/src/rules/prefer-font-token/index.ts
@@ -37,6 +37,17 @@ const GLOBAL_KEYWORDS = [
   "normal",
 ];
 
+const FONT_WEIGHT_MAP: Record<string, string> = {
+  "400": "var(--font-weight-regular)",
+  "500": "var(--font-weight-medium)",
+  "600": "var(--font-weight-semibold)",
+  "700": "var(--font-weight-bold)",
+  "$font-weight-regular": "var(--font-weight-regular)",
+  "$font-weight-medium": "var(--font-weight-medium)",
+  "$font-weight-semibold": "var(--font-weight-semibold)",
+  "$font-weight-bold": "var(--font-weight-bold)",
+};
+
 const ruleFunction: Rule = (primary, secondaryOptions, context) => {
   return (root, result) => {
     const validOptions = validateOptions(result, ruleName, {
@@ -52,12 +63,20 @@ const ruleFunction: Rule = (primary, secondaryOptions, context) => {
       const isGlobalKeyword = GLOBAL_KEYWORDS.includes(ruleNode.value);
 
       if (isFontProperty && !usesVariable && !isGlobalKeyword) {
-        report({
-          message: messages.rejected(ruleNode.value, ruleNode.prop),
-          node: ruleNode,
-          result,
-          ruleName,
-        });
+        if (
+          context.fix &&
+          ruleNode.prop === "font-weight" &&
+          FONT_WEIGHT_MAP[ruleNode.value]
+        ) {
+          ruleNode.value = FONT_WEIGHT_MAP[ruleNode.value] as string;
+        } else {
+          report({
+            message: messages.rejected(ruleNode.value, ruleNode.prop),
+            node: ruleNode,
+            result,
+            ruleName,
+          });
+        }
       }
     });
   };

--- a/packages/stylelint-plugin-meteor/src/rules/prefer-font-token/prefer-font-token.test.ts
+++ b/packages/stylelint-plugin-meteor/src/rules/prefer-font-token/prefer-font-token.test.ts
@@ -2,6 +2,7 @@ import { testRule } from "stylelint-test-rule-node";
 import plugin from "./index.js";
 
 const {
+  // @ts-expect-error - Cannot infer type correctly
   rule: { ruleName },
 } = plugin;
 
@@ -9,6 +10,7 @@ testRule({
   plugins: [plugin],
   ruleName,
   config: true,
+  fix: true,
 
   accept: [
     { code: ".a { font-family: var(--font-family-body); }" },
@@ -31,6 +33,57 @@ testRule({
       column: 6,
       endLine: 1,
       endColumn: 25,
+      unfixable: true,
+    },
+    {
+      code: ".a { font-weight: 300; }",
+      message:
+        'Unexpected hard-coded value "300" for font-weight, please use a typography token (meteor/prefer-font-token)',
+      line: 1,
+      column: 6,
+      endLine: 1,
+      endColumn: 23,
+      unfixable: true,
+    },
+    {
+      code: ".a { font-weight: $font-weight-thin; }",
+      message:
+        'Unexpected hard-coded value "$font-weight-thin" for font-weight, please use a typography token (meteor/prefer-font-token)',
+      line: 1,
+      column: 6,
+      endLine: 1,
+      endColumn: 37,
+      unfixable: true,
+    },
+    {
+      code: ".a { font-weight: 400; }",
+      message:
+        'Unexpected hard-coded value "400" for font-weight, please use a typography token (meteor/prefer-font-token)',
+      line: 1,
+      column: 6,
+      endLine: 1,
+      endColumn: 23,
+      fixed: ".a { font-weight: var(--font-weight-regular); }",
+    },
+    {
+      code: ".a { font-weight: 500; }",
+      message:
+        'Unexpected hard-coded value "500" for font-weight, please use a typography token (meteor/prefer-font-token)',
+      line: 1,
+      column: 6,
+      endLine: 1,
+      endColumn: 23,
+      fixed: ".a { font-weight: var(--font-weight-medium); }",
+    },
+    {
+      code: ".a { font-weight: 600; }",
+      message:
+        'Unexpected hard-coded value "600" for font-weight, please use a typography token (meteor/prefer-font-token)',
+      line: 1,
+      column: 6,
+      endLine: 1,
+      endColumn: 23,
+      fixed: ".a { font-weight: var(--font-weight-semibold); }",
     },
     {
       code: ".a { font-weight: 700; }",
@@ -40,6 +93,47 @@ testRule({
       column: 6,
       endLine: 1,
       endColumn: 23,
+      fixed: ".a { font-weight: var(--font-weight-bold); }",
+    },
+    {
+      code: ".a { font-weight: $font-weight-regular; }",
+      message:
+        'Unexpected hard-coded value "$font-weight-regular" for font-weight, please use a typography token (meteor/prefer-font-token)',
+      line: 1,
+      column: 6,
+      endLine: 1,
+      endColumn: 40,
+      fixed: ".a { font-weight: var(--font-weight-regular); }",
+    },
+    {
+      code: ".a { font-weight: $font-weight-medium; }",
+      message:
+        'Unexpected hard-coded value "$font-weight-medium" for font-weight, please use a typography token (meteor/prefer-font-token)',
+      line: 1,
+      column: 6,
+      endLine: 1,
+      endColumn: 39,
+      fixed: ".a { font-weight: var(--font-weight-medium); }",
+    },
+    {
+      code: ".a { font-weight: $font-weight-semibold; }",
+      message:
+        'Unexpected hard-coded value "$font-weight-semibold" for font-weight, please use a typography token (meteor/prefer-font-token)',
+      line: 1,
+      column: 6,
+      endLine: 1,
+      endColumn: 41,
+      fixed: ".a { font-weight: var(--font-weight-semibold); }",
+    },
+    {
+      code: ".a { font-weight: $font-weight-bold; }",
+      message:
+        'Unexpected hard-coded value "$font-weight-bold" for font-weight, please use a typography token (meteor/prefer-font-token)',
+      line: 1,
+      column: 6,
+      endLine: 1,
+      endColumn: 37,
+      fixed: ".a { font-weight: var(--font-weight-bold); }",
     },
     {
       code: ".a { font-size: 16px; }",
@@ -49,6 +143,7 @@ testRule({
       column: 6,
       endLine: 1,
       endColumn: 22,
+      unfixable: true,
     },
     {
       code: ".a { line-height: 10px; }",
@@ -58,6 +153,7 @@ testRule({
       column: 6,
       endLine: 1,
       endColumn: 24,
+      unfixable: true,
     },
   ],
 });


### PR DESCRIPTION
## What?

Adds a auto-fixer for the font-weight properties.

## Why?

This makes it easier for teams to adopt the Design Tokens.

We can be pretty sure that a weight of `400` maps to `--font-weight-regular`, because those values are standardised values in the design and development world.

## How?

When the rule finds a `font-weight` property with a hard-coded number value it tries to find the corresponding Design Token.

## Testing?

I added some unit tests to make sure the changes work as expected.
