### PR TITLE
feat: add external anchor prop mt-floating-ui

### DIFF
--- a/.changeset/fluffy-hornets-fix.md
+++ b/.changeset/fluffy-hornets-fix.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": minor
+---
+
+Add `anchorElement` and `detached` props to `mt-floating-ui` for external anchor positioning.

--- a/packages/component-library/src/components/_internal/mt-floating-ui/mt-floating-ui.spec.ts
+++ b/packages/component-library/src/components/_internal/mt-floating-ui/mt-floating-ui.spec.ts
@@ -173,6 +173,41 @@ describe("mt-floating-ui", () => {
     expect(floatingUiContent.style.width).toBe("200px");
   });
 
+  it("should use the external anchorElement for positioning when provided", async () => {
+    const externalRef = document.createElement("div");
+    externalRef.setAttribute("id", "externalRef");
+    externalRef.getBoundingClientRect = vi.fn(() => ({
+      width: 300,
+      height: 40,
+      top: 100,
+      left: 50,
+      bottom: 140,
+      right: 350,
+      x: 50,
+      y: 100,
+      toJSON: vi.fn(),
+    }));
+    document.body.appendChild(externalRef);
+
+    wrapper = mount(MtFloatingUi, {
+      attachTo: document.getElementById("appWrapper")!,
+      slots: {
+        default: `<div id="externalAnchorContent">External anchor content</div>`,
+      },
+      props: {
+        isOpened: true,
+        anchorElement: externalRef,
+      },
+    });
+
+    await flushPromises();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const floatingUiContent = document.querySelector("#externalAnchorContent") as HTMLElement;
+
+    expect(floatingUiContent).toBeTruthy();
+  });
+
   it("should not set width when matchReferenceWidth prop is false or not set", async () => {
     wrapper = createWrapper();
 
@@ -191,5 +226,26 @@ describe("mt-floating-ui", () => {
 
     expect(floatingUiContent).toBeTruthy();
     expect(floatingUiContent.style.width).toBe("");
+  });
+
+  it("should not render the trigger when detached is true", () => {
+    const anchorElement = document.createElement("div");
+    document.body.appendChild(anchorElement);
+
+    wrapper = mount(MtFloatingUi, {
+      attachTo: document.getElementById("appWrapper")!,
+      slots: {
+        trigger: `<div id="triggerSlotContent">Trigger</div>`,
+      },
+      props: {
+        isOpened: false,
+        detached: true,
+        anchorElement,
+      },
+    });
+
+    expect(wrapper.find(".mt-floating-ui__trigger").exists()).toBe(false);
+    expect(wrapper.find("#triggerSlotContent").exists()).toBe(false);
+    expect(wrapper.find(".mt-floating-ui").classes()).toContain("mt-floating-ui--detached");
   });
 });

