### PR TITLE
feat(admin-sdk): add telemetry.dispatch() API for extensions

### DIFF
--- a/.changeset/tangy-candles-wave.md
+++ b/.changeset/tangy-candles-wave.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-admin-sdk": minor
+---
+
+Add `telemetry.dispatch()` API for extensions to send tracking events. The `source` (extension technical name) is automatically resolved by the Admin SDK from the message origin and cannot be set manually by the extension. Also exposes `telemetry.getSourceExtensionName()` for the Admin to resolve the source when handling the event.

--- a/packages/admin-sdk/src/_internals/utils.ts
+++ b/packages/admin-sdk/src/_internals/utils.ts
@@ -64,13 +64,13 @@ export function removeRoot(path: string | number): string | number {
    if (typeof baseUrl !== 'string') {
    return undefined;
    }
- 
+
    if (baseUrl === '') {
    return undefined;
    }
- 
+
    const comparedBaseUrl = new URL(baseUrl);
- 
+
    /*
   * Check if baseUrl is the same as the current window location
   * If so, return the dummy extension with all privileges available
@@ -87,11 +87,40 @@ export function removeRoot(path: string | number): string | number {
      },
    };
    }
- 
+
    return Object.values(window._swsdk.adminExtensions)
      .find((ext) => {
      const extensionBaseUrl = new URL(ext.baseUrl);
- 
+
      return extensionBaseUrl.hostname === comparedBaseUrl.hostname;
      });
  }
+
+/**
+ * Returns the technical name (registry key) of the extension matching the given base URL.
+ * Returns undefined when the origin is the admin itself or no matching extension is found.
+ */
+export function findExtensionNameByBaseUrl(baseUrl?: string): string | undefined {
+  if (typeof baseUrl !== 'string' || baseUrl === '') {
+    return undefined;
+  }
+
+  let comparedBaseUrl: URL;
+  try {
+    comparedBaseUrl = new URL(baseUrl);
+  } catch {
+    return undefined;
+  }
+
+  if (comparedBaseUrl.origin === window.location.origin) {
+    return undefined;
+  }
+
+  return Object.entries(window._swsdk.adminExtensions).find(([, ext]) => {
+    try {
+      return new URL(ext.baseUrl).hostname === comparedBaseUrl.hostname;
+    } catch {
+      return false;
+    }
+  })?.[0];
+}

--- a/packages/admin-sdk/src/_internals/utils.ts
+++ b/packages/admin-sdk/src/_internals/utils.ts
@@ -118,7 +118,7 @@ export function findExtensionNameByBaseUrl(baseUrl?: string): string | undefined
 
   return Object.entries(window._swsdk.adminExtensions).find(([, ext]) => {
     try {
-      return new URL(ext.baseUrl).hostname === comparedBaseUrl.hostname;
+      return new URL(ext.baseUrl).origin === comparedBaseUrl.origin;
     } catch {
       return false;
     }

--- a/packages/admin-sdk/src/index.ts
+++ b/packages/admin-sdk/src/index.ts
@@ -18,6 +18,7 @@ import * as webhook from './app/action';
 import * as data from './data';
 import * as iap from './iap';
 import * as payment from './_private/payment';
+import * as telemetry from './telemetry';
 import type EntityCollectionType from './_internals/data/EntityCollection';
 import type { Entity as EntityType } from './_internals/data/Entity';
 import composables from './data/composables';
@@ -58,6 +59,7 @@ export {
   data,
   composables,
   iap,
+  telemetry,
   _private,
 };
 

--- a/packages/admin-sdk/src/message-types.ts
+++ b/packages/admin-sdk/src/message-types.ts
@@ -42,6 +42,7 @@ import type {
   repositoryCreate,
 } from './data/repository';
 import type { iapCheckout } from './iap';
+import type { telemetryDispatch } from './telemetry';
 
 /**
  * Contains all shopware send types.
@@ -106,6 +107,7 @@ export interface ShopwareMessageTypes {
   datasetUpdate: datasetUpdate,
   datasetGet: datasetGet,
   iapCheckout: iapCheckout,
+  telemetryDispatch: telemetryDispatch,
   __function__: __function__,
   __registerWindow__: __registerWindow__,
   _multiply: _multiply,

--- a/packages/admin-sdk/src/telemetry/index.spec.ts
+++ b/packages/admin-sdk/src/telemetry/index.spec.ts
@@ -57,8 +57,22 @@ describe('telemetry', () => {
     });
 
     it('returns undefined when origin matches the admin window (same origin)', () => {
-      // window.location.origin in jsdom is 'http://localhost'
       const name = getSourceExtensionName(window.location.origin);
+      expect(name).toBeUndefined();
+    });
+
+    it('does not match an extension on the same host but a different port', () => {
+      window._swsdk.adminExtensions['port-plugin'] = {
+        baseUrl: 'http://my-plugin.localhost:8080',
+        permissions: {},
+      };
+
+      const name = getSourceExtensionName('http://my-plugin.localhost:9090');
+      expect(name).toBeUndefined();
+    });
+
+    it('does not match an extension on the same host but a different scheme', () => {
+      const name = getSourceExtensionName('https://my-plugin.localhost');
       expect(name).toBeUndefined();
     });
   });

--- a/packages/admin-sdk/src/telemetry/index.spec.ts
+++ b/packages/admin-sdk/src/telemetry/index.spec.ts
@@ -1,0 +1,65 @@
+import { dispatch, getSourceExtensionName } from './index';
+
+describe('telemetry', () => {
+  describe('dispatch', () => {
+    it('is a function', () => {
+      expect(typeof dispatch).toBe('function');
+    });
+  });
+
+  describe('getSourceExtensionName', () => {
+    beforeEach(() => {
+      window._swsdk = {
+        ...window._swsdk,
+        adminExtensions: {
+          'my-plugin': {
+            baseUrl: 'http://my-plugin.localhost',
+            permissions: {},
+          },
+          'another-extension': {
+            baseUrl: 'http://another.localhost',
+            permissions: {},
+          },
+        },
+      };
+    });
+
+    afterEach(() => {
+      window._swsdk = {
+        ...window._swsdk,
+        adminExtensions: {},
+      };
+    });
+
+    it('returns the technical name for a registered extension origin', () => {
+      const name = getSourceExtensionName('http://my-plugin.localhost/some/path');
+      expect(name).toBe('my-plugin');
+    });
+
+    it('returns the correct name when multiple extensions are registered', () => {
+      const name = getSourceExtensionName('http://another.localhost');
+      expect(name).toBe('another-extension');
+    });
+
+    it('returns undefined for an unknown origin', () => {
+      const name = getSourceExtensionName('http://unknown.localhost');
+      expect(name).toBeUndefined();
+    });
+
+    it('returns undefined for empty string', () => {
+      const name = getSourceExtensionName('');
+      expect(name).toBeUndefined();
+    });
+
+    it('returns undefined for undefined', () => {
+      const name = getSourceExtensionName(undefined);
+      expect(name).toBeUndefined();
+    });
+
+    it('returns undefined when origin matches the admin window (same origin)', () => {
+      // window.location.origin in jsdom is 'http://localhost'
+      const name = getSourceExtensionName(window.location.origin);
+      expect(name).toBeUndefined();
+    });
+  });
+});

--- a/packages/admin-sdk/src/telemetry/index.ts
+++ b/packages/admin-sdk/src/telemetry/index.ts
@@ -1,0 +1,36 @@
+import { createSender } from '../channel';
+import { findExtensionNameByBaseUrl } from '../_internals/utils';
+
+/**
+ * Dispatch a telemetry event to the Admin.
+ * The source (technical name of the extension) is automatically
+ * resolved by the Admin SDK from the message origin and cannot be
+ * set manually by the extension.
+ */
+export const dispatch = createSender('telemetryDispatch');
+
+/**
+ * Resolves the technical name of the extension for the given origin URL.
+ * Used on the Admin side when handling a telemetry event to inject the
+ * source before forwarding the event to the tracking system.
+ */
+export const getSourceExtensionName = findExtensionNameByBaseUrl;
+
+/**
+ * Dispatch a telemetry event from an extension.
+ * The `source` field is not part of the extension-facing API — it is
+ * injected by the Admin after resolving the sender via {@link getSourceExtensionName}.
+ */
+export type telemetryDispatch = {
+  responseType: void,
+
+  /**
+   * The name of the event to track.
+   */
+  event: string,
+
+  /**
+   * Optional data to associate with the event.
+   */
+  data?: Record<string, unknown>,
+}


### PR DESCRIPTION
## What?

Adds a `telemetry.dispatch()` API to the Admin SDK so extensions can send tracking events to the Admin's analytics gateway.

## Why?

Extensions currently have no way to emit telemetry events. This implements [services-roadmap#430](https://github.com/shopware/services-roadmap/issues/430).

## How?

- New `telemetry` module (`src/telemetry/index.ts`) exports `dispatch` (a typed `createSender` wrapper) and `getSourceExtensionName` (for the Admin to resolve the sender)
- `telemetryDispatch` message type added to `ShopwareMessageTypes`
- `source` is intentionally absent from the extension-facing type — it is resolved by the Admin from `MessageEvent.origin` and cannot be set or forged by the extension
- `findExtensionNameByBaseUrl()` added to `_internals/utils.ts` — looks up the extension technical name by hostname from `window._swsdk.adminExtensions`

## Testing?

- 7 unit tests added in `src/telemetry/index.spec.ts` covering `dispatch` and `getSourceExtensionName` (100% coverage)
- All 169 existing unit tests pass
- Lint and type checks pass

## Screenshots (optional)

N/A

## Anything Else?

The Admin side (handler registration + forwarding to `Shopware.Telemetry.track()`) ships in a separate Shopware PR. 