### PR TITLE
feat(mt-text-editor): expose validate method for programmatic code co…

### DIFF
--- a/packages/component-library/src/components/form/mt-text-editor/mt-text-editor.mdx
+++ b/packages/component-library/src/components/form/mt-text-editor/mt-text-editor.mdx
@@ -181,6 +181,18 @@ To use the `mt-text-editor` component in your project, import it and provide the
 
 ---
 
+## Exposed Methods
+
+<Markdown>
+  {`
+| Method Name | Return Type      | Description                                                                                         |
+| ----------- | ---------------- | --------------------------------------------------------------------------------------------------- |
+| validate()  | Promise<boolean> | Validates code editor content against TipTap's parsed output. Shows diff modal if changes detected. Returns true if valid, false if diff modal was shown. |
+`}
+</Markdown>
+
+---
+
 ## Slots
 
 The `mt-text-editor` component provides several slots for customization:
@@ -544,3 +556,33 @@ When switching from Code â†’ WYSIWYG, the editor compares the code with TipTapâ€
 
 - Accept Changes & Switch: apply the parsed HTML and switch to WYSIWYG
 - Stay in Code Editor: keep editing in code view
+
+### Programmatic Validation
+
+The component exposes a `validate()` method via template ref. It checks the current code editor content against what TipTap can represent. If the HTML differs, the diff modal is shown for the user to review.
+
+- Returns `true` if valid (no diff or not in code mode).
+- Returns `false` if the diff modal was shown.
+
+This is useful for parent components that need to validate content before closing a modal or saving.
+
+```html
+<template>
+  <mt-text-editor ref="editor" v-model="content" />
+  <mt-button @click="onSave">Save</mt-button>
+</template>
+
+<script setup>
+  import { ref } from "vue";
+
+  const editor = ref(null);
+  const content = ref("<p>Your content here</p>");
+
+  const onSave = async () => {
+    if (!editor.value) return;
+    const isValid = await editor.value.validate();
+    if (!isValid) return;
+    // proceed with save
+  };
+</script>
+```

--- a/packages/component-library/src/components/form/mt-text-editor/mt-text-editor.vue
+++ b/packages/component-library/src/components/form/mt-text-editor/mt-text-editor.vue
@@ -657,25 +657,44 @@ const diffParsedHtml = ref("");
 // Raw parsed HTML to apply on acceptance (beautified only for display)
 const parsedHtmlRaw = ref("");
 
+/**
+ * Validates the current code editor content against what the visual editor can represent.
+ * If the HTML differs after parsing, the diff modal is shown for the user to review.
+ *
+ * @returns `true` if the content is valid (no diff) or the editor is not in code mode,
+ *          `false` if the diff modal was shown and the user needs to take action.
+ */
+const validate = async (): Promise<boolean> => {
+  if (!showCodeEditor.value) {
+    return true;
+  }
+
+  const diff = await getHtmlParseDiff(props.modelValue, editorExtensions, {
+    parseFromBeautified: false,
+  });
+
+  if (!diff.hasDiff) {
+    return true;
+  }
+
+  diffOriginalHtml.value = diff.originalBeautified;
+  diffParsedHtml.value = diff.parsedBeautified;
+  parsedHtmlRaw.value = diff.parsedRaw;
+  showDiffModal.value = true;
+  return false;
+};
+
 const onToggleCodeClick = async () => {
-  // Switching to Code view directly
   if (!showCodeEditor.value) {
     showCodeEditor.value = true;
     return;
   }
 
-  // Switching from Code to WYSIWYG: dry-run parse and compare using util
-  const diff = await getHtmlParseDiff(props.modelValue, editorExtensions, {
-    parseFromBeautified: false,
-  });
-  if (!diff.hasDiff) {
+  const isValid = await validate();
+
+  if (isValid) {
     showCodeEditor.value = false;
-    return;
   }
-  diffOriginalHtml.value = diff.originalBeautified;
-  diffParsedHtml.value = diff.parsedBeautified;
-  parsedHtmlRaw.value = diff.parsedRaw;
-  showDiffModal.value = true;
 };
 
 const onToggleFullscreenClick = () => {
@@ -818,6 +837,10 @@ onBeforeUnmount(() => {
   }
 
   applyFullscreenDocumentLock(false);
+});
+
+defineExpose({
+  validate,
 });
 </script>
 


### PR DESCRIPTION
## What?

Expose a `validate()` method on `mt-text-editor` via `defineExpose` that programmatically checks code editor content against TipTap's parsed output and shows the diff modal if differences are detected.

## Why?

Parent components (e.g. Shopware's CMS text element config) need to validate the editor content before closing a settings modal. Without an exposed API, there was no way to trigger the HTML diff check externally — invalid HTML in code mode could be silently accepted when the modal was closed without switching back to WYSIWYG mode first.

is part of: https://github.com/shopware/shopware/issues/15290

## How?

- Extracted the existing HTML diff logic from `onToggleCodeClick` into a standalone `validate()` method
- `validate()` returns `true` if content is valid (no diff or not in code mode), `false` if the diff modal was shown
- `onToggleCodeClick` now uses `validate()` internally, keeping existing behavior unchanged
- Added `defineExpose({ validate })` so the method is accessible via template refs
- Updated `mt-text-editor.mdx` docs with an "Exposed Methods" table and a "Programmatic Validation" section with usage example

## Testing?

1. Open the text editor in code mode
2. Add invalid HTML (e.g. `<div style="color: invalid">`)
3. From a parent component, call `editorRef.value.validate()`
4. Verify the diff modal appears and the method returns `false`
5. With valid HTML, verify `validate()` returns `true`
6. Verify the existing toggle-code button still works as before

## Screenshots (optional)

N/A

## Anything Else?

The Shopware side of this fix (calling `validate()` before closing the CMS slot settings modal) will be in a separate PR in the Shopware repo.