--- a/packages/component-library/src/components/_internal/mt-floating-ui/mt-floating-ui.stories.ts
+++ b/packages/component-library/src/components/_internal/mt-floating-ui/mt-floating-ui.stories.ts
@@ -14,6 +14,13 @@ const meta: MtFloatingUiMeta = {
     showArrow: true,
     offset: 6,
     matchReferenceWidth: false,
+    detached: false,
+  },
+  argTypes: {
+    detached: {
+      description:
+        "Omits the trigger slot and uses `display: contents` on the root. Use with `anchorElement` for external anchors.",
+    },
   },
   render: (args: MtFloatingUiProps) => ({
     components: {
@@ -105,4 +112,147 @@ export const Default: MtFloatingUiStory = {
       },
     },
   },
+};
+
+export const MultipleAnchors: MtFloatingUiStory = {
+  name: "Multiple anchors",
+  args: {
+    detached: true,
+  },
+  parameters: {
+    docs: {
+      source: {
+        language: "html",
+        code: `<div
+  v-for="btn in buttons"
+  :key="btn.label"
+  @mouseenter="openFor($event, btn)"
+  @mouseleave="scheduleClose"
+>
+  <mt-button variant="secondary">{{ btn.label }}</mt-button>
+</div>
+
+<mt-floating-ui
+  :is-opened="isOpened"
+  :anchor-element="anchorElement"
+  detached
+  @close="isOpened = false"
+>
+  <div @mouseenter="cancelClose" @mouseleave="scheduleClose">
+    Popover for {{ activeLabel }}
+  </div>
+</mt-floating-ui>`,
+      },
+    },
+  },
+  render: (args: MtFloatingUiProps) => ({
+    components: { MtFloatingUi, MtButton, MtNumberField },
+    setup() {
+      const isOpened = ref(false);
+      const anchorElement = ref<HTMLElement | null>(null);
+      const activeButton = ref<{ label: string; field1: string; field2: string } | null>(null);
+      let closeTimer: ReturnType<typeof setTimeout> | null = null;
+
+      const buttons = [
+        { label: "Adjust size", field1: "Width", field2: "Height" },
+        { label: "Adjust position", field1: "X offset", field2: "Y offset" },
+        { label: "Adjust padding", field1: "Horizontal", field2: "Vertical" },
+      ];
+
+      const values = ref<Record<string, { v1: string; v2: string }>>({
+        "Adjust size": { v1: "120", v2: "120" },
+        "Adjust position": { v1: "0", v2: "0" },
+        "Adjust padding": { v1: "16", v2: "16" },
+      });
+
+      const floatingUiOptions = { placement: "bottom" as const, ...args.floatingUiOptions };
+
+      const openFor = (event: MouseEvent, btn: (typeof buttons)[0]) => {
+        if (closeTimer) {
+          clearTimeout(closeTimer);
+          closeTimer = null;
+        }
+        anchorElement.value = event.currentTarget as HTMLElement;
+        activeButton.value = btn;
+        isOpened.value = true;
+      };
+
+      const scheduleClose = () => {
+        closeTimer = setTimeout(() => {
+          isOpened.value = false;
+        }, 200);
+      };
+
+      const cancelClose = () => {
+        if (closeTimer) {
+          clearTimeout(closeTimer);
+          closeTimer = null;
+        }
+      };
+
+      return {
+        args,
+        isOpened,
+        anchorElement,
+        activeButton,
+        buttons,
+        values,
+        floatingUiOptions,
+        openFor,
+        scheduleClose,
+        cancelClose,
+      };
+    },
+    template: `
+      <div style="padding: 32px 32px 32px 200px;">
+        <div style="display: flex; gap: 12px;">
+          <div
+            v-for="btn in buttons"
+            :key="btn.label"
+            @mouseenter="openFor($event, btn)"
+            @mouseleave="scheduleClose"
+          >
+            <mt-button variant="secondary">
+              {{ btn.label }}
+            </mt-button>
+          </div>
+        </div>
+
+        <mt-floating-ui
+          v-bind="args"
+          :is-opened="isOpened"
+          :anchor-element="anchorElement"
+          :floating-ui-options="floatingUiOptions"
+          @close="isOpened = false"
+        >
+          <div
+            v-if="activeButton"
+            style="padding: 16px; width: 320px; border-radius: var(--border-radius-m, 8px);
+              border: 1px solid var(--color-border-secondary-default, #E2E3E9);
+              background: var(--color-elevation-surface-raised, #FFF);
+              box-shadow: 0 6px 24px -8px var(--color-elevation-shadow-default, rgba(16, 16, 19, 0.10));"
+            @mouseenter="cancelClose"
+            @mouseleave="scheduleClose"
+          >
+            <strong style="display: block; margin-bottom: 10px;">{{ activeButton.label }}</strong>
+            <div style="display: flex; gap: 12px; margin-bottom: 10px;">
+              <mt-number-field
+                v-model="values[activeButton.label].v1"
+                :label="activeButton.field1"
+                size="small"
+                number-type="int"
+              />
+              <mt-number-field
+                v-model="values[activeButton.label].v2"
+                :label="activeButton.field2"
+                size="small"
+                number-type="int"
+              />
+            </div>
+            <mt-button size="small" variant="primary">Apply</mt-button>
+          </div>
+        </mt-floating-ui>
+      </div>
+    `,
+  }),
 };

