### PR TITLE
feat(admin-sdk): add typed telemetry helpers for standard events

### DIFF
--- a/.changeset/puny-sloths-flash.md
+++ b/.changeset/puny-sloths-flash.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-admin-sdk": minor
+---
+
+Add typed helpers for standard telemetry events: trackPageView() and trackLinkVisited()

--- a/packages/admin-sdk/src/telemetry/index.spec.ts
+++ b/packages/admin-sdk/src/telemetry/index.spec.ts
@@ -1,9 +1,72 @@
-import { dispatch, getSourceExtensionName } from './index';
+import { dispatch, getSourceExtensionName, trackPageView, trackLinkVisited } from './index';
+
+const mockSend = jest.fn();
+jest.mock('../channel', () => ({
+  createSender: () => (...args: unknown[]) => mockSend(...args),
+}));
 
 describe('telemetry', () => {
+  beforeEach(() => {
+    mockSend.mockReset();
+    mockSend.mockResolvedValue(undefined);
+  });
+
   describe('dispatch', () => {
     it('is a function', () => {
       expect(typeof dispatch).toBe('function');
+    });
+  });
+
+  describe('trackPageView', () => {
+    it('dispatches page_viewed with the correct property names', async () => {
+      await trackPageView({
+        sw_route_from_href: '/dashboard',
+        sw_route_from_name: 'sw.dashboard.index',
+        sw_route_to_href: '/products',
+        sw_route_to_name: 'sw.product.index',
+      });
+
+      expect(mockSend).toHaveBeenCalledWith({
+        event: 'page_viewed',
+        data: {
+          sw_route_from_href: '/dashboard',
+          sw_route_from_name: 'sw.dashboard.index',
+          sw_route_to_href: '/products',
+          sw_route_to_name: 'sw.product.index',
+        },
+      });
+    });
+
+    it('includes sw_route_to_query when provided', async () => {
+      await trackPageView({
+        sw_route_from_href: '/dashboard',
+        sw_route_from_name: null,
+        sw_route_to_href: '/products',
+        sw_route_to_name: null,
+        sw_route_to_query: 'limit=25',
+      });
+
+      expect(mockSend).toHaveBeenCalledWith(expect.objectContaining({
+        data: expect.objectContaining({ sw_route_to_query: 'limit=25' }),
+      }));
+    });
+  });
+
+  describe('trackLinkVisited', () => {
+    it('dispatches link_visited with href and internal type', async () => {
+      await trackLinkVisited({ sw_link_href: '/products', sw_link_type: 'internal' });
+      expect(mockSend).toHaveBeenCalledWith({
+        event: 'link_visited',
+        data: { sw_link_href: '/products', sw_link_type: 'internal' },
+      });
+    });
+
+    it('dispatches link_visited with external type', async () => {
+      await trackLinkVisited({ sw_link_href: 'https://example.com', sw_link_type: 'external' });
+      expect(mockSend).toHaveBeenCalledWith({
+        event: 'link_visited',
+        data: { sw_link_href: 'https://example.com', sw_link_type: 'external' },
+      });
     });
   });
 

--- a/packages/admin-sdk/src/telemetry/index.ts
+++ b/packages/admin-sdk/src/telemetry/index.ts
@@ -2,6 +2,11 @@ import { createSender } from '../channel';
 import { findExtensionNameByBaseUrl } from '../_internals/utils';
 
 /**
+ * Matches the TrackableType used by the Admin analytics gateway.
+ */
+type TrackableType = string | string[] | number | boolean | null;
+
+/**
  * Dispatch a telemetry event to the Admin.
  * The source (technical name of the extension) is automatically
  * resolved by the Admin SDK from the message origin and cannot be
@@ -26,6 +31,7 @@ export function trackPageView(properties: {
   sw_route_to_href: string,
   sw_route_to_name: string | null,
   sw_route_to_query?: string,
+  [key: string]: TrackableType | undefined,
 }): Promise<void> {
   return dispatch({ event: 'page_viewed', data: properties });
 }
@@ -37,6 +43,7 @@ export function trackPageView(properties: {
 export function trackLinkVisited(properties: {
   sw_link_href: string,
   sw_link_type: 'internal' | 'external',
+  [key: string]: TrackableType | undefined,
 }): Promise<void> {
   return dispatch({ event: 'link_visited', data: properties });
 }

--- a/packages/admin-sdk/src/telemetry/index.ts
+++ b/packages/admin-sdk/src/telemetry/index.ts
@@ -17,6 +17,31 @@ export const dispatch = createSender('telemetryDispatch');
 export const getSourceExtensionName = findExtensionNameByBaseUrl;
 
 /**
+ * Track a page view, matching the `page_viewed` event emitted by the Admin.
+ * Use this instead of `dispatch` to ensure consistent property names.
+ */
+export function trackPageView(properties: {
+  sw_route_from_href: string,
+  sw_route_from_name: string | null,
+  sw_route_to_href: string,
+  sw_route_to_name: string | null,
+  sw_route_to_query?: string,
+}): Promise<void> {
+  return dispatch({ event: 'page_viewed', data: properties });
+}
+
+/**
+ * Track a link visit, matching the `link_visited` event emitted by the Admin.
+ * Use this instead of `dispatch` to ensure consistent property names.
+ */
+export function trackLinkVisited(properties: {
+  sw_link_href: string,
+  sw_link_type: 'internal' | 'external',
+}): Promise<void> {
+  return dispatch({ event: 'link_visited', data: properties });
+}
+
+/**
  * Dispatch a telemetry event from an extension.
  * The `source` field is not part of the extension-facing API — it is
  * injected by the Admin after resolving the sender via {@link getSourceExtensionName}.


### PR DESCRIPTION
## What?

Adds typed helper functions for standard telemetry events: `trackPageView()` and `trackLinkVisited()`. The generic `dispatch()` remains available for custom events.

## Why?

Follow-up to #1099. Without helpers, extensions would invent their own event and property names for common events, making Amplitude data impossible to aggregate across extensions (e.g. `page_viewed` vs `page_view` vs `page_visited`).

## How?

- `trackPageView({ sw_route_from_href, sw_route_from_name, sw_route_to_href, sw_route_to_name, sw_route_to_query? })` — matches the `page_viewed` event shape from the Admin
- `trackLinkVisited({ sw_link_href, sw_link_type: 'internal' | 'external' })` — matches the `link_visited` event shape from the Admin
- Both wrap `dispatch()` with a fixed event name and typed properties enforced by TypeScript

Login/logout helpers were considered and intentionally excluded — those are admin lifecycle events already tracked by the Admin itself.

## Testing?

- 6 new unit tests covering all helpers and edge cases
- All 175 tests pass
- Lint and type checks pass

## Screenshots (optional)

N/A

## Anything Else?

N/A