### PR TITLE
Add auto assign PR author workflow

### DIFF
--- a/.github/workflows/auto-assign-pr-author.yml
+++ b/.github/workflows/auto-assign-pr-author.yml
@@ -1,0 +1,14 @@
+name: Auto Assign PR Author
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  assign-author:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: toshimaru/auto-author-assign@v2.1.1


### PR DESCRIPTION
## What?
Adds the PR author as assignee. Skips this step when author is bot or someone is already assigned.

## Why?
Helps us keep our project board organized and reduces manual effort when creating and triaging PRs.

## Testing?
Not sure. Can you test this without merging? 😄
