### PR TITLE
feat: Added number field config - noControls

### DIFF
--- a/packages/component-library/src/components/form/mt-number-field/mt-number-field.vue
+++ b/packages/component-library/src/components/form/mt-number-field/mt-number-field.vue
@@ -43,7 +43,11 @@
         @blur="removeFocusClass"
       />
 
-      <div class="mt-number-field__controls" :class="controlClasses">
+      <div
+        v-if="!noControls"
+        class="mt-number-field__controls"
+        :class="controlClasses"
+      >
         <button
           type="button"
           @click="increaseNumberByStep"
@@ -189,6 +193,15 @@ export default defineComponent({
      * Defines if the number should be aligned to the end of the input field.
      */
     numberAlignEnd: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
+
+    /**
+     * Defines if controls should be shown.
+     */
+    noControls: {
       type: Boolean,
       required: false,
       default: false,


### PR DESCRIPTION
## What?
Added a new config to not render number-field controls
## Why?
To be able not to show controls. So an input via keyboard is necessary

