### PR TITLE
fix(component-library): get rid of duplicate isInherited

### DIFF
--- a/.changeset/twenty-poets-know.md
+++ b/.changeset/twenty-poets-know.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": patch
+---
+
+Get rid of duplicate isInherited in mt-checkbox

--- a/packages/component-library/src/components/form/mt-checkbox/mt-checkbox.vue
+++ b/packages/component-library/src/components/form/mt-checkbox/mt-checkbox.vue
@@ -187,7 +187,7 @@ export default defineComponent({
       return {
         "has--error": !!this.hasError,
         "is--disabled": this.disabled,
-        "is--inherited": !!this.isInherited,
+        "is--inherited": !!this.isInheritedComputed,
         "is--bordered": this.bordered,
         "is--partly-checked": this.isPartlyChecked,
       };
@@ -202,7 +202,7 @@ export default defineComponent({
     },
 
     inputState(): boolean {
-      if (this.isInherited) {
+      if (this.isInheritedComputed) {
         return this.inheritedValue;
       }
 
@@ -216,15 +216,16 @@ export default defineComponent({
       return this.inheritedValue !== null;
     },
 
-    isInherited(): boolean {
-      if (this.$attrs.isInherited) {
+    isInheritedComputed(): boolean {
+      if (this.isInherited) {
         return true;
       }
+
       return this.isInheritanceField && this.currentValue === null;
     },
 
     isDisabled(): boolean {
-      return this.disabled || this.isInherited;
+      return this.disabled || this.isInheritedComputed;
     },
 
     isPartlyChecked(): boolean {


### PR DESCRIPTION
## What?

This PR removes a duplicate `isInherited` in the `mt-checkbox` component.

## Why?

The component has a prop and a computed property called `isInherited`. That caused the code to break, because Vue does not know how which one to use.

## How?

I renamed the computed property to `isInheritedComputed`