### PR TITLE
fix: resolve date-fns locale exports in datepicker

### DIFF
--- a/.changeset/fix-datepicker-locale-loader.md
+++ b/.changeset/fix-datepicker-locale-loader.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": patch
+---
+
+Fix datepicker locale loading for date-fns v4 locale module exports.

--- a/packages/component-library/src/components/form/mt-datepicker/date-fns-locale.spec.ts
+++ b/packages/component-library/src/components/form/mt-datepicker/date-fns-locale.spec.ts
@@ -1,9 +1,14 @@
 import { describe, expect, it } from "vitest";
 import { de } from "date-fns/locale/de";
 import { enGB } from "date-fns/locale/en-GB";
-import { resolveDateFnsLocaleModule } from "./date-fns-locale";
+import { importDateFnsLocaleModule, resolveDateFnsLocaleModule } from "./date-fns-locale";
 
 describe("date-fns locale resolver", () => {
+  it("imports valid locale paths", async () => {
+    await expect(importDateFnsLocaleModule("de")).resolves.toBe(de);
+    await expect(importDateFnsLocaleModule("en-GB")).resolves.toBe(enGB);
+  });
+
   it("resolves date-fns v4 named locale exports", () => {
     expect(resolveDateFnsLocaleModule("de", { de })).toBe(de);
     expect(resolveDateFnsLocaleModule("en-GB", { enGB })).toBe(enGB);
@@ -15,5 +20,10 @@ describe("date-fns locale resolver", () => {
 
   it("resolves direct default locale exports", () => {
     expect(resolveDateFnsLocaleModule("de", { default: de })).toBe(de);
+  });
+
+  it("rejects unsafe locale import paths", async () => {
+    await expect(importDateFnsLocaleModule("../format")).resolves.toBeNull();
+    await expect(importDateFnsLocaleModule("en/US")).resolves.toBeNull();
   });
 });

--- a/packages/component-library/src/components/form/mt-datepicker/date-fns-locale.spec.ts
+++ b/packages/component-library/src/components/form/mt-datepicker/date-fns-locale.spec.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { de } from "date-fns/locale/de";
+import { enGB } from "date-fns/locale/en-GB";
+import { resolveDateFnsLocaleModule } from "./date-fns-locale";
+
+describe("date-fns locale resolver", () => {
+  it("resolves date-fns v4 named locale exports", () => {
+    expect(resolveDateFnsLocaleModule("de", { de })).toBe(de);
+    expect(resolveDateFnsLocaleModule("en-GB", { enGB })).toBe(enGB);
+  });
+
+  it("resolves nested default locale exports", () => {
+    expect(resolveDateFnsLocaleModule("de", { default: { de } })).toBe(de);
+  });
+
+  it("resolves direct default locale exports", () => {
+    expect(resolveDateFnsLocaleModule("de", { default: de })).toBe(de);
+  });
+});

--- a/packages/component-library/src/components/form/mt-datepicker/date-fns-locale.ts
+++ b/packages/component-library/src/components/form/mt-datepicker/date-fns-locale.ts
@@ -1,0 +1,45 @@
+import type { Locale } from "date-fns";
+
+type DateFnsLocaleModule = {
+  default?: unknown;
+  [key: string]: unknown;
+};
+
+function isDateFnsLocale(value: unknown): value is Locale {
+  return typeof value === "object" && value !== null && "localize" in value;
+}
+
+export function resolveDateFnsLocaleModule(
+  path: string,
+  localeModule: DateFnsLocaleModule,
+): Locale | null {
+  const localeName = path.replace(/-/g, "");
+  const defaultExport = localeModule.default;
+
+  const candidates = [
+    localeModule[localeName],
+    typeof defaultExport === "object" && defaultExport !== null
+      ? (defaultExport as DateFnsLocaleModule)[localeName]
+      : undefined,
+    typeof defaultExport === "object" && defaultExport !== null
+      ? (defaultExport as DateFnsLocaleModule).default
+      : undefined,
+    defaultExport,
+    localeModule,
+  ];
+
+  return candidates.find(isDateFnsLocale) ?? null;
+}
+
+export async function importDateFnsLocaleModule(path: string): Promise<Locale | null> {
+  try {
+    const localeModule = (await import(
+      /* @vite-ignore */
+      `date-fns/locale/${path}`
+    )) as DateFnsLocaleModule;
+
+    return resolveDateFnsLocaleModule(path, localeModule);
+  } catch {
+    return null;
+  }
+}

--- a/packages/component-library/src/components/form/mt-datepicker/date-fns-locale.ts
+++ b/packages/component-library/src/components/form/mt-datepicker/date-fns-locale.ts
@@ -9,6 +9,10 @@ function isDateFnsLocale(value: unknown): value is Locale {
   return typeof value === "object" && value !== null && "localize" in value;
 }
 
+function isSafeLocalePath(path: string): boolean {
+  return /^[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*$/.test(path);
+}
+
 export function resolveDateFnsLocaleModule(
   path: string,
   localeModule: DateFnsLocaleModule,
@@ -32,6 +36,10 @@ export function resolveDateFnsLocaleModule(
 }
 
 export async function importDateFnsLocaleModule(path: string): Promise<Locale | null> {
+  if (!isSafeLocalePath(path)) {
+    return null;
+  }
+
   try {
     const localeModule = (await import(
       /* @vite-ignore */

--- a/packages/component-library/src/components/form/mt-datepicker/mt-datepicker.vue
+++ b/packages/component-library/src/components/form/mt-datepicker/mt-datepicker.vue
@@ -112,6 +112,7 @@ import "@vuepic/vue-datepicker/dist/main.css";
 import { useId } from "vue";
 import { enUS } from "date-fns/locale/en-US";
 import type { Locale } from "date-fns";
+import { importDateFnsLocaleModule } from "./date-fns-locale";
 
 interface Time {
   hours: number;
@@ -245,17 +246,6 @@ const errorMessage = ref<{ detail: string } | undefined>(undefined);
 const isTimeHintVisible = ref(true);
 const datePickerLocale = ref<Locale>(enUS);
 let localeLoadId = 0;
-
-async function importDateFnsLocaleModule(path: string): Promise<Locale | null> {
-  try {
-    const { default: locale } = (await import(/* @vite-ignore */ `date-fns/locale/${path}`)) as {
-      default: Locale;
-    };
-    return locale;
-  } catch {
-    return null;
-  }
-}
 
 async function loadDateFnsLocale(tag: string): Promise<Locale> {
   const normalized = tag.replace(/_/g, "-").trim() || "en-US";


### PR DESCRIPTION
## What changed
- Added a date-fns locale resolver for the component-library datepicker.
- Normalized date-fns v4 locale module shapes so named exports like `de` and `enGB`, nested defaults, and direct defaults all resolve to a valid `Locale` object.
- Moved the dynamic locale import through that resolver and added focused regression coverage.
- Added a patch changeset for `@shopware-ag/meteor-component-library`.

## Why
Meteor 5.0.0 upgraded the datepicker dependency stack to vue-datepicker v12 and date-fns v4. In some consumers, dynamic locale imports no longer provide the locale object as a direct default export. Passing the wrapper object through to vue-datepicker makes date-fns fail while formatting localized datepicker content.

## Impact
This keeps the existing datepicker locale API compatible for consumers and should allow a 5.0.1 patch release of `@shopware-ag/meteor-component-library` instead of downstream patch-package workarounds.

## Relationships
relates to shopware/shopware#17177