### PR TITLE
fix(telemetry): strip query string from href before same-origin baseUrl matching

### DIFF
--- a/.changeset/telemetry-query-string-source-resolution.md
+++ b/.changeset/telemetry-query-string-source-resolution.md
@@ -1,0 +1,7 @@
+---
+"@shopware-ag/meteor-admin-sdk": patch
+---
+
+fix(telemetry): strip query string from iframe href before same-origin baseUrl matching
+
+The Admin SDK appends `?location-id=...` to extension iframe URLs. The same-origin source resolution in `findExtensionNameByBaseUrl` now strips the query string and fragment from the sender window's href before matching against `baseUrl`, so same-origin extensions are correctly identified even when the iframe URL contains query parameters.

--- a/packages/admin-sdk/src/_internals/utils.ts
+++ b/packages/admin-sdk/src/_internals/utils.ts
@@ -124,8 +124,10 @@ export function findExtensionNameByBaseUrl(baseUrl?: string, sourceWindow?: Wind
     // the Admin itself. When the sender Window is provided, fall back to href-prefix matching.
     if (sourceWindow) {
       try {
-        const href = sourceWindow.location.href;
-        // Strip any trailing slash so both 'base/' and 'base' are normalised to
+        // Strip query string and fragment — the SDK appends ?location-id=...
+        // to iFrame URLs, so we must compare only the path portion.
+        const href = sourceWindow.location.href.split('?')[0].split('#')[0];
+        // Strip any trailing slash so both 'base/' and 'base' normalise to
         // 'base', then accept either an exact match (baseUrl IS the file) or a
         // path-boundary prefix match (baseUrl is a directory). Among all
         // matching extensions pick the most specific one (longest baseUrl) to

--- a/packages/admin-sdk/src/_internals/utils.ts
+++ b/packages/admin-sdk/src/_internals/utils.ts
@@ -124,9 +124,8 @@ export function findExtensionNameByBaseUrl(baseUrl?: string, sourceWindow?: Wind
     // the Admin itself. When the sender Window is provided, fall back to href-prefix matching.
     if (sourceWindow) {
       try {
-        // Strip query string and fragment — the SDK appends ?location-id=...
-        // to iFrame URLs, so we must compare only the path portion.
-        const href = sourceWindow.location.href.split('?')[0].split('#')[0];
+        // Strip query string — the SDK appends ?location-id=... to iFrame URLs.
+        const href = sourceWindow.location.href.split('?')[0];
         // Strip any trailing slash so both 'base/' and 'base' normalise to
         // 'base', then accept either an exact match (baseUrl IS the file) or a
         // path-boundary prefix match (baseUrl is a directory). Among all

--- a/packages/admin-sdk/src/telemetry/index.spec.ts
+++ b/packages/admin-sdk/src/telemetry/index.spec.ts
@@ -171,8 +171,9 @@ describe('telemetry', () => {
         permissions: {},
       };
 
+      // The SDK appends ?location-id=... to iframe URLs; we must still resolve correctly.
       const fakeWindow = {
-        location: { href: `${window.location.origin}/admin/exact-url-plugin/index.html` },
+        location: { href: `${window.location.origin}/admin/exact-url-plugin/index.html?location-id=my-location` },
       } as Window;
 
       const name = getSourceExtensionName(window.location.origin, fakeWindow);


### PR DESCRIPTION
## What?

  findExtensionNameByBaseUrl / getSourceExtensionName failed to resolve the technical name for same-origin extensions (plugins served from
  the same host as the Admin). The sender window's location.href includes a ?location-id=... query parameter appended by the SDK, which
  caused both the exact-URL match and the path-prefix match to fail, leaving source as "unknown" in telemetry events.

##  Why?

  The Admin SDK appends ?location-id=<id> to every extension iframe's src. When the same-origin fallback reads sourceWindow.location.href and compares it against the registered baseUrl (e.g. http://localhost:8000/admin/telemetrytestplugin/index.html), the href contains the query string so neither href === base nor href.startsWith(base + '/') ever matched.

##  How?

  Strip the query string and fragment from the sender window's href before matching:

  const href = sourceWindow.location.href.split('?')[0].split('#')[0];

  The rest of the matching logic (exact URL or path-boundary prefix, longest-match wins) is unchanged.

##  Testing?

  - Unit tests added in telemetry/index.spec.ts covering: exact-URL baseUrl with ?location-id=... in the sender href, path-prefix matching
  with query params, overlapping base URLs (most-specific wins), and no-match cases.
  - Manually verified end-to-end: TelemetryTestPlugin now resolves as the source in Amplitude events instead of "unknown".

##  Anything Else?

  This is the third in a series of same-origin source-resolution fixes (#1112, #1114). It closes the last known gap — the query string appended by the SDK itself.