### PR TITLE
fix(telemetry): handle exact-URL baseUrl pattern in same-origin resolution

### DIFF
--- a/packages/admin-sdk/src/_internals/utils.ts
+++ b/packages/admin-sdk/src/_internals/utils.ts
@@ -125,13 +125,15 @@ export function findExtensionNameByBaseUrl(baseUrl?: string, sourceWindow?: Wind
     if (sourceWindow) {
       try {
         const href = sourceWindow.location.href;
-        // Normalize baseUrl to end with '/' to prevent '/bundles/plugin' from
-        // matching '/bundles/plugin-extra/'. Among all matching extensions pick
-        // the most specific one (longest baseUrl) to handle nested base paths.
+        // Strip any trailing slash so both 'base/' and 'base' are normalised to
+        // 'base', then accept either an exact match (baseUrl IS the file) or a
+        // path-boundary prefix match (baseUrl is a directory). Among all
+        // matching extensions pick the most specific one (longest baseUrl) to
+        // handle nested base paths correctly.
         const match = Object.entries(window._swsdk.adminExtensions)
           .filter(([, ext]) => {
-            const base = ext.baseUrl.endsWith('/') ? ext.baseUrl : `${ext.baseUrl}/`;
-            return href.startsWith(base);
+            const base = ext.baseUrl.replace(/\/$/, '');
+            return href === base || href.startsWith(`${base}/`);
           })
           .sort(([, a], [, b]) => b.baseUrl.length - a.baseUrl.length)[0];
         return match?.[0];

--- a/packages/admin-sdk/src/telemetry/index.spec.ts
+++ b/packages/admin-sdk/src/telemetry/index.spec.ts
@@ -165,6 +165,20 @@ describe('telemetry', () => {
       expect(name).toBe('plugin-extra');
     });
 
+    it('resolves when baseUrl is the exact href of the sender window (file URL pattern)', () => {
+      window._swsdk.adminExtensions['exact-url-plugin'] = {
+        baseUrl: `${window.location.origin}/admin/exact-url-plugin/index.html`,
+        permissions: {},
+      };
+
+      const fakeWindow = {
+        location: { href: `${window.location.origin}/admin/exact-url-plugin/index.html` },
+      } as Window;
+
+      const name = getSourceExtensionName(window.location.origin, fakeWindow);
+      expect(name).toBe('exact-url-plugin');
+    });
+
     it('resolves a same-origin extension whose baseUrl has no trailing slash', () => {
       window._swsdk.adminExtensions['no-slash-plugin'] = {
         baseUrl: `${window.location.origin}/bundles/no-slash-plugin`,


### PR DESCRIPTION
## What?

  Fix same-origin extension source resolution when `baseUrl` is a file URL rather than a directory prefix.

  ## Why?

  The previous fix assumed `baseUrl` is always a directory (e.g. `/bundles/plugin/`), so it matched by checking `href.startsWith(base + '/')`. In practice Shopware sets `baseUrl` to the exact entry-point URL of the
  extension (e.g. `/admin/telemetrytestplugin/index.html`), which never matches a `startsWith` check against itself with a trailing slash appended — causing source to remain `"unknown"` in telemetry events.

  ## How?

  Strip any trailing slash from `baseUrl` before matching, then accept either an exact match (`href === base`) or a path-boundary prefix match (`href.startsWith(base + '/')`). This handles both the file-URL pattern
  and the directory-URL pattern without introducing new ambiguity.

  ## Testing?

  - New unit test: `resolves when baseUrl is the exact href of the sender window (file URL pattern)` — covers the Shopware plugin URL shape
  - All existing same-origin tests continue to pass (19 total)
  - Manually verified with `TelemetryTestPlugin` (`baseUrl: http://localhost:8000/admin/telemetrytestplugin/index.html`): source now resolves to `"TelemetryTestPlugin"` instead of `"unknown"`

  ## Screenshots (optional)

  N/A

  ## Anything Else?

  Companion change in shopware/shopware#16042 will bump `@shopware-ag/meteor-admin-sdk` to the version that ships this fix once merged.