### PR TITLE
feat(a11y): Allow `strong` and `em` html tags

### DIFF
--- a/packages/component-library/src/components/overlay/mt-tooltip/mt-tooltip.vue
+++ b/packages/component-library/src/components/overlay/mt-tooltip/mt-tooltip.vue
@@ -206,7 +206,7 @@ provide(TooltipContext, true);
 function useSanitizedHtml(html: string): ComputedRef<string> {
   return computed(() => {
     return DOMPurify.sanitize(html, {
-      ALLOWED_TAGS: ["a", "b", "i", "u", "s", "li", "ul", "img", "svg"],
+      ALLOWED_TAGS: ["a", "b", "strong", "i", "em", "u", "s", "li", "ul", "img", "svg"],
     });
   });
 }


### PR DESCRIPTION
## What?
`b` and `i` serve a different purpose than `strong` and `i`.

## Why?
In terms of accessibility, you mostly want to use `strong` and `em`

## How?
Extend the tag stripper

## Parent
https://github.com/shopware/shopware/pull/10949

## Testing?

## Screenshots (optional)

## Anything Else?
