### PR TITLE
feat: add useRepository composable

### DIFF
--- a/docs/admin-sdk/docs/guide/2_api-reference/composables/useRepository.md
+++ b/docs/admin-sdk/docs/guide/2_api-reference/composables/useRepository.md
@@ -1,0 +1,131 @@
+# useRepository
+
+The `composables.useRepository` function provides a convenient way to access and work with entity repositories in your app. This composable creates a repository instance for a specific entity type, allowing you to perform CRUD operations and interact with your data model.
+
+The repository created by this composable provides methods for searching, creating, reading, updating, and deleting entities. It handles the communication with the underlying data sources and ensures a consistent interface regardless of the repository implementation used.
+
+This composable is particularly useful when you need to access and manipulate data in your Vue components. It can use different repository sources based on the context:
+
+1. A custom repository factory provided as a parameter
+2. A repository factory injected into the Vue application context
+3. A lazy-loaded default repository as a fallback
+
+#### Usage:  
+```ts
+// Inside a Vue component setup
+import { composables } from '@shopware-ag/meteor-admin-sdk';
+const { useRepository } = composables;
+
+// Basic usage - gets repository for 'product' entity
+const productRepository = useRepository('product');
+
+// Search for products
+const products = await productRepository.search(criteria);
+
+// Get a specific product
+const product = await productRepository.get('productId');
+
+// Create a new product
+const newProduct = await productRepository.create();
+
+// Save changes to a product
+await productRepository.save(product);
+
+// Delete a product
+await productRepository.delete('productId');
+```
+
+## Repository Factory Sources
+
+The `useRepository` composable can obtain a repository instance from three different sources, which it tries in the following order:
+
+### 1. Custom Repository Factory (Parameter)
+
+You can provide a custom repository factory directly as the second parameter to `useRepository`. This gives you the most control and flexibility, allowing you to inject specific repository implementations based on your requirements.
+
+This approach is particularly useful in these scenarios:
+- When a component receives a repository factory via props from a parent component
+- When you need to override the default repository behavior for specific use cases
+- It will fall back to the default repository if no custom factory is provided
+
+```ts
+// In a Vue component that receives repositoryFactory as a prop
+import { defineComponent } from 'vue';
+import { composables } from '@shopware-ag/meteor-admin-sdk';
+const { useRepository } = composables;
+
+export default defineComponent({
+  props: {
+    repositoryFactory: {
+      type: Object
+    }
+  },
+  
+  setup(props) {
+    // Use the repository factory from props
+    const productRepository = useRepository('product', props.repositoryFactory);
+    
+    // Now you can use this repository with the specific implementation
+    // provided by the parent component
+    const loadProducts = async () => {
+      const products = await productRepository.search(criteria);
+      // work with products
+    };
+    
+    return {
+      loadProducts
+    };
+  }
+});
+```
+
+### 2. Injected Repository Factory
+
+If no custom factory is provided as a parameter, `useRepository` will look for a repository factory that has been injected into the Vue application context under the key `'repositoryFactory'`. This is used in Platform application.
+
+This approach is for:
+- Using the repository factory in Platform application where the factory is injected globally
+
+
+### 3. Lazy-Loaded Default Repository (Fallback)
+
+If neither a custom repository factory nor an injected one is available, `useRepository` will fall back to a default sdk data repository that is lazy-loaded on demand. This ensures that your components always have a working repository without requiring explicit configuration.
+
+Key benefits of the lazy-loading approach:
+- Improved initial load performance (data repository code loads only when needed)
+- Avoids returning a Promise from the composable, keeping component setup synchronous
+- Prevents side effects from importing repository code during component initialization
+- Provides a working repository even without explicit configuration
+
+The default repository is loaded only when the first method is called:
+
+```ts
+const productRepository = useRepository('product');
+
+// At this point, no repository code has been loaded yet
+
+// The first method call triggers the lazy loading
+await productRepository.search(criteria);  // Now the repository module is imported
+```
+
+This proxy-based implementation ensures that all subsequent method calls use the same repository instance without reloading the code.
+
+#### Parameters
+| Name                    | Required | Description                                                     |
+|:------------------------|:---------|:----------------------------------------------------------------|
+| `entityName`            | true     | The name of the entity type to create a repository for          |
+| `propRepositoryFactory` | false    | Optional custom repository factory for specific implementations |
+
+#### Repository Methods
+The repository provides the following methods:
+
+| Method       | Description                            |
+|:-------------|:---------------------------------------|
+| `search`     | Search for entities using criteria     |
+| `get`        | Get a single entity by ID              |
+| `save`       | Save changes to an entity              |
+| `saveAll`    | Save changes to multiple entities      |
+| `create`     | Create a new entity instance           |
+| `delete`     | Delete an entity                       |
+| `clone`      | Clone an existing entity               |
+| `hasChanges` | Check if an entity has unsaved changes |

