### PR TITLE
task: add shopware sso button to have it standardised everywhere

### DIFF
--- a/packages/component-library/src/components/form/mt-shopware-sso-button/mt-shopware-sso-button.interactive.stories.ts
+++ b/packages/component-library/src/components/form/mt-shopware-sso-button/mt-shopware-sso-button.interactive.stories.ts
@@ -1,0 +1,46 @@
+import { within, userEvent, expect } from "@storybook/test";
+
+import meta, {
+  type MtShopwareSsoButtonMeta,
+  type MtShopwareSsoButtonStory,
+} from "./mt-shopware-sso-button.stories";
+
+export default {
+  ...meta,
+  title: "Interaction Tests/Form/mt-shopware-sso-button",
+} as MtShopwareSsoButtonMeta;
+
+export const VisualTestClicks: MtShopwareSsoButtonStory = {
+  name: "Should emit click",
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(canvas.getByRole("button"));
+
+    expect(args.click).toHaveBeenCalled();
+  },
+};
+
+export const VisualTestDisabled: MtShopwareSsoButtonStory = {
+  name: "Should be disabled",
+  args: {
+    disabled: true,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(canvas.getByRole("button")).toBeDisabled();
+  },
+};
+
+export const VisualTestAsLink: MtShopwareSsoButtonStory = {
+  name: "Should render as link",
+  args: {
+    is: "a",
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(canvas.getByRole("link")).toBeVisible();
+  },
+};
+
+

--- a/packages/component-library/src/components/form/mt-shopware-sso-button/mt-shopware-sso-button.spec.ts
+++ b/packages/component-library/src/components/form/mt-shopware-sso-button/mt-shopware-sso-button.spec.ts
@@ -1,0 +1,52 @@
+import { render, screen } from "@testing-library/vue";
+import { userEvent } from "@testing-library/user-event";
+import MtShopwareSsoButton from "./mt-shopware-sso-button.vue";
+
+describe("mt-shopware-sso-button", () => {
+  it("renders default label", () => {
+    render(MtShopwareSsoButton);
+
+    expect(screen.getByRole("button", { name: /login with shopware sso/i })).toBeVisible();
+  });
+
+  it("allows custom label via default slot", () => {
+    render(MtShopwareSsoButton, {
+      slots: {
+        default: "Sign in with Shopware",
+      },
+    });
+
+    expect(screen.getByRole("button", { name: /sign in with shopware/i })).toBeVisible();
+  });
+
+  it("emits click when pressed", async () => {
+    const { emitted } = render(MtShopwareSsoButton);
+
+    await userEvent.click(screen.getByRole("button"));
+
+    expect(emitted().click).toBeTruthy();
+  });
+
+  it("can be rendered as an anchor tag", () => {
+    render(MtShopwareSsoButton, {
+      props: {
+        is: "a",
+      },
+      attrs: {
+        href: "https://example.com",
+      },
+    });
+
+    expect(screen.getByRole("link")).toHaveAttribute("href", "https://example.com");
+  });
+
+  it("supports disabled state", async () => {
+    render(MtShopwareSsoButton, {
+      props: { disabled: true },
+    });
+
+    expect(screen.getByRole("button")).toBeDisabled();
+  });
+});
+
+

--- a/packages/component-library/src/components/form/mt-shopware-sso-button/mt-shopware-sso-button.stories.ts
+++ b/packages/component-library/src/components/form/mt-shopware-sso-button/mt-shopware-sso-button.stories.ts
@@ -1,0 +1,37 @@
+import type { StoryObj } from "@storybook/vue3";
+import { action } from "@storybook/addon-actions";
+import { fn } from "@storybook/test";
+import MtShopwareSsoButton from "./mt-shopware-sso-button.vue";
+import type { SlottedMeta } from "@/_internal/story-helper";
+
+export type MtShopwareSsoButtonMeta = SlottedMeta<
+  typeof MtShopwareSsoButton,
+  "default" | "click"
+>;
+
+export default {
+  title: "Components/Form/mt-shopware-sso-button",
+  component: MtShopwareSsoButton,
+  args: {
+    default: "Login with Shopware SSO",
+    disabled: false,
+    block: false,
+    is: "button",
+    click: fn(action("click")),
+  },
+  render: (args) => ({
+    components: { MtShopwareSsoButton },
+    setup() {
+      return { args };
+    },
+    template: `<mt-shopware-sso-button @click="args.click" v-bind="args">{{ args.default }}</mt-shopware-sso-button>`,
+  }),
+} as MtShopwareSsoButtonMeta;
+
+export type MtShopwareSsoButtonStory = StoryObj<MtShopwareSsoButtonMeta>;
+
+export const DefaultStory: MtShopwareSsoButtonStory = {
+  name: "mt-shopware-sso-button",
+};
+
+

--- a/packages/component-library/src/components/form/mt-shopware-sso-button/mt-shopware-sso-button.vue
+++ b/packages/component-library/src/components/form/mt-shopware-sso-button/mt-shopware-sso-button.vue
@@ -1,0 +1,47 @@
+<template>
+  <mt-button
+    class="mt-shopware-sso-button"
+    variant="primary"
+    :block="block"
+    :disabled="disabled"
+    :is="is"
+    v-bind="$attrs"
+  >
+    <slot>
+      Login with Shopware SSO
+    </slot>
+
+    <template #iconBack="slotProps">
+      <mt-icon name="solid-shopware" :size="`${slotProps.size}px`" decorative />
+    </template>
+  </mt-button>
+  
+</template>
+
+<script setup lang="ts">
+import MtButton from "@/components/form/mt-button/mt-button.vue";
+import MtIcon from "@/components/icons-media/mt-icon/mt-icon.vue";
+
+withDefaults(
+  defineProps<{
+    is?: string;
+    disabled?: boolean;
+    block?: boolean;
+  }>(),
+  {
+    is: "button",
+  },
+);
+</script>
+
+<style scoped>
+.mt-shopware-sso-button :deep(.mt-button__content) {
+  column-gap: var(--scale-size-12);
+}
+
+.mt-shopware-sso-button :deep(.mt-icon) {
+  color: var(--color-static-white);
+}
+</style>
+
+

--- a/packages/component-library/src/index.ts
+++ b/packages/component-library/src/index.ts
@@ -47,6 +47,7 @@ import MtUrlField from "./components/form/mt-url-field/mt-url-field.vue";
 import MtUnitField from "./components/form/mt-unit-field/mt-unit-field.vue";
 import MtEntityDataTable from "./components/entity/mt-entity-data-table/mt-entity-data-table.vue";
 import MtEntitySelect from "./components/entity/mt-entity-select/mt-entity-select.vue";
+import MtShopwareSsoButton from "./components/form/mt-shopware-sso-button/mt-shopware-sso-button.vue";
 
 // Import SCSS for styling
 import "./components/assets/scss/all.scss";
@@ -105,6 +106,7 @@ export {
   MtUnitField,
   MtEntityDataTable,
   MtEntitySelect,
+  MtShopwareSsoButton,
   TooltipDirective,
   DeviceHelperPlugin,
   // @deprecated


### PR DESCRIPTION
## What?
Added a Shopware SSO button to standardise it over all apps

## Why?
I believe more and more apps will use the Shopware SSO feature, so it's good to get it in early

## How?
Just created a component and added it to the library

## Testing?
Yes, included

## Screenshots (optional)
<img width="241" height="96" alt="image" src="https://github.com/user-attachments/assets/327f8393-e2fe-4813-9f9a-be462318ea99" />

## Anything Else?
