### PR TITLE
fix(component-library): add mt-switch--disabled class to mt-switch

### DIFF
--- a/.changeset/old-owls-give.md
+++ b/.changeset/old-owls-give.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": patch
+---
+
+Add mt-switch--disabled class to mt-switch

--- a/packages/component-library/src/components/form/mt-switch/mt-switch.vue
+++ b/packages/component-library/src/components/form/mt-switch/mt-switch.vue
@@ -6,6 +6,7 @@
         'mt-switch--no-top-margin': removeTopMargin,
         'mt-switch--future-no-default-margin': !!futureFlags.removeDefaultMargin,
         'mt-switch--not-bordered': !bordered,
+        'mt-switch--disabled': disabled,
       },
     ]"
   >


### PR DESCRIPTION
## What?

Adds a `mt-switch--disabled` class to the `mt-switch` component when the switch is disabled.

## Why?

This allows developers to query all disabled switch components.

## How?

I added a `mt-switch--disabled` class to the 

## Testing?

You can checkout the Storybook branch preview below.
