### PR TITLE
Fix visual bugs for empty state

### DIFF
--- a/.changeset/tasty-peas-juggle.md
+++ b/.changeset/tasty-peas-juggle.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": patch
+---
+
+Improve text-wrapping for empty state descriptions

--- a/.changeset/three-buttons-scream.md
+++ b/.changeset/three-buttons-scream.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": patch
+---
+
+Set fixed dimensions for icon in mt-empty-state regardless which icon is used

--- a/packages/component-library/src/components/layout/mt-empty-state/mt-empty-state.vue
+++ b/packages/component-library/src/components/layout/mt-empty-state/mt-empty-state.vue
@@ -74,6 +74,7 @@ defineEmits(["button-click"]);
 
 .mt-empty-state__description {
   margin-top: var(--scale-size-8);
+  text-wrap: pretty;
 }
 
 .mt-empty-state__link {

--- a/packages/component-library/src/components/layout/mt-empty-state/mt-empty-state.vue
+++ b/packages/component-library/src/components/layout/mt-empty-state/mt-empty-state.vue
@@ -61,8 +61,10 @@ defineEmits(["button-click"]);
 }
 
 .mt-empty-state__icon {
-  display: inline-block;
-  padding: var(--scale-size-12);
+  width: var(--scale-size-48);
+  height: var(--scale-size-48);
+  display: grid;
+  place-items: center;
   border-radius: var(--border-radius-xs);
   background-color: var(--color-interaction-secondary-dark);
 }


### PR DESCRIPTION
## What?

I set the height and width for the icon always to 48px. It has now the same height and width as it is in Figma.

## Why?

The size of the gray area, for the icon, changed when you use a different icon. When you used one icon it was 42px large. If you used another icon it might be 46px tall and 43px wide.

We need to get rid of that inconsistency.

## How?

I defined a fixed height and width for the icon section. Now it's always 48px tall and wide.

## Testing?

The visual tests make sure everything still looks fine.

## Anything Else?

I've made sure the empty state description no longer shows any widows, when the texts needs to wrap.
