### PR TITLE
fix: avoid Playwright install hang

### DIFF
--- a/.github/workflows/create-meteor-extension-integration.yml
+++ b/.github/workflows/create-meteor-extension-integration.yml
@@ -41,9 +41,9 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: '24'
-          cache: 'pnpm'
-          cache-dependency-path: 'meteor/pnpm-lock.yaml'
+          node-version: "22.13.0"
+          cache: "pnpm"
+          cache-dependency-path: "meteor/pnpm-lock.yaml"
 
       # 4. Create plugin structure using Shopware's plugin:create command
       - name: Create plugin using Shopware CLI

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -125,7 +125,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: "24"
+          node-version: "22.13.0"
           cache: "pnpm"
 
       - name: Install dependencies

--- a/.github/workflows/visual-tests.yml
+++ b/.github/workflows/visual-tests.yml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: "24"
+          node-version: "22.13.0"
           cache: "pnpm"
 
       - name: Install dependencies


### PR DESCRIPTION
## What?
Pin Node.js to 22.13.0 in CI jobs that run Playwright (tests.yml playwright job, visual-tests.yml, create-meteor-extension-integration.yml). Other jobs stay on Node 24.

## Why?
playwright install can hang after download on Node 24 ([playwright#41092](https://github.com/microsoft/playwright/issues/41092)). Node 22 LTS works; Meteor already uses 22.13.0 locally.

## How?
Set node-version: "22.13.0" in actions/setup-node only in those Playwright workflows.
