### PR TITLE
fix(tokens): update sync script to correctly create color tokens with alpha value

### DIFF
--- a/packages/tokens/src/dictionary/domain/Color.test.ts
+++ b/packages/tokens/src/dictionary/domain/Color.test.ts
@@ -21,3 +21,23 @@ test('creates a hex color out of an RGBA value', () => {
   // THEN
   expect(result.toHex()).toBe('#0000ff00');
 });
+
+test('creates a hex color with full opacity out of an RGBA value', () => {
+  const subject = Color;
+
+  // WHEN
+  const result = subject.fromRGB(0, 0, 255, 1);
+
+  // THEN
+  expect(result.toHex()).toBe('#0000ff');
+});
+
+test('creates a hex color with some opacity out of an RGBA value', () => {
+  const subject = Color;
+
+  // WHEN
+  const result = subject.fromRGB(0, 0, 255, 0.5);
+
+  // THEN
+  expect(result.toHex()).toBe('#0000ff80');
+});

--- a/packages/tokens/src/dictionary/domain/Color.ts
+++ b/packages/tokens/src/dictionary/domain/Color.ts
@@ -35,6 +35,6 @@ export class Color {
     ].join('');
 
     const containsAlpha = this.value.alpha !== 1;
-    return `#${hex}` + (containsAlpha ? toHex(this.value.alpha) : '');
+    return `#${hex}` + (containsAlpha ? toHex(this.value.alpha * 255) : '');
   }
 }


### PR DESCRIPTION
## What?

I updated the token sync script, so that it correctly converts our RGBA values to the correct HEX color with alpha values.

## Why?

We do not correctly sync transparent color tokens. The hex version of our tokens have the wrong opacity value. And now they do not look exactly the way the should look.

## Testing?

I wrote a unit test to make sure we properly convert the RGBA value into the correct hex value