### PR TITLE
fix(component-library): stop showing hover styles for disabled number field controls

### DIFF
--- a/.changeset/thirty-candles-cheat.md
+++ b/.changeset/thirty-candles-cheat.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": patch
+---
+
+stop showing hover styles for disabled number field controls

--- a/packages/component-library/src/components/form/mt-number-field/mt-number-field.vue
+++ b/packages/component-library/src/components/form/mt-number-field/mt-number-field.vue
@@ -417,7 +417,7 @@ export default defineComponent({
     width: 100%;
     flex: 1;
 
-    &:is(:hover, :focus-visible) {
+    &:is(:hover, :focus-visible):not(:disabled) {
       background-color: var(--color-interaction-secondary-hover);
     }
 


### PR DESCRIPTION
## What?

This change no longer shows a hover state for the increment and decrement buttons of disabled number fields.

## Why?

A hover state tells the user that they can interact with that element. But they can't because it's disabled.

This behaviour confuses the user.

## How?

The hover styles now only apply to enabled / non-disabled input controls.
