### PR TITLE
fix: add license metadata to @shopware-ag/meteor-component-library

### DIFF
--- a/packages/component-library/package.json
+++ b/packages/component-library/package.json
@@ -172,5 +172,6 @@
   },
   "peerDependencies": {
     "@shopware-ag/meteor-icon-kit": "workspace:*"
-  }
+  },
+  "license": "MIT"
 }


### PR DESCRIPTION
## Summary

The published @shopware-ag/meteor-component-library package does not declare license metadata in its package.json even though the repository root license is MIT.

## Changes
- Added "license": "MIT" to packages/component-library/package.json

Closes Charles micro-bounty #821