### PR TITLE
fix(storybook): resolve flaky interaction tests in text-editor and entity-data-table

### DIFF
--- a/packages/component-library/src/components/entity/mt-entity-data-table/mt-entity-data-table.interactive.stories.ts
+++ b/packages/component-library/src/components/entity/mt-entity-data-table/mt-entity-data-table.interactive.stories.ts
@@ -246,8 +246,12 @@ export const InteractionTestApplyBooleanFilter: MtEntityDataTableStory = {
     await userEvent.click(addFilterButton);
 
     // Open "Active" filter in the opened dialog
-    await waitFor(() => document.querySelector('[role="dialog"]'));
-    const dialogContent = within(document.querySelector('[role="dialog"]') as HTMLElement);
+    const dialog = await waitFor(() => {
+      const el = document.querySelector<HTMLElement>('[role="dialog"]');
+      if (!el) throw new Error("Dialog not found");
+      return el;
+    });
+    const dialogContent = within(dialog);
     const activeFilter = await dialogContent.findByText("Active");
     await userEvent.click(activeFilter);
 
@@ -282,8 +286,12 @@ export const InteractionTestApplyMultiSelectFilter: MtEntityDataTableStory = {
     await userEvent.click(addFilterButton);
 
     // Open "Manufacturer" filter in the opened dialog
-    await waitFor(() => document.querySelector('[role="dialog"]'));
-    const dialogContent = within(document.querySelector('[role="dialog"]') as HTMLElement);
+    const dialog = await waitFor(() => {
+      const el = document.querySelector<HTMLElement>('[role="dialog"]');
+      if (!el) throw new Error("Dialog not found");
+      return el;
+    });
+    const dialogContent = within(dialog);
     const manufacturerFilter = await dialogContent.findByText("Manufacturer");
     await userEvent.click(manufacturerFilter);
 
@@ -319,8 +327,12 @@ export const InteractionTestClearFilter: MtEntityDataTableStory = {
     await userEvent.click(addFilterButton);
 
     // Open "Manufacturer" filter in the opened dialog
-    await waitFor(() => document.querySelector('[role="dialog"]'));
-    const dialogContent = within(document.querySelector('[role="dialog"]') as HTMLElement);
+    const dialog = await waitFor(() => {
+      const el = document.querySelector<HTMLElement>('[role="dialog"]');
+      if (!el) throw new Error("Dialog not found");
+      return el;
+    });
+    const dialogContent = within(dialog);
     const manufacturerFilter = await dialogContent.findByText("Manufacturer");
     await userEvent.click(manufacturerFilter);
 
@@ -391,7 +403,7 @@ export const InteractionTestEmitBulkEdit: MtEntityDataTableStory = {
     await waitFor(() => canvas.getByText("25 items selected"));
 
     // Click on "Edit" button
-    const editButton = await waitFor(() => canvas.getByRole("button", { name: /Edit/i }));
+    const editButton = await waitFor(() => canvas.getByRole("button", { name: "Edit" }));
     await userEvent.click(editButton);
 
     // Check if "onBulkEdit" event was emitted with the correct IDs

--- a/packages/component-library/src/components/form/mt-text-editor/mt-text-editor.interactive.stories.ts
+++ b/packages/component-library/src/components/form/mt-text-editor/mt-text-editor.interactive.stories.ts
@@ -1,4 +1,4 @@
-import { within, userEvent } from "@storybook/test";
+import { within, userEvent, waitFor, fireEvent } from "@storybook/test";
 import { expect } from "@storybook/test";
 import { waitUntil } from "../../../_internal/test-helper";
 
@@ -785,7 +785,13 @@ export const SetLink: MtTextEditorStory = defineStory({
     const body = within(document.body);
 
     // Set link url
-    const linkInput = body.getByLabelText("Link URL");
+    const linkInput = await waitFor(() => {
+      const inputs = Array.from(
+        document.querySelectorAll<HTMLInputElement>('[aria-label="Link URL"]'),
+      );
+      if (inputs.length !== 1) throw new Error("Expected exactly one Link URL input");
+      return inputs[0];
+    });
     await userEvent.clear(linkInput);
     await userEvent.type(linkInput, "https://www.shopware.com");
 
@@ -826,7 +832,13 @@ export const SetLinkWithoutNewTab: MtTextEditorStory = defineStory({
 
     const body = within(document.body);
 
-    const linkInput = body.getByLabelText("Link URL");
+    const linkInput = await waitFor(() => {
+      const inputs = Array.from(
+        document.querySelectorAll<HTMLInputElement>('[aria-label="Link URL"]'),
+      );
+      if (inputs.length !== 1) throw new Error("Expected exactly one Link URL input");
+      return inputs[0];
+    });
     await userEvent.clear(linkInput);
     await userEvent.type(linkInput, "https://www.shopware.com");
 
@@ -877,7 +889,9 @@ export const VisualTestShowRemoveLinkContextualButton: MtTextEditorStory = defin
 
     await waitForCharacterCounter(canvasElement);
 
-    await userEvent.click(canvas.getByRole("link", { name: "Hello World" }));
+    const linkEl = canvas.getByRole("link", { name: "Hello World" });
+    fireEvent.mouseDown(linkEl);
+    fireEvent.mouseUp(linkEl);
     selectText(canvas.getByText("Hello World"));
 
     expect(canvas.getByLabelText("Remove link")).toBeDefined();


### PR DESCRIPTION
- Replace userEvent.click on <a> link with fireEvent mousedown/mouseup in VisualTestShowRemoveLinkContextualButton to prevent Chromium navigation
- Wrap Link URL input queries in waitFor to guard against stale modal DOM left over from a test-runner retry
- Make dialog querySelector atomic (capture in waitFor) in entity-data-table filter tests to eliminate the null race condition
- Use exact "Edit" button name match in InteractionTestEmitBulkEdit to avoid accidentally matching row-level navigation buttons