### PR TITLE
feat: Add consent API

### DIFF
--- a/.changeset/few-dogs-clean.md
+++ b/.changeset/few-dogs-clean.md
@@ -1,0 +1,6 @@
+---
+"@shopware-ag/meteor-admin-sdk": minor
+---
+
+Add an experimental consent API to the Admin SDK with `sw.consent.status()` and
+`sw.consent.request()`, both returning a typed `Consent` result.

--- a/docs/admin-sdk/api-reference/consent.md
+++ b/docs/admin-sdk/api-reference/consent.md
@@ -1,0 +1,110 @@
+# Consent
+
+:::caution
+The consent API is experimental. Behavior, payloads, and availability may still change in upcoming Shopware versions.
+:::
+
+The `sw.consent` API can be used to inspect the current state of a consent and to trigger a consent request flow in the Administration.
+
+Both `sw.consent.status()` and `sw.consent.request()` return a `Promise<Consent>`.
+
+## `Consent`
+
+`Consent` is the value object returned by the consent API. It represents the current state of a consent in Shopware.
+
+### Properties
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `name` | `string` | Technical name of the consent. |
+| `status` | `'unset' \| 'declined' \| 'revoked' \| 'accepted'` | Current consent status. |
+| `updatedAt` | `string \| null` | Timestamp of the last consent state update. |
+| `acceptedRevision` | `string \| null` | Revision that was accepted by the user. |
+| `lastRevision` | `string \| null` | Latest known revision of the consent. |
+
+### Derived flags
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `isAccepted` | `boolean` | `true` when the current status is `accepted`. |
+| `isStale` | `boolean` | `true` when the consent is accepted, but the accepted revision differs from the latest revision. |
+
+### Example
+
+```ts
+const consent = await sw.consent.status({
+  consent: 'product_analytics',
+});
+
+if (consent.isAccepted && !consent.isStale) {
+  console.log(`Consent "${consent.name}" is up to date.`);
+}
+```
+
+## Get consent status
+
+Read the current state of a consent without opening a consent prompt.
+
+#### Usage
+
+```ts
+const consent = await sw.consent.status({
+  consent: 'product_analytics',
+});
+```
+
+#### Parameters
+
+| Name | Required | Description |
+| :------ | :------ | :------ |
+| `consent` | true | Technical name of the consent to load. |
+
+#### Return value
+
+```ts
+Promise<Consent>
+```
+
+#### Example value
+
+```ts
+{
+  name: 'product_analytics',
+  status: 'accepted',
+  updatedAt: '2026-04-13T11:00:00.000Z',
+  acceptedRevision: '2026-03-01',
+  lastRevision: '2026-05-01',
+  isAccepted: true,
+  isStale: false,
+}
+```
+
+## Request consent
+
+Trigger the consent request flow in the Administration and resolve with the resulting consent state.
+
+#### Usage
+
+```ts
+const consent = await sw.consent.request({
+  consent: 'product_analytics',
+  requestMessage: 'Please confirm that we may track Admin usage data.',
+  privacyLink: 'https://www.shopware.com/en/privacy/dpa/',
+});
+```
+
+#### Parameters
+
+| Name | Required | Description |
+| :------ | :------ | :------ |
+| `consent` | true | Technical name of the consent to request. |
+| `requestMessage` | false | Optional message shown together with the consent request. |
+| `privacyLink` | false | Optional link to the privacy policy or related information. |
+
+#### Return value
+
+```ts
+Promise<Consent>
+```
+
+The promise resolves when Shopware sends back the matching consent response.

--- a/docs/admin-sdk/api-reference/consent.md
+++ b/docs/admin-sdk/api-reference/consent.md
@@ -6,7 +6,10 @@ The consent API is experimental. Behavior, payloads, and availability may still 
 
 The `sw.consent` API can be used to inspect the current state of a consent and to trigger a consent request flow in the Administration.
 
-Both `sw.consent.status()` and `sw.consent.request()` return a `Promise<Consent>`.
+`sw.consent.status()` returns a `Promise<Consent>`.
+`sw.consent.request()` returns an object with:
+- `requestPromise: Promise<Consent>`
+- `abort: (reason: unknown) => void`
 
 ## `Consent`
 
