### PR TITLE
build(tokens): mark all deps as dev deps

### DIFF
--- a/.changeset/late-moose-sit.md
+++ b/.changeset/late-moose-sit.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-tokens": patch
+---
+
+mark every dependency as a dev dependency

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -31,13 +31,11 @@
     "test:unit:watch": "vitest",
     "build": "echo 'This is only used for turbo repo caching'"
   },
-  "dependencies": {
+  "devDependencies": {
     "dotenv": "^16.4.7",
     "ora": "^8.2.0",
     "vitest": "^3.0.6",
-    "zod": "^3.25.75"
-  },
-  "devDependencies": {
+    "zod": "^3.25.75",
     "@eslint/js": "^9.20.0",
     "@types/node": "^22.13.4",
     "eslint": "^9.20.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -646,19 +646,6 @@ importers:
         version: 4.15.6
 
   packages/tokens:
-    dependencies:
-      dotenv:
-        specifier: ^16.4.7
-        version: 16.4.7
-      ora:
-        specifier: ^8.2.0
-        version: 8.2.0
-      vitest:
-        specifier: ^3.0.6
-        version: 3.0.6(@types/node@22.13.4)(jsdom@26.1.0)(msw@2.7.1(@types/node@22.13.4)(typescript@5.7.3))(sass@1.77.6)(terser@5.31.1)
-      zod:
-        specifier: ^3.25.75
-        version: 3.25.75
     devDependencies:
       '@eslint/js':
         specifier: ^9.20.0
@@ -666,6 +653,9 @@ importers:
       '@types/node':
         specifier: ^22.13.4
         version: 22.13.4
+      dotenv:
+        specifier: ^16.4.7
+        version: 16.4.7
       eslint:
         specifier: ^9.20.1
         version: 9.20.1(jiti@1.21.7)
@@ -675,6 +665,9 @@ importers:
       msw:
         specifier: ^2.7.1
         version: 2.7.1(@types/node@22.13.4)(typescript@5.7.3)
+      ora:
+        specifier: ^8.2.0
+        version: 8.2.0
       prettier:
         specifier: ^3.5.1
         version: 3.5.1
@@ -684,6 +677,12 @@ importers:
       typescript-eslint:
         specifier: ^8.24.1
         version: 8.24.1(eslint@9.20.1(jiti@1.21.7))(typescript@5.7.3)
+      vitest:
+        specifier: ^3.0.6
+        version: 3.0.6(@types/node@22.13.4)(jsdom@26.1.0)(msw@2.7.1(@types/node@22.13.4)(typescript@5.7.3))(sass@1.77.6)(terser@5.31.1)
+      zod:
+        specifier: ^3.25.75
+        version: 3.25.75
 
 packages:
 
@@ -6444,6 +6443,7 @@ packages:
 
   expect-playwright@0.8.0:
     resolution: {integrity: sha512-+kn8561vHAY+dt+0gMqqj1oY+g5xWrsuGMk4QGxotT2WS545nVqqjs37z6hrYfIuucwqthzwJfCJUEYqixyljg==}
+    deprecated: ⚠️ The 'expect-playwright' package is deprecated. The Playwright core assertions (via @playwright/test) now cover the same functionality. Please migrate to built-in expect. See https://playwright.dev/docs/test-assertions for migration.
 
   expect-type@1.1.0:
     resolution: {integrity: sha512-bFi65yM+xZgk+u/KRIpekdSYkTB5W1pEf0Lt8Q8Msh7b+eQ7LXVtIB1Bkm4fvclDEL1b2CZkMhv2mOeF8tMdkA==}
@@ -6975,6 +6975,7 @@ packages:
 
   has-own@1.0.1:
     resolution: {integrity: sha512-RDKhzgQTQfMaLvIFhjahU+2gGnRBK6dYOd5Gd9BzkmnBneOCRYjRC003RIMrdAbH52+l+CnMS4bBCXGer8tEhg==}
+    deprecated: This project is not maintained. Use Object.hasOwn() instead.
 
   has-property-descriptors@1.0.2:
     resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
@@ -7723,6 +7724,7 @@ packages:
 
   jest-playwright-preset@4.0.0:
     resolution: {integrity: sha512-+dGZ1X2KqtwXaabVjTGxy0a3VzYfvYsWaRcuO8vMhyclHSOpGSI1+5cmlqzzCwQ3+fv0EjkTc7I5aV9lo08dYw==}
+    deprecated: ⚠️ The 'jest-playwright-preset' package is deprecated. Please migrate to Playwright's built-in test runner (@playwright/test) which now includes full Jest-style features and parallel testing. See https://playwright.dev/docs/intro for details.
     peerDependencies:
       jest: ^29.3.1
       jest-circus: ^29.3.1
@@ -7740,6 +7742,7 @@ packages:
 
   jest-process-manager@0.4.0:
     resolution: {integrity: sha512-80Y6snDyb0p8GG83pDxGI/kQzwVTkCxc7ep5FPe/F6JYdvRDhwr6RzRmPSP7SEwuLhxo80lBS/NqOdUIbHIfhw==}
+    deprecated: ⚠️ The 'jest-process-manager' package is deprecated. Please migrate to Playwright's built-in test runner (@playwright/test) which now includes full Jest-style features and parallel testing. See https://playwright.dev/docs/intro for details.
 
   jest-regex-util@27.5.1:
     resolution: {integrity: sha512-4bfKq2zie+x16okqDXjXn9ql2B0dScQu+vcwe4TvFVhkVyuWLqpZrZtXxLLWoXYgn0E87I6r6GRYHF7wFZBUvg==}
@@ -9698,7 +9701,7 @@ packages:
   puppeteer@12.0.1:
     resolution: {integrity: sha512-YQ3GRiyZW0ddxTW+iiQcv2/8TT5c3+FcRUCg7F8q2gHqxd5akZN400VRXr9cHQKLWGukmJLDiE72MrcLK9tFHQ==}
     engines: {node: '>=10.18.1'}
-    deprecated: < 22.8.2 is no longer supported
+    deprecated: < 24.15.0 is no longer supported
 
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
@@ -11589,8 +11592,8 @@ packages:
   vue-component-type-helpers@2.0.21:
     resolution: {integrity: sha512-3NaicyZ7N4B6cft4bfb7dOnPbE9CjLcx+6wZWAg5zwszfO4qXRh+U52dN5r5ZZfc6iMaxKCEcoH9CmxxoFZHLg==}
 
-  vue-component-type-helpers@3.1.1:
-    resolution: {integrity: sha512-B0kHv7qX6E7+kdc5nsaqjdGZ1KwNKSUQDWGy7XkTYT7wFsOpkEyaJ1Vq79TjwrrtuLRgizrTV7PPuC4rRQo+vw==}
+  vue-component-type-helpers@3.1.3:
+    resolution: {integrity: sha512-V1dOD8XYfstOKCnXbWyEJIrhTBMwSyNjv271L1Jlx9ExpNlCSuqOs3OdWrGJ0V544zXufKbcYabi/o+gK8lyfQ==}
 
   vue-demi@0.14.10:
     resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
@@ -15223,7 +15226,7 @@ snapshots:
       ts-dedent: 2.2.0
       type-fest: 2.19.0
       vue: 3.5.13(typescript@5.7.3)
-      vue-component-type-helpers: 3.1.1
+      vue-component-type-helpers: 3.1.3
 
   '@supercharge/promise-pool@2.4.0': {}
 
@@ -25764,7 +25767,7 @@ snapshots:
 
   vue-component-type-helpers@2.0.21: {}
 
-  vue-component-type-helpers@3.1.1: {}
+  vue-component-type-helpers@3.1.3: {}
 
   vue-demi@0.14.10(vue@3.5.13(typescript@5.7.3)):
     dependencies:


### PR DESCRIPTION
## What?

I marked every dependency for the meteor token package as a dev dependency. 

## Why?

The package just outputs some CSS files. 

All of our dependencies are just needed to create the files. But they're not needed for other use use these now, but we're still requiring others to install these packages.

## How?

I marked every dependency as a dev dependency.