### PR TITLE
fix(component-library): allow focus items in popover that are in modals

### DIFF
--- a/packages/component-library/src/components/overlay/mt-modal/mt-modal.vue
+++ b/packages/component-library/src/components/overlay/mt-modal/mt-modal.vue
@@ -123,10 +123,16 @@ watch(
 
     if (!modalRef.value) return;
     if (isModalOpen) {
-      trap = focusTrap.createFocusTrap(modalRef.value as HTMLElement, {
-        tabbableOptions: { displayCheck: "none" },
-        allowOutsideClick: true,
-      });
+      trap = focusTrap.createFocusTrap(
+        [
+          modalRef.value as HTMLElement,
+          ...(document.querySelectorAll(".sw-popover__wrapper") as NodeListOf<HTMLElement>),
+        ],
+        {
+          tabbableOptions: { displayCheck: "none" },
+          allowOutsideClick: true,
+        },
+      );
 
       trap.activate();
 


### PR DESCRIPTION
## What?

## Why?

## How?

## Testing?

## Screenshots (optional)

## Anything Else?
