### PR TITLE
fix: missing validation errors

### DIFF
--- a/.changeset/quick-dolls-trade.md
+++ b/.changeset/quick-dolls-trade.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": patch
+---
+
+fix: validator errors mt-field-error

--- a/packages/component-library/src/components/form/_internal/mt-field-error/mt-field-error.spec.ts
+++ b/packages/component-library/src/components/form/_internal/mt-field-error/mt-field-error.spec.ts
@@ -1,0 +1,48 @@
+import { render, screen } from "@testing-library/vue";
+import { expect, describe, it, vi } from "vitest";
+import MtFieldError from "./mt-field-error.vue";
+
+// Mock the i18n composable
+vi.mock("vue-i18n", () => ({
+  useI18n: () => ({
+    t: vi.fn((key: string) => {
+      const translations: Record<string, string> = {
+        "global.error-codes.FRAMEWORK__MISSING_PRIVILEGE_ERROR": "Missing permissions",
+        "mt-field-error.FRAMEWORK__MISSING_PRIVILEGE_ERROR": "Missing permissions",
+        "mt-field-error.FRAMEWORK__DELETE_RESTRICTED": "Deletion failed",
+        "mt-field-error.INVALID_MAIL": "Please enter a valid email address.",
+        "mt-field-error.c1051bb4-d103-4f74-8988-acbcafc7fdc3": "This field must not be empty.",
+      };
+
+      return translations[key] || key;
+    }),
+  }),
+}));
+
+describe("mt-field-error", () => {
+  it("should render translated error message", () => {
+    const error = {
+      code: "FRAMEWORK__MISSING_PRIVILEGE_ERROR",
+      detail: "Fallback error message",
+    };
+
+    render(MtFieldError, {
+      props: { error },
+    });
+
+    expect(screen.getByText("Missing permissions")).toBeInTheDocument();
+  });
+
+  it("should fallback to detail when no translation is found", () => {
+    const error = {
+      code: "UNKNOWN_ERROR_CODE",
+      detail: "This is a custom error message",
+    };
+
+    render(MtFieldError, {
+      props: { error },
+    });
+
+    expect(screen.getByText("This is a custom error message")).toBeInTheDocument();
+  });
+});

--- a/packages/component-library/src/components/form/_internal/mt-field-error/mt-field-error.spec.ts
+++ b/packages/component-library/src/components/form/_internal/mt-field-error/mt-field-error.spec.ts
@@ -7,11 +7,10 @@ vi.mock("vue-i18n", () => ({
   useI18n: () => ({
     t: vi.fn((key: string) => {
       const translations: Record<string, string> = {
-        "global.error-codes.FRAMEWORK__MISSING_PRIVILEGE_ERROR": "Missing permissions",
-        "mt-field-error.FRAMEWORK__MISSING_PRIVILEGE_ERROR": "Missing permissions",
-        "mt-field-error.FRAMEWORK__DELETE_RESTRICTED": "Deletion failed",
-        "mt-field-error.INVALID_MAIL": "Please enter a valid email address.",
-        "mt-field-error.c1051bb4-d103-4f74-8988-acbcafc7fdc3": "This field must not be empty.",
+        "global.error-codes.FRAMEWORK__MISSING_PRIVILEGE_ERROR": "This is a global error",
+        "mt-field-error.FRAMEWORK__MISSING_PRIVILEGE_ERROR": "This is a mt-field-error error",
+        "global.error-codes.GLOBAL_ONLY_ERROR": "This is a global only error",
+        "mt-field-error.MT_FIELD_ONLY_ERROR": "This is a mt-field-error only error",
       };
 
       return translations[key] || key;
@@ -20,19 +19,6 @@ vi.mock("vue-i18n", () => ({
 }));
 
 describe("mt-field-error", () => {
-  it("should render translated error message", () => {
-    const error = {
-      code: "FRAMEWORK__MISSING_PRIVILEGE_ERROR",
-      detail: "Fallback error message",
-    };
-
-    render(MtFieldError, {
-      props: { error },
-    });
-
-    expect(screen.getByText("Missing permissions")).toBeInTheDocument();
-  });
-
   it("should fallback to detail when no translation is found", () => {
     const error = {
       code: "UNKNOWN_ERROR_CODE",
@@ -44,5 +30,31 @@ describe("mt-field-error", () => {
     });
 
     expect(screen.getByText("This is a custom error message")).toBeInTheDocument();
+  });
+
+  it("should prefer global.error-codes over mt-field-errors", () => {
+    const error = {
+      code: "GLOBAL_ONLY_ERROR",
+      detail: "Fallback error message",
+    };
+
+    render(MtFieldError, {
+      props: { error },
+    });
+
+    expect(screen.getByText("This is a global only error")).toBeInTheDocument();
+  });
+
+  it("should show mt-field-error when global.error-codes is not available", () => {
+    const error = {
+      code: "MT_FIELD_ONLY_ERROR",
+      detail: "Fallback error message",
+    };
+
+    render(MtFieldError, {
+      props: { error },
+    });
+
+    expect(screen.getByText("This is a mt-field-error only error")).toBeInTheDocument();
   });
 });

--- a/packages/component-library/src/components/form/_internal/mt-field-error/mt-field-error.vue
+++ b/packages/component-library/src/components/form/_internal/mt-field-error/mt-field-error.vue
@@ -29,13 +29,27 @@ const errorMessage = computed(() => {
     return t(props.error?.detail ?? "");
   }
 
-  const translation = t(props.error.code, props.error.parameters || {});
-  const noTranslationFound = translation === props.error.code.toString();
+  // Try multiple translation namespaces with fallback
+  const translationKeys = [
+    `global.error-codes.${props.error.code}`,
+    `mt-field-error.${props.error.code}`,
+  ];
 
-  return noTranslationFound ? props.error.detail : translation;
+  for (const key of translationKeys) {
+    const translation = t(key, props.error.parameters || {});
+    const noTranslationFound = translation === key;
+
+    if (!noTranslationFound) {
+      return translation;
+    }
+  }
+
+  // Fallback to error detail if no translation found
+  return props.error.detail;
 });
 
 const { t } = useI18n({
+  useScope: "global",
   messages: {
     en: {
       "mt-field-error": {


### PR DESCRIPTION
## What?
This pr fixes the bug that some validation errors were missing or incorrect in meteor components. 

## Why?
In platform when the page was translated some validation errors were appearing in English or in some cases not at all.

## How?
I've added logic to check global.error-codes then mt-field-errors and if nothing matches, we fall back to the default behaviour.

## Testing?
I've added some unit tests but also tested this in admin