### PR TITLE
fix: mt-field-error supporting meta properties

### DIFF
--- a/.changeset/sixty-cooks-draw.md
+++ b/.changeset/sixty-cooks-draw.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": patch
+---
+
+mt-field-error now resolves interpolation params from error.meta.parameters while continuing to support error.parameters.

--- a/packages/component-library/src/components/form/_internal/mt-field-error/mt-field-error.spec.ts
+++ b/packages/component-library/src/components/form/_internal/mt-field-error/mt-field-error.spec.ts
@@ -95,7 +95,9 @@ describe("mt-field-error", () => {
       props: { error },
     });
 
-    expect(screen.getByText("This is a global error with top-level parameters")).toBeInTheDocument();
+    expect(
+      screen.getByText("This is a global error with top-level parameters"),
+    ).toBeInTheDocument();
   });
 
   it("should prefer top-level parameters over meta.parameters when both are present", () => {
@@ -116,6 +118,8 @@ describe("mt-field-error", () => {
       props: { error },
     });
 
-    expect(screen.getByText("This is a global error with top-level parameters")).toBeInTheDocument();
+    expect(
+      screen.getByText("This is a global error with top-level parameters"),
+    ).toBeInTheDocument();
   });
 });

--- a/packages/component-library/src/components/form/_internal/mt-field-error/mt-field-error.spec.ts
+++ b/packages/component-library/src/components/form/_internal/mt-field-error/mt-field-error.spec.ts
@@ -5,15 +5,21 @@ import MtFieldError from "./mt-field-error.vue";
 // Mock the i18n composable
 vi.mock("vue-i18n", () => ({
   useI18n: () => ({
-    t: vi.fn((key: string) => {
+    t: vi.fn((key: string, params?: Record<string, string | number>) => {
       const translations: Record<string, string> = {
         "global.error-codes.FRAMEWORK__MISSING_PRIVILEGE_ERROR": "This is a global error",
         "mt-field-error.FRAMEWORK__MISSING_PRIVILEGE_ERROR": "This is a mt-field-error error",
         "global.error-codes.GLOBAL_ONLY_ERROR": "This is a global only error",
         "mt-field-error.MT_FIELD_ONLY_ERROR": "This is a mt-field-error only error",
+        "global.error-codes.GLOBAL_PARAMETER_ERROR": "This is a global error with {value}",
       };
+      const translation = translations[key] || key;
 
-      return translations[key] || key;
+      return translation.replace(/\{(\w+)\}/g, (_, placeholder: string) => {
+        const value = params?.[placeholder];
+
+        return value === undefined ? `{${placeholder}}` : String(value);
+      });
     }),
   }),
 }));
@@ -56,5 +62,60 @@ describe("mt-field-error", () => {
     });
 
     expect(screen.getByText("This is a mt-field-error only error")).toBeInTheDocument();
+  });
+
+  it("should interpolate meta.parameters when present", () => {
+    const error = {
+      code: "GLOBAL_PARAMETER_ERROR",
+      detail: "Fallback error message",
+      meta: {
+        parameters: {
+          value: "meta parameters",
+        },
+      },
+    };
+
+    render(MtFieldError, {
+      props: { error },
+    });
+
+    expect(screen.getByText("This is a global error with meta parameters")).toBeInTheDocument();
+  });
+
+  it("should interpolate parameters when present", () => {
+    const error = {
+      code: "GLOBAL_PARAMETER_ERROR",
+      detail: "Fallback error message",
+      parameters: {
+        value: "top-level parameters",
+      },
+    };
+
+    render(MtFieldError, {
+      props: { error },
+    });
+
+    expect(screen.getByText("This is a global error with top-level parameters")).toBeInTheDocument();
+  });
+
+  it("should prefer top-level parameters over meta.parameters when both are present", () => {
+    const error = {
+      code: "GLOBAL_PARAMETER_ERROR",
+      detail: "Fallback error message",
+      meta: {
+        parameters: {
+          value: "meta parameters",
+        },
+      },
+      parameters: {
+        value: "top-level parameters",
+      },
+    };
+
+    render(MtFieldError, {
+      props: { error },
+    });
+
+    expect(screen.getByText("This is a global error with top-level parameters")).toBeInTheDocument();
   });
 });

--- a/packages/component-library/src/components/form/_internal/mt-field-error/mt-field-error.vue
+++ b/packages/component-library/src/components/form/_internal/mt-field-error/mt-field-error.vue
@@ -34,9 +34,13 @@ const errorMessage = computed(() => {
     `global.error-codes.${props.error.code}`,
     `mt-field-error.${props.error.code}`,
   ];
+  const interpolationParams = {
+    ...(props.error.meta?.parameters ?? {}),
+    ...(props.error.parameters ?? {}),
+  };
 
   for (const key of translationKeys) {
-    const translation = t(key, props.error.parameters || {});
+    const translation = t(key, interpolationParams);
     const noTranslationFound = translation === key;
 
     if (!noTranslationFound) {


### PR DESCRIPTION
## What?
Fixes #906 to support both `parameters` and `meta.parameters`

## Why?
According to the ticket error responses are often in props.error.meta.parameters, and supporting that out of the box seems valid

## How?
- Added support for both meta.parameters as well as parameters as possible sources in the mt-field-error component, which are then passed into the translation

## Testing?
- Adjusted unit test to test the behavior of the different error values

## Screenshots (optional)

## Anything Else?
