### PR TITLE
fix(component-library): only emit change event when using @change on mt-number-field

### DIFF
--- a/.changeset/flat-queens-explain.md
+++ b/.changeset/flat-queens-explain.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": patch
+---
+
+Only emit change event when using `@change` on `mt-number-field`

--- a/.changeset/fresh-cooks-flow.md
+++ b/.changeset/fresh-cooks-flow.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": patch
+---
+
+Do not emit change event when pressing increment and decrement buttons on `mt-number-field`

--- a/packages/component-library/src/components/form/mt-number-field/mt-number-field.interactive.stories.ts
+++ b/packages/component-library/src/components/form/mt-number-field/mt-number-field.interactive.stories.ts
@@ -10,7 +10,7 @@ export default {
 
 export const TestInputValue: MtNumberFieldStory = {
   name: "Should keep input value",
-  play: async ({ canvasElement, args }) => {
+  play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
     await userEvent.click(canvas.getByRole("textbox"));
@@ -18,10 +18,7 @@ export const TestInputValue: MtNumberFieldStory = {
     await userEvent.click(canvas.getByText("hidden"));
 
     // Notice that the value is of type string and the value of the event is of type number
-    expect((canvas.getByRole("textbox") as HTMLInputElement).value).toBe("42");
-
-    expect(args.change).toHaveBeenCalledWith(42);
-    expect(args.updateModelValue).toHaveBeenCalledWith(42);
+    expect(canvas.getByRole<HTMLInputElement>("textbox").value).toBe("42");
   },
 };
 
@@ -41,7 +38,6 @@ export const TestIncreaseByKeyStroke: MtNumberFieldStory = {
     // Notice that the value is of type string and the value of the event is of type number
     expect((canvas.getByRole("textbox") as HTMLInputElement).value).toBe("11");
 
-    expect(args.change).toHaveBeenCalledWith(11);
     expect(args.updateModelValue).toHaveBeenCalledWith(11);
   },
 };
@@ -60,7 +56,6 @@ export const TestIncreaseByControl: MtNumberFieldStory = {
     // Notice that the value is of type string and the value of the event is of type number
     expect((canvas.getByRole("textbox") as HTMLInputElement).value).toBe("11");
 
-    expect(args.change).toHaveBeenCalledWith(11);
     expect(args.updateModelValue).toHaveBeenCalledWith(11);
   },
 };
@@ -80,7 +75,6 @@ export const TestDecreaseByKeyStroke: MtNumberFieldStory = {
     // Notice that the value is of type string and the value of the event is of type number
     expect((canvas.getByRole("textbox") as HTMLInputElement).value).toBe("9");
 
-    expect(args.change).toHaveBeenCalledWith(9);
     expect(args.updateModelValue).toHaveBeenCalledWith(9);
   },
 };
@@ -100,7 +94,6 @@ export const TestDecreaseByControl: MtNumberFieldStory = {
     // Notice that the value is of type string and the value of the event is of type number
     expect((canvas.getByRole("textbox") as HTMLInputElement).value).toBe("9");
 
-    expect(args.change).toHaveBeenCalledWith(9);
     expect(args.updateModelValue).toHaveBeenCalledWith(9);
   },
 };
@@ -124,7 +117,6 @@ export const TestStepIncrease: MtNumberFieldStory = {
     // Notice that the value is of type string and the value of the event is of type number
     expect((canvas.getByRole("textbox") as HTMLInputElement).value).toBe("11.40");
 
-    expect(args.change).toHaveBeenCalledWith(11.4);
     expect(args.updateModelValue).toHaveBeenCalledWith(11.4);
   },
 };
@@ -146,7 +138,6 @@ export const TestDecreaseConsidersMin: MtNumberFieldStory = {
     // Notice that the value is of type string and the value of the event is of type number
     expect((canvas.getByRole("textbox") as HTMLInputElement).value).toBe("10");
 
-    expect(args.change).toHaveBeenCalledWith(10);
     expect(args.updateModelValue).toHaveBeenCalledWith(10);
   },
 };
@@ -168,7 +159,6 @@ export const TestIncreaseConsiderMax: MtNumberFieldStory = {
     // Notice that the value is of type string and the value of the event is of type number
     expect((canvas.getByRole("textbox") as HTMLInputElement).value).toBe("10");
 
-    expect(args.change).toHaveBeenCalledWith(10);
     expect(args.updateModelValue).toHaveBeenCalledWith(10);
   },
 };
@@ -185,7 +175,6 @@ export const TestIncreaseByKeyStrokeAfterTyping: MtNumberFieldStory = {
     // Notice that the value is of type string and the value of the event is of type number
     expect((canvas.getByRole("textbox") as HTMLInputElement).value).toBe("11");
 
-    expect(args.change).toHaveBeenCalledWith(11);
     expect(args.updateModelValue).toHaveBeenCalledWith(11);
   },
 };
