### PR TITLE
fix(telemetry): resolve source for same-origin extensions via sender window href

### DIFF
--- a/.changeset/telemetry-same-origin-extension-resolution.md
+++ b/.changeset/telemetry-same-origin-extension-resolution.md
@@ -1,0 +1,7 @@
+---
+"@shopware-ag/meteor-admin-sdk": patch
+---
+
+fix(telemetry): resolve source for same-origin extensions via sender window href
+
+`findExtensionNameByBaseUrl` (and `getSourceExtensionName`) now accept an optional `sourceWindow` parameter. When the message origin matches the Admin's own origin — which happens for plugins served from the same host — the function falls back to matching `sourceWindow.location.href` against the known `baseUrl` prefixes instead of returning `undefined`. Cross-origin behaviour is unchanged.

--- a/packages/admin-sdk/src/_internals/utils.ts
+++ b/packages/admin-sdk/src/_internals/utils.ts
@@ -98,9 +98,16 @@ export function removeRoot(path: string | number): string | number {
 
 /**
  * Returns the technical name (registry key) of the extension matching the given base URL.
- * Returns undefined when the origin is the admin itself or no matching extension is found.
+ *
+ * For cross-origin extensions the lookup uses origin comparison. For same-origin extensions
+ * (e.g. plugins served from the same host as the Admin) the origin alone is not enough to
+ * distinguish the extension from the Admin itself. Pass the sender `Window` as `sourceWindow`
+ * to enable a fallback that matches the window's full href against the known `baseUrl` prefixes.
+ *
+ * Returns undefined when no matching extension is found or when the origin is the Admin's own
+ * origin and no `sourceWindow` is provided.
  */
-export function findExtensionNameByBaseUrl(baseUrl?: string): string | undefined {
+export function findExtensionNameByBaseUrl(baseUrl?: string, sourceWindow?: Window): string | undefined {
   if (typeof baseUrl !== 'string' || baseUrl === '') {
     return undefined;
   }
@@ -113,6 +120,18 @@ export function findExtensionNameByBaseUrl(baseUrl?: string): string | undefined
   }
 
   if (comparedBaseUrl.origin === window.location.origin) {
+    // Origin alone cannot resolve same-origin extensions because origin matches
+    // the Admin itself. When the sender Window is provided, fall back to href-prefix matching.
+    if (sourceWindow) {
+      try {
+        const href = sourceWindow.location.href;
+        const match = Object.entries(window._swsdk.adminExtensions)
+          .find(([, ext]) => href.startsWith(ext.baseUrl));
+        return match?.[0];
+      } catch {
+        // Same-origin access should never be denied; ignore defensively.
+      }
+    }
     return undefined;
   }
 

--- a/packages/admin-sdk/src/_internals/utils.ts
+++ b/packages/admin-sdk/src/_internals/utils.ts
@@ -125,8 +125,15 @@ export function findExtensionNameByBaseUrl(baseUrl?: string, sourceWindow?: Wind
     if (sourceWindow) {
       try {
         const href = sourceWindow.location.href;
+        // Normalize baseUrl to end with '/' to prevent '/bundles/plugin' from
+        // matching '/bundles/plugin-extra/'. Among all matching extensions pick
+        // the most specific one (longest baseUrl) to handle nested base paths.
         const match = Object.entries(window._swsdk.adminExtensions)
-          .find(([, ext]) => href.startsWith(ext.baseUrl));
+          .filter(([, ext]) => {
+            const base = ext.baseUrl.endsWith('/') ? ext.baseUrl : `${ext.baseUrl}/`;
+            return href.startsWith(base);
+          })
+          .sort(([, a], [, b]) => b.baseUrl.length - a.baseUrl.length)[0];
         return match?.[0];
       } catch {
         // Same-origin access should never be denied; ignore defensively.

--- a/packages/admin-sdk/src/telemetry/index.spec.ts
+++ b/packages/admin-sdk/src/telemetry/index.spec.ts
@@ -119,8 +119,31 @@ describe('telemetry', () => {
       expect(name).toBeUndefined();
     });
 
-    it('returns undefined when origin matches the admin window (same origin)', () => {
+    it('returns undefined when origin matches the admin window and no sourceWindow is given', () => {
       const name = getSourceExtensionName(window.location.origin);
+      expect(name).toBeUndefined();
+    });
+
+    it('resolves a same-origin extension when sourceWindow href matches a baseUrl prefix', () => {
+      window._swsdk.adminExtensions['same-origin-plugin'] = {
+        baseUrl: `${window.location.origin}/bundles/same-origin-plugin/`,
+        permissions: {},
+      };
+
+      const fakeWindow = {
+        location: { href: `${window.location.origin}/bundles/same-origin-plugin/index.html` },
+      } as Window;
+
+      const name = getSourceExtensionName(window.location.origin, fakeWindow);
+      expect(name).toBe('same-origin-plugin');
+    });
+
+    it('returns undefined for same-origin when sourceWindow href does not match any baseUrl', () => {
+      const fakeWindow = {
+        location: { href: `${window.location.origin}/some/other/path` },
+      } as Window;
+
+      const name = getSourceExtensionName(window.location.origin, fakeWindow);
       expect(name).toBeUndefined();
     });
 

--- a/packages/admin-sdk/src/telemetry/index.spec.ts
+++ b/packages/admin-sdk/src/telemetry/index.spec.ts
@@ -147,6 +147,56 @@ describe('telemetry', () => {
       expect(name).toBeUndefined();
     });
 
+    it('does not match an extension whose baseUrl is a string prefix of another extension baseUrl', () => {
+      window._swsdk.adminExtensions['plugin'] = {
+        baseUrl: `${window.location.origin}/bundles/plugin/`,
+        permissions: {},
+      };
+      window._swsdk.adminExtensions['plugin-extra'] = {
+        baseUrl: `${window.location.origin}/bundles/plugin-extra/`,
+        permissions: {},
+      };
+
+      const fakeWindow = {
+        location: { href: `${window.location.origin}/bundles/plugin-extra/index.html` },
+      } as Window;
+
+      const name = getSourceExtensionName(window.location.origin, fakeWindow);
+      expect(name).toBe('plugin-extra');
+    });
+
+    it('resolves a same-origin extension whose baseUrl has no trailing slash', () => {
+      window._swsdk.adminExtensions['no-slash-plugin'] = {
+        baseUrl: `${window.location.origin}/bundles/no-slash-plugin`,
+        permissions: {},
+      };
+
+      const fakeWindow = {
+        location: { href: `${window.location.origin}/bundles/no-slash-plugin/index.html` },
+      } as Window;
+
+      const name = getSourceExtensionName(window.location.origin, fakeWindow);
+      expect(name).toBe('no-slash-plugin');
+    });
+
+    it('returns the most specific match when baseUrls are nested', () => {
+      window._swsdk.adminExtensions['parent-plugin'] = {
+        baseUrl: `${window.location.origin}/bundles/parent/`,
+        permissions: {},
+      };
+      window._swsdk.adminExtensions['child-plugin'] = {
+        baseUrl: `${window.location.origin}/bundles/parent/child/`,
+        permissions: {},
+      };
+
+      const fakeWindow = {
+        location: { href: `${window.location.origin}/bundles/parent/child/index.html` },
+      } as Window;
+
+      const name = getSourceExtensionName(window.location.origin, fakeWindow);
+      expect(name).toBe('child-plugin');
+    });
+
     it('does not match an extension on the same host but a different port', () => {
       window._swsdk.adminExtensions['port-plugin'] = {
         baseUrl: 'http://my-plugin.localhost:8080',


### PR DESCRIPTION
## What?

  `findExtensionNameByBaseUrl` / `getSourceExtensionName` now accept an optional `sourceWindow?: Window` parameter to resolve the technical
  name of same-origin extensions.

  ## Why?

  The existing implementation short-circuits with `undefined` whenever `event.origin === window.location.origin`, which is intentional for
  the Admin window itself — but also silently breaks plugins served from the same host. This caused the `source` field to always be
  `"unknown"` in telemetry events dispatched by same-origin extensions.

  ## How?

  When the message origin matches the Admin's own origin and a `sourceWindow` is provided, the function falls back to matching
  `sourceWindow.location.href` against the known `ext.baseUrl` prefixes in `window._swsdk.adminExtensions`. Cross-origin resolution is
  unchanged.

  On the Admin side, the `telemetryDispatch` handler passes `event.source` as `sourceWindow` when it is a `Window` instance.

  ## Testing?

  - Two new unit tests in `telemetry/index.spec.ts`: same-origin with matching href → resolves name; same-origin with non-matching href →
  `undefined`
  - Two new unit tests in the Admin's `telemetry.init.spec.js` covering the same cases end-to-end
  - Manually verified with `TelemetryTestPlugin` (served from the same host as the Admin): source now shows the plugin technical name in
  Amplitude instead of `"unknown"`

  ## Screenshots (optional)

  N/A

  ## Anything Else?

  The Admin-side change (`telemetry.init.ts`) lives in shopware/shopware#16042 and will be updated to depend on `6.7.2` once this ships.