### PR TITLE
fix: add small size to mt-text-field

### DIFF
--- a/.changeset/yummy-rooms-press.md
+++ b/.changeset/yummy-rooms-press.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": minor
+---
+
+fix size `small` for `mt-base-field`

--- a/packages/component-library/src/components/form/_internal/mt-base-field/mt-base-field.vue
+++ b/packages/component-library/src/components/form/_internal/mt-base-field/mt-base-field.vue
@@ -387,6 +387,10 @@ export default defineComponent({
   margin-bottom: 0;
 }
 
+.mt-field.mt-field--small .mt-block-field__block {
+  min-height: var(--scale-size-32);
+}
+
 .mt-field.mt-field--small input,
 .mt-field.mt-field--small textarea,
 .mt-field.mt-field--small select {

--- a/packages/component-library/src/components/form/mt-slider/mt-slider.vue
+++ b/packages/component-library/src/components/form/mt-slider/mt-slider.vue
@@ -30,7 +30,6 @@
         :max="max - minDistance"
         :step="step"
         :disabled="disabled"
-        size="small"
         :number-type="step % 1 === 0 ? 'int' : 'float'"
         data-testid="left-number-field"
       />
@@ -94,7 +93,6 @@
         :max="max"
         :step="step"
         :disabled="disabled"
-        size="small"
         :number-type="step % 1 === 0 ? 'int' : 'float'"
         data-testid="right-number-field"
       />
@@ -403,13 +401,13 @@ export default defineComponent({
   overflow: visible;
 }
 
-.mt-slider .mt-field--small {
+.mt-slider .mt-field--default {
   width: 5ch;
   flex-grow: 0;
   flex-shrink: 0;
 }
 
-.mt-slider .mt-field--small > .mt-field__label {
+.mt-slider .mt-field--default > .mt-field__label {
   margin-bottom: 0;
 }
 
@@ -417,11 +415,11 @@ export default defineComponent({
   flex-shrink: 1;
 }
 
-.mt-slider .mt-field--small .mt-field__controls {
+.mt-slider .mt-field--default .mt-field__controls {
   display: none;
 }
 
-.mt-slider .mt-field--small input {
+.mt-slider .mt-field--default input {
   text-align: center;
   padding-left: var(--scale-size-4);
   padding-right: var(--scale-size-4);


### PR DESCRIPTION
## What?
closes [#737](https://github.com/shopware/meteor/issues/737)
I've added the small size for the text field.

## Why?
In some cases we need smaller input fields.

## How?
I've added size small to the base field. This also adds the small size to other input fields. 