--- a/packages/component-library/src/components/_internal/mt-floating-ui/mt-floating-ui.vue
+++ b/packages/component-library/src/components/_internal/mt-floating-ui/mt-floating-ui.vue
@@ -1,6 +1,6 @@
 <template>
-  <div ref="floatingUi" class="mt-floating-ui">
-    <div ref="floatingUiTrigger" class="mt-floating-ui__trigger">
+  <div ref="floatingUi" class="mt-floating-ui" :class="{ 'mt-floating-ui--detached': detached }">
+    <div v-if="!detached" ref="floatingUiTrigger" class="mt-floating-ui__trigger">
       <slot name="trigger" />
     </div>
     <Teleport to="body">
@@ -56,6 +56,16 @@ export type MtFloatingUiProps = {
    * If true, the floating UI content will match the width of the reference element.
    */
   matchReferenceWidth?: boolean;
+  /**
+   * An external DOM element to anchor the floating content to, instead of the
+   * built-in trigger slot wrapper
+   */
+  anchorElement?: HTMLElement | null;
+  /**
+   * When true, the trigger slot is not rendered and the root wrapper is not displayed
+   * Use with `anchorElement`.
+   */
+  detached?: boolean;
 };
 
 const props = defineProps<MtFloatingUiProps>();
@@ -86,7 +96,9 @@ const contentStyles = computed(() => {
 });
 
 const createFloatingUi = () => {
-  if (!floatingUiTrigger.value || !floatingUiContent.value) {
+  const referenceEl = props.anchorElement ?? floatingUiTrigger.value;
+
+  if (!referenceEl || !floatingUiContent.value) {
     return;
   }
 
@@ -97,14 +109,14 @@ const createFloatingUi = () => {
   floatingUiContent.value.classList.add(...givenClasses);
 
   cleanup = autoUpdate(
-    floatingUiTrigger.value,
+    referenceEl,
     floatingUiContent.value as HTMLElement,
     () => {
-      if (!floatingUiTrigger.value || !floatingUiContent.value) {
+      if (!referenceEl || !floatingUiContent.value) {
         return;
       }
 
-      computePosition(floatingUiTrigger.value, floatingUiContent.value as HTMLElement, {
+      computePosition(referenceEl, floatingUiContent.value as HTMLElement, {
         placement: "bottom-start",
         strategy: "fixed",
         middleware: [
@@ -190,9 +202,24 @@ watch(
   { immediate: true },
 );
 
+watch(
+  () => props.anchorElement,
+  () => {
+    if (props.isOpened) {
+      removeFloatingUi();
+      nextTick(() => {
+        createFloatingUi();
+      });
+    }
+  },
+);
+
 const onClickOutside = (event: Event) => {
-  // emit close when click is not inside trigger or content
-  if (floatingUi.value?.contains(event.target as Node)) {
+  // emit close when click is not inside trigger, external reference, or content
+  if (
+    floatingUi.value?.contains(event.target as Node) ||
+    props.anchorElement?.contains(event.target as Node)
+  ) {
     return;
   }
 
@@ -217,6 +244,10 @@ onBeforeUnmount(() => {
 
   .mt-floating-ui__trigger {
     display: inline-block;
+  }
+
+  &.mt-floating-ui--detached {
+    display: contents;
   }
 }
 


### PR DESCRIPTION
## What?
Add `anchorElement` and `detached` props to `mt-floating-ui` for external anchor positioning.

## Why?
The existing trigger slot pattern requires the anchor to live inside the component's own subtree, which is not always possible when the trigger and floating content are in different parts of the component tree.

## How?
When anchorElement is provided it replaces the internal trigger as the reference for autoUpdate and computePosition. A watcher re-anchors the popover immediately if the element changes while already open and the onClickOutside guard is extended to exclude clicks on the anchor element.

## Testing?
I've added a unit test to check the behaviour 
