### PR TITLE
Fix: make datepicker clearable

### DIFF
--- a/packages/component-library/src/components/form/mt-datepicker/mt-datepicker.vue
+++ b/packages/component-library/src/components/form/mt-datepicker/mt-datepicker.vue
@@ -195,8 +195,8 @@ export default defineComponent({
     },
 
     /**
-     * Enables the date range selection feature.
-     * If true, the user can select a start and end date.
+     * Enables the clear button.
+     * If true, the user can clear the date picker value.
      */
     clearable: {
       type: Boolean as PropType<boolean>,


### PR DESCRIPTION
## What?
Implemented a clearable prop so that mt-datepicker input can be cleared 

## Why?
mt-datepicker was missing this functionality

## How?
Added the prop and corresponding functionality so that the modelValue returns null when cleared

## Testing?
I've added a test for this behaviour
