### PR TITLE
fix: move ellipsis animation from mixins

### DIFF
--- a/.changeset/great-planes-march.md
+++ b/.changeset/great-planes-march.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": patch
+---
+
+Moved ellipsis animation from mixins to global

--- a/packages/component-library/src/components/assets/scss/global.scss
+++ b/packages/component-library/src/components/assets/scss/global.scss
@@ -93,3 +93,9 @@ button {
 :root {
   --color-elevation-shadow-default: #1010131a !important;
 }
+
+@keyframes ellipsis {
+  to {
+    width: 1.25rem;
+  }
+}

--- a/packages/component-library/src/components/assets/scss/mixins.scss
+++ b/packages/component-library/src/components/assets/scss/mixins.scss
@@ -66,12 +66,6 @@
   }
 }
 
-@keyframes ellipsis {
-  to {
-    width: 1.25rem;
-  }
-}
-
 /// @type Other
 @mixin transition($what: all, $time: 0.3s, $how: ease) {
   transition: $what $time $how;


### PR DESCRIPTION
## What?

Moved ellipsis @keyframes CSS animation from mixins to global CSS.

## Why?

It was dumped to dist index.css multiple times, now it's present exactly once.

## How?

## Testing?

Built the package locally.

## Screenshots (optional)

## Anything Else?
