### PR TITLE
chore: export tiptap editor/link types

### DIFF
--- a/packages/component-library/src/index.ts
+++ b/packages/component-library/src/index.ts
@@ -187,3 +187,5 @@ export {
 
 // Exporting types
 export type { Filter, Option, Toast, Snackbar, ChartOptions };
+export type { Editor } from "@tiptap/vue-3";
+export type { default as Link } from "@tiptap/extension-link";


### PR DESCRIPTION
## What?
Admin’s tsc failed because it imports types from @tiptap/vue-3 and @tiptap/extension-link, but those packages aren’t direct dependencies—only pulled in via the component library.

## Why?
TypeScript needs to resolve those modules for type-checking.

## How?
Export Editor and Link from @shopware-ag/meteor-component-library so admin can imports types