### PR TITLE
fix: add center prop to mt-empty-state

### DIFF
--- a/packages/component-library/src/components/layout/mt-empty-state/mt-empty-state.vue
+++ b/packages/component-library/src/components/layout/mt-empty-state/mt-empty-state.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="mt-empty-state">
+  <div class="mt-empty-state" :class="{ 'mt-empty-state--centered': centered }">
     <div class="mt-empty-state__icon">
       <mt-icon :name="icon" color="var(--color-icon-primary-default)" aria-hidden="true" />
     </div>
@@ -48,6 +48,7 @@ defineProps<{
   linkHref?: string;
   linkText?: string;
   buttonText?: string;
+  centered?: boolean;
 }>();
 
 defineEmits(["button-click"]);
@@ -58,6 +59,12 @@ defineEmits(["button-click"]);
   display: flex;
   flex-direction: column;
   align-items: flex-start;
+}
+
+.mt-empty-state--centered {
+  align-items: center;
+  text-align: center;
+  max-width: 560px;
 }
 
 .mt-empty-state__icon {


### PR DESCRIPTION
## What?
Fixes #[#689]

## Why?
Our mt-empty-state component isn't easy to use visually because it forces left alignment

## How?
I've added a prop to allow center alignment
