### PR TITLE
fix(component-library): preserve decimal edits in number field

### DIFF
--- a/.changeset/smart-planes-fix.md
+++ b/.changeset/smart-planes-fix.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": patch
+---
+
+Prevent mt-number-field from normalizing the displayed decimal value while the user is editing.

--- a/packages/component-library/src/components/form/mt-number-field/mt-number-field.spec.ts
+++ b/packages/component-library/src/components/form/mt-number-field/mt-number-field.spec.ts
@@ -393,6 +393,81 @@ describe("mt-number-field", () => {
     expect(handler).toHaveBeenCalledWith(80);
   });
 
+  it("keeps fractional trailing zeros visible after deleting while editing", async () => {
+    // ARRANGE
+    const inputChangeHandler = vi.fn();
+    const updateHandler = vi.fn();
+
+    render(MtNumberField, {
+      props: {
+        modelValue: 1.07,
+        "onInput-change": inputChangeHandler,
+        "onUpdate:modelValue": updateHandler,
+      },
+    });
+
+    const input = screen.getByRole("textbox") as HTMLInputElement;
+
+    // ACT
+    await userEvent.click(input);
+    input.setSelectionRange(input.value.length, input.value.length);
+    await userEvent.keyboard("{Backspace}");
+
+    // ASSERT
+    expect(input).toHaveValue("1.0");
+    expect(inputChangeHandler).toHaveBeenLastCalledWith(1);
+    expect(updateHandler).not.toHaveBeenCalled();
+  });
+
+  it("commits the edited fractional value on blur", async () => {
+    // ARRANGE
+    const updateHandler = vi.fn();
+
+    render(MtNumberField, {
+      props: {
+        modelValue: 1.07,
+        "onUpdate:modelValue": updateHandler,
+      },
+    });
+
+    const input = screen.getByRole("textbox") as HTMLInputElement;
+
+    // ACT
+    await userEvent.click(input);
+    input.setSelectionRange(input.value.length, input.value.length);
+    await userEvent.keyboard("{Backspace}");
+    await userEvent.type(input, "8");
+    await userEvent.click(document.body);
+
+    // ASSERT
+    expect(updateHandler).toHaveBeenLastCalledWith(1.08);
+    expect(input).toHaveValue("1.08");
+  });
+
+  it("normalizes fractional trailing zeros on blur", async () => {
+    // ARRANGE
+    const updateHandler = vi.fn();
+
+    render(MtNumberField, {
+      props: {
+        modelValue: 1.07,
+        "onUpdate:modelValue": updateHandler,
+      },
+    });
+
+    const input = screen.getByRole("textbox") as HTMLInputElement;
+
+    // ACT
+    await userEvent.click(input);
+    input.setSelectionRange(input.value.length, input.value.length);
+    await userEvent.keyboard("{Backspace}");
+    await userEvent.click(document.body);
+
+    // ASSERT
+    expect(updateHandler).toHaveBeenLastCalledWith(1);
+    expect(input).toHaveValue("1");
+  });
+
   it("warns when allowEmpty is set to false", () => {
     // ARRANGE
     vi.spyOn(console, "warn").mockImplementation(() => {});

--- a/packages/component-library/src/components/form/mt-number-field/mt-number-field.spec.ts
+++ b/packages/component-library/src/components/form/mt-number-field/mt-number-field.spec.ts
@@ -468,6 +468,55 @@ describe("mt-number-field", () => {
     expect(input).toHaveValue("1");
   });
 
+  it("does not normalize exponent notation while editing", async () => {
+    // ARRANGE
+    const inputChangeHandler = vi.fn();
+    const updateHandler = vi.fn();
+
+    render(MtNumberField, {
+      props: {
+        "onInput-change": inputChangeHandler,
+        "onUpdate:modelValue": updateHandler,
+      },
+    });
+
+    const input = screen.getByRole("textbox") as HTMLInputElement;
+
+    // ACT
+    await userEvent.click(input);
+    await userEvent.paste("1e3");
+
+    // ASSERT
+    expect(inputChangeHandler).toHaveBeenLastCalledWith(1000);
+    expect(updateHandler).not.toHaveBeenCalled();
+    expect(input).toHaveValue("1e3");
+  });
+
+  it("normalizes exponent notation when committing on blur", async () => {
+    // ARRANGE
+    const inputChangeHandler = vi.fn();
+    const updateHandler = vi.fn();
+
+    render(MtNumberField, {
+      props: {
+        "onInput-change": inputChangeHandler,
+        "onUpdate:modelValue": updateHandler,
+      },
+    });
+
+    const input = screen.getByRole("textbox") as HTMLInputElement;
+
+    // ACT
+    await userEvent.click(input);
+    await userEvent.paste("1e3");
+    await userEvent.click(document.body);
+
+    // ASSERT
+    expect(inputChangeHandler).toHaveBeenLastCalledWith(1000);
+    expect(updateHandler).toHaveBeenLastCalledWith(1000);
+    expect(input).toHaveValue("1000");
+  });
+
   it("warns when allowEmpty is set to false", () => {
     // ARRANGE
     vi.spyOn(console, "warn").mockImplementation(() => {});

--- a/packages/component-library/src/components/form/mt-number-field/mt-number-field.vue
+++ b/packages/component-library/src/components/form/mt-number-field/mt-number-field.vue
@@ -267,14 +267,7 @@ export default defineComponent({
         return this.rawUserInput;
       }
 
-      if (this.currentValue === null) {
-        return "";
-      }
-
-      return this.fillDigits && this.numberType !== "int"
-        ? // @ts-expect-error - wrong type because of component extends
-          this.currentValue.toFixed(this.digits)
-        : this.currentValue.toString();
+      return this.getStringRepresentationFromCurrentValue();
     },
 
     controlClasses() {
@@ -347,6 +340,17 @@ export default defineComponent({
   },
 
   methods: {
+    getStringRepresentationFromCurrentValue(): string {
+      if (this.currentValue === null) {
+        return "";
+      }
+
+      return this.fillDigits && this.numberType !== "int"
+        ? // @ts-expect-error - wrong type because of component extends
+          this.currentValue.toFixed(this.digits)
+        : this.currentValue.toString();
+    },
+
     onChange(event: Event) {
       // @ts-expect-error - target exists
       this.computeValue(event.target.value);
@@ -428,7 +432,13 @@ export default defineComponent({
     },
 
     getNumberFromString(value: any) {
-      let splits = value.split("e").shift();
+      const normalizedValue = value.toString().replace(/,/g, ".");
+
+      if (normalizedValue.toLowerCase().includes("e")) {
+        return Number.parseFloat(normalizedValue);
+      }
+
+      let splits = normalizedValue;
       splits = splits.replace(/,/g, ".").split(".");
 
       if (splits.length === 1) {

--- a/packages/component-library/src/components/form/mt-number-field/mt-number-field.vue
+++ b/packages/component-library/src/components/form/mt-number-field/mt-number-field.vue
@@ -232,6 +232,12 @@ export default defineComponent({
     return { t };
   },
 
+  data() {
+    return {
+      rawUserInput: null as string | null,
+    };
+  },
+
   computed: {
     realStep(): number {
       if (this.step === null) {
@@ -257,6 +263,10 @@ export default defineComponent({
     },
 
     stringRepresentation(): string {
+      if (this.rawUserInput !== null) {
+        return this.rawUserInput;
+      }
+
       if (this.currentValue === null) {
         return "";
       }
@@ -284,6 +294,10 @@ export default defineComponent({
   watch: {
     modelValue: {
       handler() {
+        if (!this.hasFocus) {
+          this.rawUserInput = null;
+        }
+
         if (this.modelValue === null || this.modelValue === undefined) {
           // @ts-expect-error - defined in parent
           this.currentValue = null;
@@ -336,6 +350,7 @@ export default defineComponent({
     onChange(event: Event) {
       // @ts-expect-error - target exists
       this.computeValue(event.target.value);
+      this.rawUserInput = null;
 
       this.$emit("change", event);
       this.$emit("update:modelValue", this.currentValue);
@@ -344,6 +359,7 @@ export default defineComponent({
     onInput(event: Event) {
       // @ts-expect-error - target exists
       const inputValue = event.target.value;
+      this.rawUserInput = inputValue;
 
       if (inputValue === "" && this.allowEmptyWithDefault) {
         // @ts-expect-error - defined in parent
@@ -366,6 +382,7 @@ export default defineComponent({
 
     increaseNumberByStep() {
       this.computeValue((Number(this.currentValue) + this.realStep).toString());
+      this.rawUserInput = null;
 
       this.$emit("update:modelValue", this.currentValue);
     },
@@ -373,6 +390,7 @@ export default defineComponent({
     decreaseNumberByStep() {
       // @ts-expect-error - wrong type because of component extends
       this.computeValue((this.currentValue - this.realStep).toString());
+      this.rawUserInput = null;
 
       this.$emit("update:modelValue", this.currentValue);
     },


### PR DESCRIPTION
## What?

`mt-number-field` now preserves the raw text a user is editing while the field has focus. This prevents intermediate decimal values such as `1.0` from being rendered back as `1` before the user finishes editing.

### Reviewer walkthrough

* `mt-number-field.vue`: the component keeps `rawUserInput` separate from the parsed numeric `currentValue`, uses it only for the displayed input value while editing, and clears it again when the value is committed or changed by step controls.

## Why?

Shopware issue https://github.com/shopware/shopware/issues/16104 reports that price fields normalize `1.07` to `1` while the user is still editing after pressing Backspace. The field should allow editing through `1.0` so the user can continue to `1.08`; final numeric normalization should still happen on blur.

## How?

The displayed value now prefers a transient `rawUserInput` string while it exists. `onInput` still parses and emits the numeric `input-change` value, but Vue no longer re-renders the focused input from `currentValue.toString()` on every keystroke. `rawUserInput` is cleared when the value is committed, when external model updates arrive while the field is not focused, and when step controls change the number.

## Testing?

`mt-number-field`:
- focused deletion keeps `1.0` visible after `1.07` + Backspace and does not emit `update:modelValue` yet;
- completing the edit with `8` and blurring commits `1.08`;
- blurring directly after `1.07` + Backspace still normalizes the committed value to `1`.