@@ -202,7 +191,6 @@ export const TestDecreaseByKeyStrokeAfterTyping: MtNumberFieldStory = {
     // Notice that the value is of type string and the value of the event is of type number
     expect((canvas.getByRole("textbox") as HTMLInputElement).value).toBe("9");
 
-    expect(args.change).toHaveBeenCalledWith(9);
     expect(args.updateModelValue).toHaveBeenCalledWith(9);
   },
 };

--- a/packages/component-library/src/components/form/mt-number-field/mt-number-field.spec.ts
+++ b/packages/component-library/src/components/form/mt-number-field/mt-number-field.spec.ts
@@ -49,6 +49,42 @@ describe("mt-number-field", () => {
     expect(screen.getByRole("textbox")).toHaveValue("1000");
   });
 
+  it("does not emit a change event when clicking the increment button", async () => {
+    const handler = vi.fn();
+
+    render(MtNumberField, {
+      props: {
+        modelValue: 10,
+        // @ts-expect-error -- Event exist, but type is not defined via TypeScript
+        onChange: handler,
+      },
+    });
+
+    // ACT
+    await userEvent.click(screen.getByRole("button", { name: "Increase" }));
+
+    // ASSERT
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("does not emit a change event when clicking the decrement button", async () => {
+    const handler = vi.fn();
+
+    render(MtNumberField, {
+      props: {
+        modelValue: 10,
+        // @ts-expect-error -- Event exist, but type is not defined via TypeScript
+        onChange: handler,
+      },
+    });
+
+    // ACT
+    await userEvent.click(screen.getByRole("button", { name: "Decrease" }));
+
+    // ASSERT
+    expect(handler).not.toHaveBeenCalled();
+  });
+
   it("is not possible to increment the value by pressing the increment button when inheritance is linked", async () => {
     // ASSERT
     const handler = vi.fn();

--- a/packages/component-library/src/components/form/mt-number-field/mt-number-field.spec.ts
+++ b/packages/component-library/src/components/form/mt-number-field/mt-number-field.spec.ts
@@ -27,6 +27,28 @@ describe("mt-number-field", () => {
     expect(handler).not.toHaveBeenCalled();
   });
 
+  it("only emits change event with the native HTML event when blurring the input", async () => {
+    const handler = vi.fn();
+
+    render(MtNumberField, {
+      props: {
+        modelValue: 10,
+        // @ts-expect-error -- Event exist, but type is not defined via TypeScript
+        onChange: handler,
+      },
+    });
+
+    await userEvent.click(screen.getByRole("textbox"));
+    await userEvent.keyboard("00");
+
+    // ACT
+    await userEvent.click(document.body);
+
+    // ASSERT
+    expect(handler).toHaveBeenCalledExactlyOnceWith(expect.any(Event));
+    expect(screen.getByRole("textbox")).toHaveValue("1000");
+  });
+
   it("is not possible to increment the value by pressing the increment button when inheritance is linked", async () => {
     // ASSERT
     const handler = vi.fn();

--- a/packages/component-library/src/components/form/mt-number-field/mt-number-field.vue
+++ b/packages/component-library/src/components/form/mt-number-field/mt-number-field.vue
@@ -259,9 +259,6 @@ export default defineComponent({
       // @ts-expect-error - target exists
       this.computeValue(event.target.value);
 
-      /** @deprecated tag: 5.0 - Will be removed use update:model-value instead */
-      this.$emit("change", this.currentValue);
-
       this.$emit("update:modelValue", this.currentValue);
     },
 

--- a/packages/component-library/src/components/form/mt-number-field/mt-number-field.vue
+++ b/packages/component-library/src/components/form/mt-number-field/mt-number-field.vue
@@ -282,18 +282,12 @@ export default defineComponent({
     increaseNumberByStep() {
       this.computeValue((Number(this.currentValue) + this.realStep).toString());
 
-      /** @deprecated tag: 5.0 - Will be removed use update:model-value instead */
-      this.$emit("change", this.currentValue);
-
       this.$emit("update:modelValue", this.currentValue);
     },
 
     decreaseNumberByStep() {
       // @ts-expect-error - wrong type because of component extends
       this.computeValue((this.currentValue - this.realStep).toString());
-
-      /** @deprecated tag: 5.0 - Will be removed use update:model-value instead */
-      this.$emit("change", this.currentValue);
 
       this.$emit("update:modelValue", this.currentValue);
     },


### PR DESCRIPTION
## What?

This PR stop the `mt-number-field` from emitting the `change` event twice.

## Why?

a) Listening on the change event was practically unusable.
It first emitted the newly entered value, after that it instantly emitted the standard HTML change event. Creating the bug described in shopware/shopware#8940
  
b) This aligns with the standard HTML convention

## How?

When the user blurs the input, it no longer emits the `change` event twice.

## Testing?

I've written in TTD style, to make sure the changes work as expected.

## Anything Else?

Closes shopware/shopware#8940

I did not want to change the API in the past, because it's breaking change. I no longer agree to this and would like to remove the event. Right now, it's broken and does not work anyway. Why keep and API that does not work anyway?

Do you see any issues with this move @jleifeld ?
