### PR TITLE
fix: fix mt-card overflow behavior

### DIFF
--- a/.changeset/rude-cars-help.md
+++ b/.changeset/rude-cars-help.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": patch
+---
+
+Fix that overflowed elements like popovers aren't visible inside mt-card

--- a/packages/component-library/src/components/layout/mt-card/mt-card.vue
+++ b/packages/component-library/src/components/layout/mt-card/mt-card.vue
@@ -183,7 +183,6 @@ const cardClasses = computed(() => ({
   background: var(--color-elevation-surface-raised);
   border: 1px solid var(--color-border-secondary-default);
   border-radius: var(--border-radius-card); /* Added here */
-  overflow: hidden;
 
   &:not(:has(.mt-card__tabs:empty)) .mt-card__header {
     border-bottom: none;


### PR DESCRIPTION
## What?

Fixes https://github.com/shopware/shopware/issues/12359

## Why?

`overflow:hidden` hides anything outside the card, e.g at popover elements