### PR TITLE
hide scroll shadow in data table when showing an empty state

### DIFF
--- a/packages/component-library/src/components/table-and-list/mt-data-table/composables/useScrollPossibilitiesClasses.spec.ts
+++ b/packages/component-library/src/components/table-and-list/mt-data-table/composables/useScrollPossibilitiesClasses.spec.ts
@@ -1,6 +1,6 @@
 import useScrollPossibilitiesClasses from "./useScrollPossibilitiesClasses";
 import { mount } from "@vue/test-utils";
-import { ref, onMounted } from "vue";
+import { ref, onMounted, computed, toRef } from "vue";
 
 // mock throttle
 vi.mock("@/utils/throttle", () => ({
@@ -71,7 +71,7 @@ const createWrapper = async ({
         vi.spyOn(window, "addEventListener").mockImplementation(() => {});
       });
 
-      useScrollPossibilitiesClasses(exampleElement);
+      useScrollPossibilitiesClasses(exampleElement, toRef(true));
 
       return { exampleElement, parentElement };
     },

--- a/packages/component-library/src/components/table-and-list/mt-data-table/mt-data-table.vue
+++ b/packages/component-library/src/components/table-and-list/mt-data-table/mt-data-table.vue
@@ -1718,11 +1718,17 @@ export default defineComponent({
       return !!filterInUse.type.options.find((option) => option.id === optionId);
     }
 
+    const showData = computed(() => {
+      console.log(props.dataSource.length, props.isLoading);
+
+      return props.dataSource.length > 0 || props.isLoading;
+    });
+
     /***
      * Add scroll possibilities to tableWrapper
      */
     const tableWrapper = ref();
-    useScrollPossibilitiesClasses(tableWrapper);
+    useScrollPossibilitiesClasses(tableWrapper, showData);
 
     /**
      * General classes for whole data table


### PR DESCRIPTION
## What?

This PR hides the scroll shadow when displaying an empty state for the data table.

## Why?

A shadow tells the user that they can scroll. But you can't scroll when there's not content. 

This confuses the user and we should hide the scroll shadow.

## How?

I've updated the `useScrollPossbilities` class so that it no longer shows a scroll indicator when we show an empty state.

## Testing?

I've added a unit test to make sure it works. Moreover, I've we have some visual tests in place, to make sure everything works as expected.