--- a/packages/admin-sdk/src/data/composables/index.ts
+++ b/packages/admin-sdk/src/data/composables/index.ts
@@ -1,5 +1,7 @@
 import { useSharedState } from './useSharedState';
+import { useRepository } from './useRepository';
 
 export default {
   useSharedState,
+  useRepository,
 };

--- a/packages/admin-sdk/src/data/composables/useRepository.spec.ts
+++ b/packages/admin-sdk/src/data/composables/useRepository.spec.ts
@@ -1,0 +1,175 @@
+import { useRepository } from './useRepository';
+import * as repositoryModule from '../repository';
+import { inject } from 'vue';
+import { createRepositoryAdapter, type RepositorySource } from '../repository-adapter';
+import type Criteria from '../Criteria';
+import type { ApiContext } from '../../_internals/data/EntityCollection';
+import type { Entity } from '../../_internals/data/Entity';
+
+// Mock dependencies
+jest.mock('vue');
+jest.mock('../repository-adapter');
+jest.mock('../repository', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+// Type definitions for testing
+type TestEntityName = 'product';
+declare global {
+  namespace EntitySchema {
+    interface Entities {
+      product: {
+        id: string;
+        name: string;
+      };
+    }
+  }
+}
+
+describe('useRepository', () => {
+  // Common mocks and setup
+  const mockRepositorySource: RepositorySource<TestEntityName> = {
+    search: jest.fn(),
+    get: jest.fn(),
+    save: jest.fn(),
+    clone: jest.fn(),
+    saveAll: jest.fn(),
+    delete: jest.fn(),
+    hasChanges: jest.fn(),
+    create: jest.fn(),
+  };
+  
+  const mockRepositoryAdapter = {
+    search: jest.fn(),
+    get: jest.fn(),
+    save: jest.fn(),
+    clone: jest.fn(),
+    saveAll: jest.fn(),
+    delete: jest.fn(),
+    hasChanges: jest.fn(),
+    create: jest.fn(),
+  };
+
+  const mockDefaultRepository = {
+    search: jest.fn(),
+    get: jest.fn(),
+    save: jest.fn(),
+    clone: jest.fn(),
+    saveAll: jest.fn(),
+    delete: jest.fn(),
+    hasChanges: jest.fn(),
+    create: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (createRepositoryAdapter as jest.Mock).mockReturnValue(mockRepositoryAdapter);
+    (repositoryModule.default as jest.Mock).mockReturnValue(mockDefaultRepository);
+  });
+
+  describe('with propRepositoryFactory', () => {
+    it('should use the provided repository factory', () => {
+      const propRepositoryFactory = jest.fn().mockReturnValue(mockRepositorySource);
+      
+      const repository = useRepository('product', propRepositoryFactory);
+      
+      expect(propRepositoryFactory).toHaveBeenCalledWith('product');
+      expect(createRepositoryAdapter).toHaveBeenCalledWith(mockRepositorySource);
+      expect(repository).toBe(mockRepositoryAdapter);
+    });
+  });
+
+  describe('with injected repositoryFactory', () => {
+    it('should use the injected repository factory when available', () => {
+      const injectedFactory = {
+        create: jest.fn().mockReturnValue(mockRepositorySource)
+      };
+      (inject as jest.Mock).mockReturnValue(injectedFactory);
+      
+      const repository = useRepository('product');
+      
+      expect(inject).toHaveBeenCalledWith('repositoryFactory');
+      expect(injectedFactory.create).toHaveBeenCalledWith('product');
+      expect(createRepositoryAdapter).toHaveBeenCalledWith(mockRepositorySource);
+      expect(repository).toBe(mockRepositoryAdapter);
+    });
+  });
+
+  describe('with lazy loading fallback', () => {
+    beforeEach(() => {
+      (inject as jest.Mock).mockReturnValue(undefined);
+    });
+
+    it('should create a proxy for lazy loading repository', async () => {
+      const repository = useRepository('product');
+      
+      // Repository should be a proxy at this point
+      expect(repository).toBeInstanceOf(Object);
+      
+      // Verify lazy loading works on method call
+      await repository.search({ limit: 10 } as Criteria);
+      
+      expect(repositoryModule.default).toHaveBeenCalledWith('product');
+      expect(mockDefaultRepository.search).toHaveBeenCalledWith({ limit: 10 });
+    });
+
+    it('should only load the repository once across multiple method calls', async () => {
+      const repository = useRepository('product');
+      
+      expect(repositoryModule.default).not.toHaveBeenCalled();
+      await repository.search({ limit: 10 } as Criteria);
+      await repository.get('123');
+
+      // Repository module should only be imported once
+      expect(repositoryModule.default).toHaveBeenCalledTimes(1);
+      expect(mockDefaultRepository.search).toHaveBeenCalledWith({ limit: 10 });
+      expect(mockDefaultRepository.get).toHaveBeenCalledWith('123');
+    });
+
+    it('should pass all arguments to the underlying repository methods', async () => {
+      const repository = useRepository('product');
+      
+      await repository.search({ limit: 10 } as Criteria, { languageId: 'en-US' } as ApiContext);
+      await repository.get('123', { languageId: 'en-US' } as ApiContext, { limit: 1 } as Criteria);
+      await repository.save({ id: '123', name: 'Test' } as Entity<'product'>, { languageId: 'en-US' } as ApiContext);
+      
+      expect(mockDefaultRepository.search).toHaveBeenCalledWith(
+        { limit: 10 }, 
+        { languageId: 'en-US' }
+      );
+      expect(mockDefaultRepository.get).toHaveBeenCalledWith(
+        '123', 
+        { languageId: 'en-US' }, 
+        { limit: 1 }
+      );
+      expect(mockDefaultRepository.save).toHaveBeenCalledWith(
+        { id: '123', name: 'Test' }, 
+        { languageId: 'en-US' }
+      );
+    });
+
+    it('should support all repository methods', async () => {
+      const repository = useRepository('product');
+      const entity = { id: '123', name: 'Test' } as Entity<'product'>;
+      
+      await repository.search({} as Criteria);
+      await repository.get('123');
+      await repository.save(entity);
+      await repository.clone('123', {});
+      await repository.hasChanges(entity);
+      await repository.saveAll([] as any);
+      await repository.delete('123');
+      await repository.create();
+      
+      expect(mockDefaultRepository.search).toHaveBeenCalled();
+      expect(mockDefaultRepository.get).toHaveBeenCalled();
+      expect(mockDefaultRepository.save).toHaveBeenCalled();
+      expect(mockDefaultRepository.clone).toHaveBeenCalled();
+      expect(mockDefaultRepository.hasChanges).toHaveBeenCalled();
+      expect(mockDefaultRepository.saveAll).toHaveBeenCalled();
+      expect(mockDefaultRepository.delete).toHaveBeenCalled();
+      expect(mockDefaultRepository.create).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/admin-sdk/src/data/composables/useRepository.ts
+++ b/packages/admin-sdk/src/data/composables/useRepository.ts
@@ -1,0 +1,52 @@
+import {
+  createRepositoryAdapter,
+  type RepositorySource,
+  type SDKRepository,
+} from '../repository-adapter';
+import { inject } from 'vue';
+
+export function useRepository<EntityName extends keyof EntitySchema.Entities>(
+  entityName: EntityName,
+  propRepositoryFactory?: (
+    entityName: EntityName
+  ) => RepositorySource<EntityName>
+): SDKRepository<EntityName> {
+  if (propRepositoryFactory) {
+    return createRepositoryAdapter(propRepositoryFactory(entityName));
+  }
+
+  const injectedFactory = inject<{
+    create: (entityName: EntityName) => RepositorySource<EntityName>,
+      }>('repositoryFactory');
+
+  if (injectedFactory) {
+    return createRepositoryAdapter(injectedFactory.create(entityName));
+  }
+
+  /*
+   * The use of a Proxy delays the import of the repository until the first method is called.
+   * This avoids side effects from the repository import and prevents returning a Promise
+   * from this composable, which would force components using it to be async.
+   */
+  let lazyDataRepository: SDKRepository<EntityName>;
+
+  return new Proxy(
+    {},
+    {
+      get(_, property: keyof SDKRepository<EntityName>) {
+        return async function (...args: unknown[]) {
+          if (!lazyDataRepository) {
+            lazyDataRepository = (await import('../repository')).default(
+              entityName
+            );
+          }
+
+          const method = lazyDataRepository[property] as (
+            ...args: unknown[]
+          ) => Promise<unknown>;
+          return method(...args);
+        };
+      },
+    }
+  ) as SDKRepository<EntityName>;
+}

--- a/packages/admin-sdk/src/data/repository-adapter.spec.ts
+++ b/packages/admin-sdk/src/data/repository-adapter.spec.ts
@@ -1,0 +1,313 @@
+import {
+  RepositoryAdapter,
+  createRepositoryAdapter,
+} from './repository-adapter';
+import type { RepositorySource } from './repository-adapter';
+import type EntityCollection from '../_internals/data/EntityCollection';
+import type { ApiContext } from '../_internals/data/EntityCollection';
+import Criteria from './Criteria';
+import type { Entity } from '../_internals/data/Entity';
+
+// Mock types to make testing easier
+type TestEntityName = 'product';
+interface TestEntity extends Entity<TestEntityName> {
+  id: string;
+  name: string;
+}
+
+declare global {
+  namespace EntitySchema {
+    interface Entities {
+      product: {
+        id: string;
+        name: string;
+      };
+    }
+  }
+}
+
+describe('RepositoryAdapter', () => {
+  // Mock repository source
+  const mockEntity = { id: '123', name: 'Test Product' } as TestEntity;
+  const mockEntityCollection = {
+    length: 1,
+  } as EntityCollection<TestEntityName>;
+  const mockContext = { languageId: 'en-US' } as ApiContext;
+  const mockAsyncSource: RepositorySource<TestEntityName> = {
+    search: jest.fn().mockResolvedValue(mockEntityCollection),
+    get: jest.fn().mockResolvedValue(mockEntity),
+    save: jest.fn().mockResolvedValue(undefined),
+    clone: jest.fn().mockResolvedValue({ id: '456', name: 'Cloned Product' }),
+    saveAll: jest.fn().mockResolvedValue(undefined),
+    delete: jest.fn().mockResolvedValue(undefined),
+    hasChanges: jest.fn().mockResolvedValue(true),
+    create: jest.fn().mockResolvedValue(mockEntity),
+  };
+  const mockSyncSource: RepositorySource<TestEntityName> = {
+    search: jest.fn().mockResolvedValue(mockEntityCollection),
+    get: jest.fn().mockResolvedValue(mockEntity),
+    save: jest.fn().mockResolvedValue(undefined),
+    clone: jest.fn().mockResolvedValue({ id: '456', name: 'Cloned Product' }),
+    saveAll: jest.fn().mockResolvedValue(undefined),
+    delete: jest.fn().mockResolvedValue(undefined),
+    hasChanges: jest.fn().mockReturnValue(true),
+    create: jest.fn().mockReturnValue(mockEntity),
+  };
+  const asyncRepositoryAdapter: RepositoryAdapter<TestEntityName> =
+    new RepositoryAdapter(mockAsyncSource);
+  const syncRepositoryAdapter: RepositoryAdapter<TestEntityName> =
+    new RepositoryAdapter(mockSyncSource);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('async repository', () => {
+    it('should call source.search with provided parameters', async () => {
+      const criteria = { limit: 10 } as Criteria;
+
+      const result = await asyncRepositoryAdapter.search(criteria, mockContext);
+
+      expect(mockAsyncSource.search).toHaveBeenCalledWith(
+        criteria,
+        mockContext
+      );
+      expect(result).toBe(mockEntityCollection);
+    });
+
+    it('should call source.get with provided parameters', async () => {
+      const id = '123';
+      const criteria = { limit: 1 } as Criteria;
+
+      const result = await asyncRepositoryAdapter.get(
+        id,
+        mockContext,
+        criteria
+      );
+
+      expect(mockAsyncSource.get).toHaveBeenCalledWith(
+        id,
+        mockContext,
+        criteria
+      );
+      expect(result).toBe(mockEntity);
+    });
+
+    it('should call source.save with provided parameters', async () => {
+      await asyncRepositoryAdapter.save(mockEntity, mockContext);
+
+      expect(mockAsyncSource.save).toHaveBeenCalledWith(
+        mockEntity,
+        mockContext
+      );
+    });
+
+    it('should call source.clone with provided parameters', async () => {
+      const entityId = '123';
+      const behavior = { deep: true };
+
+      const result = await asyncRepositoryAdapter.clone(
+        entityId,
+        behavior,
+        mockContext
+      );
+
+      expect(mockAsyncSource.clone).toHaveBeenCalledWith(
+        entityId,
+        behavior,
+        mockContext
+      );
+      expect(result).toEqual({ id: '456', name: 'Cloned Product' });
+    });
+
+    it('should handle Promise return from source.hasChanges', async () => {
+      mockAsyncSource.hasChanges = jest.fn().mockResolvedValue(true);
+
+      const result = await asyncRepositoryAdapter.hasChanges(mockEntity);
+
+      expect(mockAsyncSource.hasChanges).toHaveBeenCalledWith(mockEntity);
+      expect(result).toBe(true);
+    });
+
+    it('should handle boolean return from source.hasChanges', async () => {
+      mockAsyncSource.hasChanges = jest.fn().mockReturnValue(false);
+
+      const result = await asyncRepositoryAdapter.hasChanges(mockEntity);
+
+      expect(mockAsyncSource.hasChanges).toHaveBeenCalledWith(mockEntity);
+      expect(result).toBe(false);
+    });
+
+    it('should call source.saveAll with provided parameters', async () => {
+      await asyncRepositoryAdapter.saveAll(mockEntityCollection, mockContext);
+
+      expect(mockAsyncSource.saveAll).toHaveBeenCalledWith(
+        mockEntityCollection,
+        mockContext
+      );
+    });
+
+    it('should call source.delete with provided parameters', async () => {
+      const entityId = '123';
+
+      await asyncRepositoryAdapter.delete(entityId, mockContext);
+
+      expect(mockAsyncSource.delete).toHaveBeenCalledWith(
+        entityId,
+        mockContext
+      );
+    });
+
+    it('should handle Promise return from source.create', async () => {
+      mockAsyncSource.create = jest.fn().mockResolvedValue(mockEntity);
+      const entityId = '123';
+
+      const result = await asyncRepositoryAdapter.create(mockContext, entityId);
+
+      expect(mockAsyncSource.create).toHaveBeenCalledWith(
+        mockContext,
+        entityId
+      );
+      expect(result).toBe(mockEntity);
+    });
+
+    it('should handle direct return from source.create', async () => {
+      mockAsyncSource.create = jest.fn().mockReturnValue(mockEntity);
+      const entityId = '123';
+
+      const result = await asyncRepositoryAdapter.create(mockContext, entityId);
+
+      expect(mockAsyncSource.create).toHaveBeenCalledWith(
+        mockContext,
+        entityId
+      );
+      expect(result).toBe(mockEntity);
+    });
+  });
+
+  describe('sync repository', () => {
+    it('should call source.search with provided parameters', async () => {
+      const criteria = { limit: 10 } as Criteria;
+
+      const result = await syncRepositoryAdapter.search(criteria, mockContext);
+
+      expect(mockSyncSource.search).toHaveBeenCalledWith(
+        criteria,
+        mockContext
+      );
+      expect(result).toBe(mockEntityCollection);
+    });
+
+    it('should call source.get with provided parameters', async () => {
+      const id = '123';
+      const criteria = { limit: 1 } as Criteria;
+
+      const result = await syncRepositoryAdapter.get(id, mockContext, criteria);
+
+      expect(mockSyncSource.get).toHaveBeenCalledWith(
+        id,
+        mockContext,
+        criteria
+      );
+      expect(result).toBe(mockEntity);
+    });
+
+    it('should call source.save with provided parameters', async () => {
+      await syncRepositoryAdapter.save(mockEntity, mockContext);
+
+      expect(mockSyncSource.save).toHaveBeenCalledWith(
+        mockEntity,
+        mockContext
+      );
+    });
+
+    it('should call source.clone with provided parameters', async () => {
+      const entityId = '123';
+      const behavior = { deep: true };
+
+      const result = await syncRepositoryAdapter.clone(
+        entityId,
+        behavior,
+        mockContext
+      );
+
+      expect(mockSyncSource.clone).toHaveBeenCalledWith(
+        entityId,
+        behavior,
+        mockContext
+      );
+      expect(result).toEqual({ id: '456', name: 'Cloned Product' });
+    });
+
+    it('should handle Promise return from source.hasChanges', async () => {
+      mockSyncSource.hasChanges = jest.fn().mockResolvedValue(true);
+
+      const result = await syncRepositoryAdapter.hasChanges(mockEntity);
+
+      expect(mockSyncSource.hasChanges).toHaveBeenCalledWith(mockEntity);
+      expect(result).toBe(true);
+    });
+
+    it('should handle boolean return from source.hasChanges', async () => {
+      mockSyncSource.hasChanges = jest.fn().mockReturnValue(false);
+
+      const result = await syncRepositoryAdapter.hasChanges(mockEntity);
+
+      expect(mockSyncSource.hasChanges).toHaveBeenCalledWith(mockEntity);
+      expect(result).toBe(false);
+    });
+
+    it('should call source.saveAll with provided parameters', async () => {
+      await syncRepositoryAdapter.saveAll(mockEntityCollection, mockContext);
+
+      expect(mockSyncSource.saveAll).toHaveBeenCalledWith(
+        mockEntityCollection,
+        mockContext
+      );
+    });
+
+    it('should call source.delete with provided parameters', async () => {
+      const entityId = '123';
+
+      await syncRepositoryAdapter.delete(entityId, mockContext);
+
+      expect(mockSyncSource.delete).toHaveBeenCalledWith(
+        entityId,
+        mockContext
+      );
+    });
+
+    it('should handle Promise return from source.create', async () => {
+      mockSyncSource.create = jest.fn().mockResolvedValue(mockEntity);
+      const entityId = '123';
+
+      const result = await syncRepositoryAdapter.create(mockContext, entityId);
+
+      expect(mockSyncSource.create).toHaveBeenCalledWith(
+        mockContext,
+        entityId
+      );
+      expect(result).toBe(mockEntity);
+    });
+
+    it('should handle direct return from source.create', async () => {
+      mockSyncSource.create = jest.fn().mockReturnValue(mockEntity);
+      const entityId = '123';
+
+      const result = await syncRepositoryAdapter.create(mockContext, entityId);
+
+      expect(mockSyncSource.create).toHaveBeenCalledWith(
+        mockContext,
+        entityId
+      );
+      expect(result).toBe(mockEntity);
+    });
+  });
+
+  it('should create a repository adapter instance', () => {
+    const mockSource = {} as RepositorySource<'product'>;
+    const adapter = createRepositoryAdapter(mockSource);
+
+    expect(adapter).toBeInstanceOf(RepositoryAdapter);
+  });
+});

--- a/packages/admin-sdk/src/data/repository-adapter.ts
+++ b/packages/admin-sdk/src/data/repository-adapter.ts
@@ -1,0 +1,101 @@
+import type RepositoryFactory from './repository';
+import type { Entity } from '../_internals/data/Entity';
+import type EntityCollection from '../_internals/data/EntityCollection';
+import type { ApiContext } from '../_internals/data/EntityCollection';
+import type Criteria from './Criteria';
+
+export type SDKRepository<EntityName extends keyof EntitySchema.Entities> = ReturnType<
+  typeof RepositoryFactory<EntityName>
+>;
+
+export type RepositorySource<EntityName extends keyof EntitySchema.Entities> = Pick<
+  SDKRepository<EntityName>,
+  'search' | 'get' | 'save' | 'clone' | 'saveAll' | 'delete'
+> & {
+  hasChanges: (entity: Entity<EntityName>) => Promise<boolean | null> | boolean,
+  create: (
+    context?: ApiContext,
+    entityId?: string | null
+  ) => Promise<Entity<EntityName> | null> | Entity<EntityName>,
+};
+
+function isPromise<T>(value: unknown): value is Promise<T> {
+  return (
+    !!value &&
+    typeof value === 'object' &&
+    'then' in value &&
+    typeof value.then === 'function' &&
+    'catch' in value &&
+    typeof value.catch === 'function'
+  );
+}
+
+/**
+ * Repository adapter that can wrap different source implementations
+ * and provide a consistent interface
+ */
+export class RepositoryAdapter<EntityName extends keyof EntitySchema.Entities> implements SDKRepository<EntityName>
+{
+  // eslint-disable-next-line no-empty-function,no-useless-constructor
+  constructor(private sourceRepository: RepositorySource<EntityName>) {}
+
+  async search(
+    criteria: Criteria,
+    context?: ApiContext
+  ): Promise<EntityCollection<EntityName> | null> {
+    return this.sourceRepository.search(criteria, context);
+  }
+
+  async get(
+    id: string,
+    context?: ApiContext,
+    criteria?: Criteria
+  ): Promise<Entity<EntityName> | null> {
+    return this.sourceRepository.get(id, context, criteria);
+  }
+
+  async save(
+    entity: Entity<EntityName>,
+    context?: ApiContext
+  ): Promise<void | null> {
+    return this.sourceRepository.save(entity, context);
+  }
+
+  async clone(
+    entityId: string,
+    behavior: unknown,
+    context?: ApiContext
+  ): Promise<unknown> {
+    return this.sourceRepository.clone(entityId, behavior, context);
+  }
+
+  async hasChanges(entity: Entity<EntityName>): Promise<boolean | null> {
+    const result = this.sourceRepository.hasChanges(entity);
+    return isPromise(result) ? result : Promise.resolve(result);
+  }
+
+  async saveAll(
+    entities: EntityCollection<EntityName>,
+    context?: ApiContext
+  ): Promise<unknown> {
+    return this.sourceRepository.saveAll(entities, context);
+  }
+
+  async delete(entityId: string, context?: ApiContext): Promise<void | null> {
+    return this.sourceRepository.delete(entityId, context);
+  }
+
+  async create(
+    context?: ApiContext,
+    entityId?: string
+  ): Promise<Entity<EntityName> | null> {
+    const result = this.sourceRepository.create(context, entityId);
+    return isPromise(result) ? result : Promise.resolve(result);
+  }
+}
+
+export function createRepositoryAdapter<
+  EntityName extends keyof EntitySchema.Entities,
+>(source: RepositorySource<EntityName>): SDKRepository<EntityName> {
+  return new RepositoryAdapter(source);
+}

--- a/packages/admin-sdk/src/data/repository.ts
+++ b/packages/admin-sdk/src/data/repository.ts
@@ -19,7 +19,21 @@ export default <EntityName extends keyof Entities>(entityName: EntityName) => ({
     return send('repositorySave', { entityName, entity, context });
   },
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  clone: (entityId: string, context?: ApiContext, behavior?: any): Promise<unknown | null> => {
+  clone: (entityId: string, contextOrBehavior?: any, behaviorOrContext?: any): Promise<unknown | null> => {
+    let context: ApiContext;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let behavior: any;
+    if(isApiContext(contextOrBehavior)) {
+      context = contextOrBehavior;
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      behavior = behaviorOrContext;
+    } else if (isApiContext(behaviorOrContext)) {
+      context = behaviorOrContext;
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      behavior = contextOrBehavior;
+    } else {
+      throw new Error('Invalid arguments for clone method');
+    }
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     return send('repositoryClone', { entityName, entityId, context, behavior });
   },
@@ -37,6 +51,30 @@ export default <EntityName extends keyof Entities>(entityName: EntityName) => ({
     return send('repositoryCreate', { entityName, entityId, context });
   },
 });
+
+function isApiContext(value: unknown): value is ApiContext {
+  const listOfApiContextProperties = [
+    'apiPath',
+    'apiResourcePath',
+    'assetsPath',
+    'authToken',
+    'basePath',
+    'pathInfo',
+    'inheritance',
+    'installationPath',
+    'languageId',
+    'language',
+    'apiVersion',
+    'liveVersionId',
+    'systemLanguageId',
+  ];
+
+  return (
+    !!value &&
+    typeof value === 'object' &&
+        listOfApiContextProperties.some(propertyKey => propertyKey in value)
+  );
+}
 
 export type repositoryGet<EntityName extends keyof Entities> = {
   responseType: Entity<EntityName> | null,


### PR DESCRIPTION
## What?

Added `useRepository` composable with supporting adapter and tests for simplified repository access in Vue components.

## Why?

- Simplifies repository usage in Vue components
- Improves performance through lazy loading
- Standardizes behavior across repository implementations
- Enhances developer experience

## How?

Three ways to obtain repositories: props, dependency injection, or lazy loading fallback, with an adapter to normalize interfaces.

## Testing?

Complete test coverage for initialization paths, methods, sync/async sources, and edge cases.

## Anything Else?

Change the `clone` parameters order in the SDK repository to mimic Platform repository, maintaining backward compatibility 