@@ -86,11 +89,13 @@ Trigger the consent request flow in the Administration and resolve with the resu
 #### Usage
 
 ```ts
-const consent = await sw.consent.request({
+const { requestPromise } = sw.consent.request({
   consent: 'product_analytics',
   requestMessage: 'Please confirm that we may track Admin usage data.',
   privacyLink: 'https://www.shopware.com/en/privacy/dpa/',
 });
+
+const consent = await requestPromise;
 ```
 
 #### Parameters
@@ -104,7 +109,31 @@ const consent = await sw.consent.request({
 #### Return value
 
 ```ts
-Promise<Consent>
+{
+  requestPromise: Promise<Consent>,
+  abort: (reason: unknown) => void,
+}
 ```
 
-The promise resolves when Shopware sends back the matching consent response.
+`requestPromise` resolves when Shopware sends back the matching consent response.
+
+#### Abort example
+
+```ts
+const { requestPromise, abort } = sw.consent.request({
+  consent: 'product_analytics',
+});
+
+const timeout = setTimeout(() => {
+  abort(new Error('Consent request timed out'));
+}, 5000);
+
+try {
+  const consent = await requestPromise;
+  console.log(consent.status);
+} catch (error) {
+  console.error(error);
+} finally {
+  clearTimeout(timeout);
+}
+```

--- a/docs/admin-sdk/api-reference/consent.md
+++ b/docs/admin-sdk/api-reference/consent.md
@@ -75,7 +75,7 @@ Promise<Consent>
   acceptedRevision: '2026-03-01',
   lastRevision: '2026-05-01',
   isAccepted: true,
-  isStale: false,
+  isStale: true,
 }
 ```
 

--- a/docs/admin-sdk/api-reference/consent.md
+++ b/docs/admin-sdk/api-reference/consent.md
@@ -4,6 +4,8 @@
 The consent API is experimental. Behavior, payloads, and availability may still change in upcoming Shopware versions.
 :::
 
+> Available since Shopware v6.7.10.0
+
 The `sw.consent` API can be used to inspect the current state of a consent and to trigger a consent request flow in the Administration.
 
 `sw.consent.status()` returns a `Promise<Consent>`.

--- a/packages/admin-sdk/src/channel.ts
+++ b/packages/admin-sdk/src/channel.ts
@@ -289,11 +289,11 @@ export function handle<MESSAGE_TYPE extends keyof ShopwareMessageTypes>
 
     let shopwareMessageData;
 
-    // Try to parse the json file
+    // Try to parse the json data
     try {
       shopwareMessageData = JSON.parse(event.data) as unknown;
     } catch {
-      // Fail silently when message is not a valid json file
+      // Fail silently when message is not a valid json data
       return;
     }
 

--- a/packages/admin-sdk/src/consent/index.spec.ts
+++ b/packages/admin-sdk/src/consent/index.spec.ts
@@ -1,0 +1,176 @@
+const mockStatusSender = jest.fn();
+const mockRequestSender = jest.fn();
+const mockCreateSender = jest.fn((messageType: string) => {
+  if (messageType === 'consentStatus') {
+    return mockStatusSender;
+  }
+
+  if (messageType === 'consentRequest') {
+    return mockRequestSender;
+  }
+
+  throw new Error(`Unexpected sender type: ${messageType}`);
+});
+
+const mockUnhandle = jest.fn();
+let mockConsentRequestResponseHandler: ((message: unknown) => unknown) | undefined;
+const mockCreateHandler = jest.fn((messageType: string) => {
+  if (messageType !== 'consentRequestResponse') {
+    throw new Error(`Unexpected handler type: ${messageType}`);
+  }
+
+  return (callback: (message: unknown) => unknown) => {
+    mockConsentRequestResponseHandler = callback;
+
+    return mockUnhandle;
+  };
+});
+
+jest.mock('../channel', () => ({
+  createSender: (messageType: string) => mockCreateSender(messageType),
+  createHandler: (messageType: string) => mockCreateHandler(messageType),
+}));
+
+import { request, status } from './index';
+
+describe('consent', () => {
+  beforeEach(() => {
+    mockStatusSender.mockReset();
+    mockRequestSender.mockReset();
+    mockCreateSender.mockClear();
+    mockCreateHandler.mockClear();
+    mockUnhandle.mockReset();
+    mockConsentRequestResponseHandler = undefined;
+  });
+
+  describe('status', () => {
+    it('sends the consent status request and maps the response', async () => {
+      mockStatusSender.mockResolvedValue({
+        name: 'newsletter',
+        status: 'accepted',
+        updatedAt: '2026-04-13T10:00:00.000Z',
+        acceptedRevision: '2',
+        latestRevision: '3',
+      });
+
+      const consent = await status({
+        consent: 'newsletter',
+      });
+
+      expect(mockCreateSender).toHaveBeenCalledWith('consentStatus');
+      expect(mockStatusSender).toHaveBeenCalledWith({
+        consent: 'newsletter',
+      });
+      expect(consent).toMatchObject({
+        name: 'newsletter',
+        status: 'accepted',
+        updatedAt: '2026-04-13T10:00:00.000Z',
+        acceptedRevision: '2',
+        lastRevision: '3',
+      });
+      expect(consent.isAccepted).toBe(true);
+      expect(consent.isStale).toBe(true);
+    });
+  });
+
+  describe('request', () => {
+    it('registers the response handler before sending the consent request', async () => {
+      mockRequestSender.mockResolvedValue(undefined);
+
+      const requestPromise = request({
+        consent: 'newsletter',
+        requestMessage: 'Please confirm',
+        privacyLink: 'https://example.com/privacy',
+      });
+
+      expect(mockCreateHandler).toHaveBeenCalledWith('consentRequestResponse');
+      expect(mockCreateSender).toHaveBeenCalledWith('consentRequest');
+      expect(mockRequestSender).toHaveBeenCalledWith({
+        consent: 'newsletter',
+        requestMessage: 'Please confirm',
+        privacyLink: 'https://example.com/privacy',
+      });
+      expect(mockConsentRequestResponseHandler).toEqual(expect.any(Function));
+
+      await mockConsentRequestResponseHandler?.({
+        name: 'newsletter',
+        consent: {
+          name: 'newsletter',
+          status: 'accepted',
+          updatedAt: '2026-04-13T11:00:00.000Z',
+          acceptedRevision: '3',
+          latestRevision: '3',
+        },
+      });
+
+      const consent = await requestPromise;
+
+      expect(consent).toMatchObject({
+        name: 'newsletter',
+        status: 'accepted',
+        acceptedRevision: '3',
+        lastRevision: '3',
+      });
+      expect(consent.isAccepted).toBe(true);
+      expect(consent.isStale).toBe(false);
+      expect(mockUnhandle).toHaveBeenCalledTimes(1);
+    });
+
+    it('ignores non-matching consent responses', async () => {
+      mockRequestSender.mockResolvedValue(undefined);
+
+      const requestPromise = request({
+        consent: 'newsletter',
+      });
+
+      await mockConsentRequestResponseHandler?.({
+        name: 'terms-and-conditions',
+        consent: {
+          name: 'terms-and-conditions',
+          status: 'declined',
+          updatedAt: null,
+          acceptedRevision: null,
+          latestRevision: '1',
+        },
+      });
+
+      let isResolved = false;
+      void requestPromise.then(() => {
+        isResolved = true;
+      });
+
+      await Promise.resolve();
+
+      expect(isResolved).toBe(false);
+      expect(mockUnhandle).not.toHaveBeenCalled();
+
+      await mockConsentRequestResponseHandler?.({
+        name: 'newsletter',
+        consent: {
+          name: 'newsletter',
+          status: 'accepted',
+          updatedAt: null,
+          acceptedRevision: '1',
+          latestRevision: '1',
+        },
+      });
+
+      await expect(requestPromise).resolves.toMatchObject({
+        name: 'newsletter',
+        status: 'accepted',
+      });
+      expect(mockUnhandle).toHaveBeenCalledTimes(1);
+    });
+
+    it('rejects and unregisters the response handler when sending fails', async () => {
+      const sendError = new Error('request failed');
+      mockRequestSender.mockRejectedValue(sendError);
+
+      await expect(request({
+        consent: 'newsletter',
+      })).rejects.toThrow('request failed');
+
+      expect(mockUnhandle).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/admin-sdk/src/consent/index.spec.ts
+++ b/packages/admin-sdk/src/consent/index.spec.ts
@@ -41,6 +41,9 @@ describe('consent', () => {
     mockCreateHandler.mockClear();
     mockUnhandle.mockReset();
     mockConsentRequestResponseHandler = undefined;
+    mockUnhandle.mockImplementation(() => {
+      mockConsentRequestResponseHandler = undefined;
+    });
   });
 
   describe('status', () => {
@@ -77,7 +80,7 @@ describe('consent', () => {
     it('registers the response handler before sending the consent request', async () => {
       mockRequestSender.mockResolvedValue(undefined);
 
-      const requestPromise = request({
+      const { requestPromise } = request({
         consent: 'newsletter',
         requestMessage: 'Please confirm',
         privacyLink: 'https://example.com/privacy',
@@ -119,7 +122,7 @@ describe('consent', () => {
     it('ignores non-matching consent responses', async () => {
       mockRequestSender.mockResolvedValue(undefined);
 
-      const requestPromise = request({
+      const { requestPromise } = request({
         consent: 'newsletter',
       });
 
@@ -166,9 +169,40 @@ describe('consent', () => {
       const sendError = new Error('request failed');
       mockRequestSender.mockRejectedValue(sendError);
 
-      await expect(request({
+      const { requestPromise } = request({
         consent: 'newsletter',
-      })).rejects.toThrow('request failed');
+      })
+
+      await expect(requestPromise).rejects.toThrow('request failed');
+
+      expect(mockUnhandle).toHaveBeenCalledTimes(1);
+    });
+
+    it('aborts and unregisters the response handler so no further messages are handled', async () => {
+      mockRequestSender.mockResolvedValue(undefined);
+
+      const { requestPromise, abort } = request({
+        consent: 'newsletter',
+      });
+
+      const abortError = new Error('request aborted');
+      abort(abortError);
+
+      expect(mockUnhandle).toHaveBeenCalledTimes(1);
+      expect(mockConsentRequestResponseHandler).toBeUndefined();
+      await expect(requestPromise).rejects.toThrow('request aborted');
+
+      const handlerAfterAbort = mockConsentRequestResponseHandler;
+      await handlerAfterAbort?.({
+        name: 'newsletter',
+        consent: {
+          name: 'newsletter',
+          status: 'accepted',
+          updatedAt: null,
+          acceptedRevision: '1',
+          latestRevision: '1',
+        },
+      });
 
       expect(mockUnhandle).toHaveBeenCalledTimes(1);
     });

--- a/packages/admin-sdk/src/consent/index.spec.ts
+++ b/packages/admin-sdk/src/consent/index.spec.ts
@@ -1,11 +1,13 @@
 const mockStatusSender = jest.fn();
 const mockRequestSender = jest.fn();
-const mockCreateSender = jest.fn((messageType: string) => {
+let mockConsentRequestId: string | undefined;
+const mockCreateSender = jest.fn((messageType: string, options?: { requestId?: string }) => {
   if (messageType === 'consentStatus') {
     return mockStatusSender;
   }
 
   if (messageType === 'consentRequest') {
+    mockConsentRequestId = options?.requestId;
     return mockRequestSender;
   }
 
@@ -27,7 +29,7 @@ const mockCreateHandler = jest.fn((messageType: string) => {
 });
 
 jest.mock('../channel', () => ({
-  createSender: (messageType: string) => mockCreateSender(messageType),
+  createSender: (messageType: string, options?: { requestId?: string }) => mockCreateSender(messageType, options),
   createHandler: (messageType: string) => mockCreateHandler(messageType),
 }));
 
@@ -41,6 +43,7 @@ describe('consent', () => {
     mockCreateHandler.mockClear();
     mockUnhandle.mockReset();
     mockConsentRequestResponseHandler = undefined;
+    mockConsentRequestId = undefined;
     mockUnhandle.mockImplementation(() => {
       mockConsentRequestResponseHandler = undefined;
     });
@@ -60,7 +63,7 @@ describe('consent', () => {
         consent: 'newsletter',
       });
 
-      expect(mockCreateSender).toHaveBeenCalledWith('consentStatus');
+      expect(mockCreateSender).toHaveBeenCalledWith('consentStatus', undefined);
       expect(mockStatusSender).toHaveBeenCalledWith({
         consent: 'newsletter',
       });
@@ -87,16 +90,23 @@ describe('consent', () => {
       });
 
       expect(mockCreateHandler).toHaveBeenCalledWith('consentRequestResponse');
-      expect(mockCreateSender).toHaveBeenCalledWith('consentRequest');
+      expect(mockCreateSender).toHaveBeenCalledWith(
+        'consentRequest',
+        expect.objectContaining({
+          requestId: expect.any(String),
+        }),
+      );
       expect(mockRequestSender).toHaveBeenCalledWith({
         consent: 'newsletter',
         requestMessage: 'Please confirm',
         privacyLink: 'https://example.com/privacy',
       });
+      expect(mockConsentRequestId).toEqual(expect.any(String));
       expect(mockConsentRequestResponseHandler).toEqual(expect.any(Function));
 
       await mockConsentRequestResponseHandler?.({
         name: 'newsletter',
+        requestId: mockConsentRequestId,
         consent: {
           name: 'newsletter',
           status: 'accepted',
@@ -128,6 +138,7 @@ describe('consent', () => {
 
       await mockConsentRequestResponseHandler?.({
         name: 'terms-and-conditions',
+        requestId: mockConsentRequestId,
         consent: {
           name: 'terms-and-conditions',
           status: 'declined',
@@ -149,6 +160,7 @@ describe('consent', () => {
 
       await mockConsentRequestResponseHandler?.({
         name: 'newsletter',
+        requestId: mockConsentRequestId,
         consent: {
           name: 'newsletter',
           status: 'accepted',

--- a/packages/admin-sdk/src/consent/index.ts
+++ b/packages/admin-sdk/src/consent/index.ts
@@ -63,7 +63,7 @@ export const request = (messageOptions: Omit<consentRequest, 'responseType' | 'r
     }
 
     if(message.requestId !== requestId) {
-      return;
+      return Promise.resolve();
     }
 
     unhandle();

--- a/packages/admin-sdk/src/consent/index.ts
+++ b/packages/admin-sdk/src/consent/index.ts
@@ -1,0 +1,89 @@
+import { createHandler, createSender } from "../channel";
+
+class Consent {
+    static fromStatusResponse(response: Exclude<consentStatus['responseType'], null>) {
+        return new Consent(
+            response.name,
+            response.status,
+            response.updatedAt,
+            response.acceptedRevision,
+            response.latestRevision,
+        );
+    }
+
+    private constructor(
+        public readonly name: string,
+        public readonly status: ConsentStatusResponseType['status'],
+        public readonly updatedAt: string | null,
+        public readonly acceptedRevision: string | null,
+        public readonly lastRevision: string | null,
+    ) {}
+
+    get isAccepted(): boolean {
+        return this.status === 'accepted';
+    }
+
+    get isStale(): boolean {
+        if (!this.isAccepted) {
+            return false;
+        }
+
+        return this.lastRevision !== null && this.lastRevision !== this.acceptedRevision;
+    }
+}
+
+export type { Consent };
+
+export const status = async (messageData: Omit<consentStatus, 'responseType'>): Promise<Consent> => {
+    const sender = createSender("consentStatus");
+    const response = await sender(messageData);
+
+    return Consent.fromStatusResponse(response);
+}
+
+export const request = (messageOptions: Omit<consentRequest, 'responseType'>): Promise<Consent> => {
+    return new Promise((resolve, reject) => {
+        const unhandle = createHandler('consentRequestResponse')(async (message) => {
+            if (message.name !== messageOptions.consent) {
+                return;
+            }
+
+            unhandle();
+            resolve(Consent.fromStatusResponse(message.consent));
+        });
+
+        createSender('consentRequest')(messageOptions).catch((reason: unknown) => {
+            unhandle();
+            reject(reason)
+        });
+    });
+}
+
+type ConsentStatusResponseType = {
+    name: string,
+    status: 'unset' | 'declined' | 'revoked' | 'accepted',
+    updatedAt: string | null,
+    acceptedRevision: string | null,
+    latestRevision: string | null,
+}
+
+export type consentStatus = {
+    responseType: ConsentStatusResponseType,
+
+    consent: string,
+};
+
+export type consentRequest = {
+    responseType: void,
+
+    consent: string,
+    requestMessage?: string,
+    privacyLink?: string,
+};
+
+export type consentRequestResponse = {
+    responseType: void;
+
+    name: string,
+    consent: ConsentStatusResponseType,
+}

--- a/packages/admin-sdk/src/consent/index.ts
+++ b/packages/admin-sdk/src/consent/index.ts
@@ -41,23 +41,42 @@ export const status = async (messageData: Omit<consentStatus, 'responseType'>): 
   return Consent.fromStatusResponse(response);
 };
 
-export const request = (messageOptions: Omit<consentRequest, 'responseType'>): Promise<Consent> => {
-  return new Promise((resolve, reject) => {
-    const unhandle = createHandler('consentRequestResponse')((message) => {
-      if (message.name !== messageOptions.consent) {
-        return Promise.resolve();
-      }
+export const request = (messageOptions: Omit<consentRequest, 'responseType'>): {
+  requestPromise: Promise<Consent>,
+  abort: (reason?: unknown) => void,
+} => {
+  /*
+   * Fake Promise.withResolvers because it is not available in our TS version
+   */
+  let resolve: (value: Consent | PromiseLike<Consent>) => void;
+  let reject: (reason?: unknown) => void;
+  const requestPromise = new Promise<Consent>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
 
-      unhandle();
-      resolve(Consent.fromStatusResponse(message.consent));
+  const unhandle = createHandler('consentRequestResponse')((message) => {
+    if (message.name !== messageOptions.consent) {
       return Promise.resolve();
-    });
+    }
 
-    createSender('consentRequest')(messageOptions).catch((reason: unknown) => {
+    unhandle();
+    resolve(Consent.fromStatusResponse(message.consent));
+    return Promise.resolve();
+  });
+
+  createSender('consentRequest')(messageOptions).catch((reason: unknown) => {
+    unhandle();
+    reject(reason);
+  });
+
+  return {
+    requestPromise,
+    abort: (reason: unknown): void => {
       unhandle();
       reject(reason);
-    });
-  });
+    },
+  };
 };
 
 type ConsentStatusResponseType = {

--- a/packages/admin-sdk/src/consent/index.ts
+++ b/packages/admin-sdk/src/consent/index.ts
@@ -1,63 +1,64 @@
-import { createHandler, createSender } from "../channel";
+import { createHandler, createSender } from '../channel';
 
 class Consent {
-    static fromStatusResponse(response: Exclude<consentStatus['responseType'], null>) {
-        return new Consent(
-            response.name,
-            response.status,
-            response.updatedAt,
-            response.acceptedRevision,
-            response.latestRevision,
-        );
-    }
+  static fromStatusResponse(response: Exclude<consentStatus['responseType'], null>): Consent {
+    return new Consent(
+      response.name,
+      response.status,
+      response.updatedAt,
+      response.acceptedRevision,
+      response.latestRevision,
+    );
+  }
 
-    private constructor(
+  private constructor(
         public readonly name: string,
         public readonly status: ConsentStatusResponseType['status'],
         public readonly updatedAt: string | null,
         public readonly acceptedRevision: string | null,
         public readonly lastRevision: string | null,
-    ) {}
+  ) {}
 
-    get isAccepted(): boolean {
-        return this.status === 'accepted';
+  get isAccepted(): boolean {
+    return this.status === 'accepted';
+  }
+
+  get isStale(): boolean {
+    if (!this.isAccepted) {
+      return false;
     }
 
-    get isStale(): boolean {
-        if (!this.isAccepted) {
-            return false;
-        }
-
-        return this.lastRevision !== null && this.lastRevision !== this.acceptedRevision;
-    }
+    return this.lastRevision !== null && this.lastRevision !== this.acceptedRevision;
+  }
 }
 
 export type { Consent };
 
 export const status = async (messageData: Omit<consentStatus, 'responseType'>): Promise<Consent> => {
-    const sender = createSender("consentStatus");
-    const response = await sender(messageData);
+  const sender = createSender('consentStatus');
+  const response = await sender(messageData);
 
-    return Consent.fromStatusResponse(response);
-}
+  return Consent.fromStatusResponse(response);
+};
 
 export const request = (messageOptions: Omit<consentRequest, 'responseType'>): Promise<Consent> => {
-    return new Promise((resolve, reject) => {
-        const unhandle = createHandler('consentRequestResponse')(async (message) => {
-            if (message.name !== messageOptions.consent) {
-                return;
-            }
+  return new Promise((resolve, reject) => {
+    const unhandle = createHandler('consentRequestResponse')((message) => {
+      if (message.name !== messageOptions.consent) {
+        return Promise.resolve();
+      }
 
-            unhandle();
-            resolve(Consent.fromStatusResponse(message.consent));
-        });
-
-        createSender('consentRequest')(messageOptions).catch((reason: unknown) => {
-            unhandle();
-            reject(reason)
-        });
+      unhandle();
+      resolve(Consent.fromStatusResponse(message.consent));
+      return Promise.resolve();
     });
-}
+
+    createSender('consentRequest')(messageOptions).catch((reason: unknown) => {
+      unhandle();
+      reject(reason);
+    });
+  });
+};
 
 type ConsentStatusResponseType = {
     name: string,
@@ -82,7 +83,7 @@ export type consentRequest = {
 };
 
 export type consentRequestResponse = {
-    responseType: void;
+    responseType: void,
 
     name: string,
     consent: ConsentStatusResponseType,

--- a/packages/admin-sdk/src/consent/index.ts
+++ b/packages/admin-sdk/src/consent/index.ts
@@ -1,3 +1,4 @@
+import { generateUniqueId } from '../_internals/utils';
 import { createHandler, createSender } from '../channel';
 
 class Consent {
@@ -41,7 +42,7 @@ export const status = async (messageData: Omit<consentStatus, 'responseType'>): 
   return Consent.fromStatusResponse(response);
 };
 
-export const request = (messageOptions: Omit<consentRequest, 'responseType'>): {
+export const request = (messageOptions: Omit<consentRequest, 'responseType' | 'requestId'>): {
   requestPromise: Promise<Consent>,
   abort: (reason?: unknown) => void,
 } => {
@@ -54,10 +55,15 @@ export const request = (messageOptions: Omit<consentRequest, 'responseType'>): {
     resolve = res;
     reject = rej;
   });
+  const requestId = generateUniqueId();
 
   const unhandle = createHandler('consentRequestResponse')((message) => {
     if (message.name !== messageOptions.consent) {
       return Promise.resolve();
+    }
+
+    if(message.requestId !== requestId) {
+      return;
     }
 
     unhandle();
@@ -65,7 +71,7 @@ export const request = (messageOptions: Omit<consentRequest, 'responseType'>): {
     return Promise.resolve();
   });
 
-  createSender('consentRequest')(messageOptions).catch((reason: unknown) => {
+  createSender('consentRequest', { requestId })(messageOptions).catch((reason: unknown) => {
     unhandle();
     reject(reason);
   });
@@ -96,6 +102,8 @@ export type consentStatus = {
 export type consentRequest = {
     responseType: void,
 
+    requestId: string,
+
     consent: string,
     requestMessage?: string,
     privacyLink?: string,
@@ -105,5 +113,6 @@ export type consentRequestResponse = {
     responseType: void,
 
     name: string,
+    requestId: string,
     consent: ConsentStatusResponseType,
 }

--- a/packages/admin-sdk/src/index.ts
+++ b/packages/admin-sdk/src/index.ts
@@ -19,6 +19,7 @@ import * as data from './data';
 import * as iap from './iap';
 import * as payment from './_private/payment';
 import * as telemetry from './telemetry';
+import * as consent from './consent';
 import type EntityCollectionType from './_internals/data/EntityCollection';
 import type { Entity as EntityType } from './_internals/data/Entity';
 import composables from './data/composables';
@@ -61,6 +62,7 @@ export {
   iap,
   telemetry,
   _private,
+  consent,
 };
 
 /**

--- a/packages/admin-sdk/src/message-types.ts
+++ b/packages/admin-sdk/src/message-types.ts
@@ -43,6 +43,11 @@ import type {
 } from './data/repository';
 import type { iapCheckout } from './iap';
 import type { telemetryDispatch } from './telemetry';
+import type {
+  consentStatus,
+  consentRequest,
+  consentRequestResponse,
+} from './consent';
 
 /**
  * Contains all shopware send types.
@@ -108,6 +113,9 @@ export interface ShopwareMessageTypes {
   datasetGet: datasetGet,
   iapCheckout: iapCheckout,
   telemetryDispatch: telemetryDispatch,
+  consentStatus: consentStatus,
+  consentRequest: consentRequest,
+  consentRequestResponse: consentRequestResponse,
   __function__: __function__,
   __registerWindow__: __registerWindow__,
   _multiply: _multiply,


### PR DESCRIPTION
## What?

Adds new namespace `consent` to the Admin-SDK

## Why?

Extensions must be able to read a consent state and request consent. Details are in the added documentation. 