### PR TITLE
feat: support async search function in the mt-select

### DIFF
--- a/packages/component-library/src/components/form/mt-select/mt-select.vue
+++ b/packages/component-library/src/components/form/mt-select/mt-select.vue
@@ -121,6 +121,7 @@ import type { PropType } from "vue";
 import { defineComponent } from "vue";
 import { debounce } from "@/utils/debounce";
 import { getPropertyValue } from "@/utils/object";
+import { isPromise } from "@/utils/promise";
 import MtSelectBase from "../_internal/mt-select-base/mt-select-base.vue";
 import MtSelectResultList from "../_internal/mt-select-base/_internal/mt-select-result-list.vue";
 import MtSelectResult from "../_internal/mt-select-base/_internal/mt-select-result.vue";
@@ -366,6 +367,7 @@ export default defineComponent({
     return {
       searchTerm: "",
       limit: this.valueLimit,
+      searchResults: [],
     };
   },
 
@@ -452,12 +454,7 @@ export default defineComponent({
 
     visibleResults(): any[] {
       if (this.searchTerm) {
-        return this.searchFunction({
-          options: this.options,
-          labelProperty: this.labelProperty,
-          valueProperty: this.valueProperty,
-          searchTerm: this.searchTerm,
-        });
+        return this.searchResults;
       }
 
       return this.options;
@@ -491,6 +488,30 @@ export default defineComponent({
   watch: {
     valueLimit(value) {
       this.limit = value;
+    },
+
+    searchTerm(newSearchTerm) {
+      this.searchResults = [];
+      if (newSearchTerm) {
+        const result = this.searchFunction({
+          options: this.options,
+          labelProperty: this.labelProperty,
+          valueProperty: this.valueProperty,
+          searchTerm: this.searchTerm,
+        });
+
+        if (isPromise(result)) {
+          result.then((res: any) => {
+            if (res) {
+              this.searchResults = res;
+            }
+          });
+        } else {
+          if (result) {
+            this.searchResults = result;
+          }
+        }
+      }
     },
   },
 

--- a/packages/component-library/src/utils/promise.spec.ts
+++ b/packages/component-library/src/utils/promise.spec.ts
@@ -1,0 +1,77 @@
+import { isPromise } from './promise';
+
+describe('utils/promise', () => {
+  describe('isPromise', () => {
+    it('should return true for a Promise', () => {
+      const promise = new Promise<void>((resolve) => {
+        resolve();
+      });
+
+      expect(isPromise(promise)).toBe(true);
+    });
+
+    it('should return true for a Promise created with Promise.resolve', () => {
+      const promise = Promise.resolve('test');
+
+      expect(isPromise(promise)).toBe(true);
+    });
+
+    it('should return true for a Promise created with Promise.reject (when caught)', () => {
+      const promise = Promise.reject('error').catch(() => {});
+
+      expect(isPromise(promise)).toBe(true);
+    });
+
+    it('should return false for null', () => {
+      expect(isPromise(null)).toBe(false);
+    });
+
+    it('should return false for undefined', () => {
+      expect(isPromise(undefined)).toBe(false);
+    });
+
+    it('should return false for a string', () => {
+      expect(isPromise('string')).toBe(false);
+    });
+
+    it('should return false for a number', () => {
+      expect(isPromise(123)).toBe(false);
+    });
+
+    it('should return false for a boolean', () => {
+      expect(isPromise(true)).toBe(false);
+    });
+
+    it('should return false for a regular object', () => {
+      const obj = { key: 'value' };
+
+      expect(isPromise(obj)).toBe(false);
+    });
+
+    it('should return false for an object with only a then method', () => {
+      const thennable = {
+        then: () => {}
+      };
+
+      expect(isPromise(thennable)).toBe(false);
+    });
+
+    it('should return false for an object with non-function then and catch properties', () => {
+      const obj = {
+        then: 'not a function',
+        catch: 'not a function'
+      };
+
+      expect(isPromise(obj)).toBe(false);
+    });
+
+    it('should return false for an object with then and catch methods that aren\'t functions', () => {
+      const obj = {
+        then: 123,
+        catch: true
+      };
+
+      expect(isPromise(obj)).toBe(false);
+    });
+  });
+});

--- a/packages/component-library/src/utils/promise.ts
+++ b/packages/component-library/src/utils/promise.ts
@@ -1,0 +1,15 @@
+/**
+ * Checks if a value is a Promise.
+ * @param value - The value to check.
+ * @return True if the value is a Promise, false otherwise.
+ */
+export function isPromise<T>(value: unknown): value is Promise<T> {
+  return (
+    !!value &&
+    typeof value === 'object' &&
+    'then' in value &&
+    typeof value.then === 'function' &&
+    'catch' in value &&
+    typeof value.catch === 'function'
+  );
+}


### PR DESCRIPTION
## What?
Adds support to `mt-select` for async `searchFunction` prop

## Why?
If the search function needs to call any API, then it needs to be async.

## How?
adding a data for the search results and returning it in the computed instead of the directly the results of the search function

## Testing?
Added for a new `isPromise` util

