### PR TITLE
fix(component-library): add color for banner content

### DIFF
--- a/.changeset/cyan-needles-speak.md
+++ b/.changeset/cyan-needles-speak.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": patch
+---
+
+Add color for banner content

--- a/packages/component-library/src/components/feedback-indicator/mt-banner/mt-banner.vue
+++ b/packages/component-library/src/components/feedback-indicator/mt-banner/mt-banner.vue
@@ -139,6 +139,10 @@ const bodyClasses = computed(() => ({
   gap: var(--scale-size-4);
 }
 
+.mt-banner__message {
+  color: var(--color-text-primary-default);
+}
+
 .mt-banner__icon {
   width: var(--scale-size-20);
   height: var(--scale-size-20);


### PR DESCRIPTION
## What?

A defined a color for the banner content.

## Why?

When you're in dark mode and you take a look at the banner content. You'll see that the contrast of that 

You only really notice that when the Dark Mode is turned on. 

## How?

I set a color for the banner content.

## Testing?

I did some manual testing to verify the changes.

## Screenshots (optional)

### Before
<img width="799" height="123" alt="Bildschirmfoto 2025-08-25 um 14 31 34" src="https://github.com/user-attachments/assets/449e6697-7633-4ac4-a924-4d6f41dcae0d" />

### After
<img width="1080" height="130" alt="Bildschirmfoto 2025-08-25 um 14 30 53" src="https://github.com/user-attachments/assets/fd88a3c2-0774-4203-a7db-a0a79178ee54" />
