### PR TITLE
docs(component-library): add i18n configuration

### DIFF
--- a/packages/component-library/README.md
+++ b/packages/component-library/README.md
@@ -13,10 +13,10 @@ You need a working **Vue 3 application** with the **i18n plugin** for the transl
 
 ## Installation
 
-Add this package to your project:
+Add these packages to your project:
 
 ```cli
-npm i @shopware-ag/meteor-component-library
+npm i @shopware-ag/meteor-component-library vue-i18n
 ```
 
 Import the `style.css` for general styling and `font.css` for the Inter font in the root file of your application or in you root styling file.
@@ -24,6 +24,16 @@ Import the `style.css` for general styling and `font.css` for the Inter font in 
 ```js
 import "@shopware-ag/meteor-component-library/styles.css";
 import "@shopware-ag/meteor-component-library/font.css";
+```
+
+Now, configure the i18n plugin for Vue.
+
+```js
+const i18n = createI18n({
+  legacy: false,
+});
+
+app.use(i18n);
 ```
 
 Each component works independently and can be imported directly from the root like this:


### PR DESCRIPTION
## What?

I added a i18n configuration step into the getting started guide for meteor

## Why?


We require i18n for meteor to work. And this step is missing in the docs.

So, a lot of people had this issue when setting up the component library.

## How?

I added the step to the getting started guide.