### PR TITLE
build(@shopware-ag/meteor-icon-kit): remove prepublish script

### DIFF
--- a/packages/icon-kit/package.json
+++ b/packages/icon-kit/package.json
@@ -29,7 +29,6 @@
     "lint:all": "npm run lint:types && npm run lint:eslint",
     "lint:eslint": "eslint ./src",
     "lint:types": "tsc --noEmit",
-    "prepublish": "npm run build",
     "start": "tsx ./src/index.ts",
     "format": "prettier --write .",
     "format:check": "prettier --check .",


### PR DESCRIPTION
## What?

Removes the pre-publish script from the icon kit.

## Why?

This script causes the release job to fail, because it's calling a build script which no longer exists and is no longer needed.

There's no longe a need for a pre-publish command because the whole icon automation is done via GitHub workflows.
