### PR TITLE
fix: lazy-initialize BroadcastChannel in payment module

### DIFF
--- a/.changeset/fix-payment-broadcast-channel.md
+++ b/.changeset/fix-payment-broadcast-channel.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-admin-sdk": patch
+---
+
+fix: lazy-initialize BroadcastChannel in payment module to prevent crash in environments without BroadcastChannel support (e.g. Jest/jsdom)

--- a/packages/admin-sdk/src/_private/payment/index.ts
+++ b/packages/admin-sdk/src/_private/payment/index.ts
@@ -119,7 +119,7 @@ export const addPaymentIframe = async (
 
   const unmount = (): void => {
     window.removeEventListener('message', handleEvent);
-    getChannel().close();
+    channel?.close();
   };
 
   el.appendChild(iframeEl);

--- a/packages/admin-sdk/src/_private/payment/index.ts
+++ b/packages/admin-sdk/src/_private/payment/index.ts
@@ -38,7 +38,13 @@ type Flow = {
   },
 }
 
-const channel = new BroadcastChannel('payment');
+let channel: BroadcastChannel | null = null;
+const getChannel = (): BroadcastChannel => {
+  if (!channel) {
+    channel = new BroadcastChannel('payment');
+  }
+  return channel;
+};
 
 const servicePaymentModalLocationId = 'sw-service-payment-modal';
 
@@ -52,11 +58,11 @@ const _createFlow = (): Flow => {
           callback();
         }
       };
-      channel.addEventListener('message', func);
+      getChannel().addEventListener('message', func);
 
       return {
         unsubscribe: (): void => {
-          channel.removeEventListener('message', func);
+          getChannel().removeEventListener('message', func);
         },
       };
     },
@@ -105,7 +111,7 @@ export const addPaymentIframe = async (
         locationId: servicePaymentModalLocationId,
       });
     } else if ([MESSAGE_EVENT_TYPE.PAYMENT_SUCCESS].includes(event.data.type as MESSAGE_EVENT_TYPE)){
-      channel.postMessage(event.data);
+      getChannel().postMessage(event.data);
     }
   };
 
@@ -113,7 +119,7 @@ export const addPaymentIframe = async (
 
   const unmount = (): void => {
     window.removeEventListener('message', handleEvent);
-    channel.close();
+    getChannel().close();
   };
 
   el.appendChild(iframeEl);


### PR DESCRIPTION
## What?
Lazy-initializes `BroadcastChannel` in the payment module instead of instantiating it at module scope.

## Why?
`new BroadcastChannel('payment')` at the top level of `_private/payment/index.ts` crashes immediately on import in environments that don't support `BroadcastChannel` (e.g. Jest/jsdom). This caused every test suite importing `@shopware-ag/meteor-admin-sdk` to fail with `ReferenceError: BroadcastChannel is not defined` after the SDK version bump to 6.7.0.

## How?
Replaced the module-level `const channel = new BroadcastChannel('payment')` with a lazy `getChannel()` accessor that initializes the channel on first use. All existing call sites updated to use `getChannel()`.

## Testing?
- Existing payment-related tests still pass
- Importing `@shopware-ag/meteor-admin-sdk` in Jest/jsdom no longer throws `BroadcastChannel is not defined`

## Screenshots (optional)
N/A

## Anything Else?
N/A