### PR TITLE
feat: upgrade vue-i18n to v10

### DIFF
--- a/packages/component-library/package.json
+++ b/packages/component-library/package.json
@@ -106,7 +106,7 @@
     "js-beautify": "^1.15.1",
     "nanoid": "^5.0.7",
     "vue-codemirror6": "^1.3.8",
-    "vue-i18n": "^9.9.1",
+    "vue-i18n": "^10.0.8",
     "vue-smooth-reflow": "^0.1.12"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -378,8 +378,8 @@ importers:
         specifier: ^1.3.8
         version: 1.3.8(@lezer/common@1.2.3)(vue@3.5.13(typescript@5.7.3))
       vue-i18n:
-        specifier: ^9.9.1
-        version: 9.13.1(vue@3.5.13(typescript@5.7.3))
+        specifier: ^10.0.8
+        version: 10.0.8(vue@3.5.13(typescript@5.7.3))
       vue-smooth-reflow:
         specifier: ^0.1.12
         version: 0.1.12(vue@3.5.13(typescript@5.7.3))
@@ -2034,12 +2034,24 @@ packages:
       '@types/node':
         optional: true
 
+  '@intlify/core-base@10.0.8':
+    resolution: {integrity: sha512-FoHslNWSoHjdUBLy35bpm9PV/0LVI/DSv9L6Km6J2ad8r/mm0VaGg06C40FqlE8u2ADcGUM60lyoU7Myo4WNZQ==}
+    engines: {node: '>= 16'}
+
   '@intlify/core-base@9.13.1':
     resolution: {integrity: sha512-+bcQRkJO9pcX8d0gel9ZNfrzU22sZFSA0WVhfXrf5jdJOS24a+Bp8pozuS9sBI9Hk/tGz83pgKfmqcn/Ci7/8w==}
     engines: {node: '>= 16'}
 
+  '@intlify/message-compiler@10.0.8':
+    resolution: {integrity: sha512-DV+sYXIkHVd5yVb2mL7br/NEUwzUoLBsMkV3H0InefWgmYa34NLZUvMCGi5oWX+Hqr2Y2qUxnVrnOWF4aBlgWg==}
+    engines: {node: '>= 16'}
+
   '@intlify/message-compiler@9.13.1':
     resolution: {integrity: sha512-SKsVa4ajYGBVm7sHMXd5qX70O2XXjm55zdZB3VeMFCvQyvLew/dLvq3MqnaIsTMF1VkkOb9Ttr6tHcMlyPDL9w==}
+    engines: {node: '>= 16'}
+
+  '@intlify/shared@10.0.8':
+    resolution: {integrity: sha512-BcmHpb5bQyeVNrptC3UhzpBZB/YHHDoEREOUERrmF2BRxsyOEuRrq+Z96C/D4+2KJb8kuHiouzAei7BXlG0YYw==}
     engines: {node: '>= 16'}
 
   '@intlify/shared@9.13.1':
@@ -11703,6 +11715,12 @@ packages:
     peerDependencies:
       eslint: '>=6.0.0'
 
+  vue-i18n@10.0.8:
+    resolution: {integrity: sha512-mIjy4utxMz9lMMo6G9vYePv7gUFt4ztOMhY9/4czDJxZ26xPeJ49MAGa9wBAE3XuXbYCrtVPmPxNjej7JJJkZQ==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      vue: ^3.0.0
+
   vue-i18n@9.13.1:
     resolution: {integrity: sha512-mh0GIxx0wPtPlcB1q4k277y0iKgo25xmDPWioVVYanjPufDBpvu5ySTjP5wOrSvlYQ2m1xI+CFhGdauv/61uQg==}
     engines: {node: '>= 16'}
@@ -11844,14 +11862,17 @@ packages:
 
   whatwg-encoding@1.0.5:
     resolution: {integrity: sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-encoding@2.0.0:
     resolution: {integrity: sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==}
     engines: {node: '>=12'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
     engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-mimetype@2.3.0:
     resolution: {integrity: sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==}
@@ -13514,15 +13535,27 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.13.4
 
+  '@intlify/core-base@10.0.8':
+    dependencies:
+      '@intlify/message-compiler': 10.0.8
+      '@intlify/shared': 10.0.8
+
   '@intlify/core-base@9.13.1':
     dependencies:
       '@intlify/message-compiler': 9.13.1
       '@intlify/shared': 9.13.1
 
+  '@intlify/message-compiler@10.0.8':
+    dependencies:
+      '@intlify/shared': 10.0.8
+      source-map-js: 1.2.1
+
   '@intlify/message-compiler@9.13.1':
     dependencies:
       '@intlify/shared': 9.13.1
       source-map-js: 1.2.0
+
+  '@intlify/shared@10.0.8': {}
 
   '@intlify/shared@9.13.1': {}
 
@@ -26029,6 +26062,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  vue-i18n@10.0.8(vue@3.5.13(typescript@5.7.3)):
+    dependencies:
+      '@intlify/core-base': 10.0.8
+      '@intlify/shared': 10.0.8
+      '@vue/devtools-api': 6.6.4
+      vue: 3.5.13(typescript@5.7.3)
+
   vue-i18n@9.13.1(vue@3.5.0(typescript@5.7.3)):
     dependencies:
       '@intlify/core-base': 9.13.1
@@ -26042,13 +26082,6 @@ snapshots:
       '@intlify/shared': 9.13.1
       '@vue/devtools-api': 6.6.3
       vue: 3.5.13(typescript@5.4.5)
-
-  vue-i18n@9.13.1(vue@3.5.13(typescript@5.7.3)):
-    dependencies:
-      '@intlify/core-base': 9.13.1
-      '@intlify/shared': 9.13.1
-      '@vue/devtools-api': 6.6.3
-      vue: 3.5.13(typescript@5.7.3)
 
   vue-inbrowser-compiler-independent-utils@4.71.1(vue@3.5.13(typescript@5.7.3)):
     dependencies:


### PR DESCRIPTION
## What?

Upgrades `vue-i18n` from `v9` to `v10` - both enter end of maintenance period in 1 day: https://vue-i18n.intlify.dev/guide/maintenance.html .

## Why?

Meteor component library introduced multiple breaking changes in `v4.24.0` (https://github.com/shopware/meteor/pull/979). This seems to solve one issue. There's still an issue with `mt-text-editor` emitting tailwind css reset and other CSS.

Seems related to `import "@git-diff-view/vue/styles/diff-view.css";` in https://github.com/shopware/meteor/pull/932, but we don't use `mt-text-editor` nor `mt-text-editor-diff-modal`.

Seems related to new bundling: some global CSS is auto-imported simply by calling `import { AnyFoo } from '@shopware-ag/meteor-component-library'`, without ever using the `AnyFoo`. The situation gets worse when the component is actually registered with `app.component('AnyFoo', AnyFoo)`.

## How?

## Testing?

Local `pnpm link` + `pnpm build`.

## Screenshots (optional)

## Anything Else?

Alternatively, we can keep bundling `vue-i18n` as in this branch: https://github.com/shopware/meteor/compare/main...dx/fix-bundle

See discussion https://github.com/shopware/meteor/pull/979#discussion_r2652840732 
