### PR TITLE
fix: padding and size for buttons inside field addition

### DIFF
--- a/packages/component-library/src/components/form/_internal/mt-base-field/mt-base-field.vue
+++ b/packages/component-library/src/components/form/_internal/mt-base-field/mt-base-field.vue
@@ -420,6 +420,16 @@ export default defineComponent({
   display: none;
 }
 
+.mt-field .mt-field__addition:has(button) {
+  padding: 0;
+
+  & > button {
+    width: 100%;
+    height: 100%;
+    padding: var(--scale-size-12) 15px;
+  }
+}
+
 .mt-field .mt-field__addition.is--prefix {
   border-right: 1px solid var(--color-border-primary-default);
   border-left: none;


### PR DESCRIPTION
## What?
Changing the padding in the field addition when there is a button inside.

## Why?
Because the issue with the button size described [here](https://github.com/shopware/shopware/issues/10048)

## How?
checking with CSS if the addition has a button or not, and removing the container padding and adding it to the button
