### PR TITLE
chore(docs): Use correct headline level for sw.window.getId

### DIFF
--- a/docs/admin-sdk/api-reference/window.md
+++ b/docs/admin-sdk/api-reference/window.md
@@ -66,24 +66,24 @@ No parameters required.
 #### Return value:
 Returns a promise without data.
 
-### Get an unique identifier for the window
+### Get a unique identifier for the window
 
 > Available since Shopware v6.7.1.0
 
 When it comes to session handling it can be useful to have a unique identifier for your window.
 
-### Usage:
+#### Usage:
 ```ts
 sw.window.getId() 
 ```
 
-### Parameters
+#### Parameters:
 No parameters required
 
-### Return value:
+#### Return value:
 A `string` representing an unique identifier for the current window
 
-### Example
+#### Example:
 In this example we check if the `sessionStorage` contains data from a former window. This can happen if a user uses the *Duplicate Tab* feature of some browsers.
 
 ```ts


### PR DESCRIPTION
## What?

Updates the headline level in the "Get a unique identifier for the window" section in `docs/admin-sdk/api-reference/window.md`

## Why?

The wrong levels created a wrong navigation at https://developer.shopware.com/resources/admin-extension-sdk/api-reference/window.html

## Screenshots (optional)

<img width="1078" height="554" alt="image" src="https://github.com/user-attachments/assets/de3d1e68-ab25-48a0-a629-4c43a346b305" />
