### PR TITLE
fix: adjusted font bundling which now skips vite bundling

### DIFF
--- a/.changeset/fuzzy-buckets-lay.md
+++ b/.changeset/fuzzy-buckets-lay.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": patch
+---
+
+Adjusted font bundling to import the actual woff2 font files instead of vite bundling them in base64 due to library mode defaults

--- a/packages/component-library/build/helper.ts
+++ b/packages/component-library/build/helper.ts
@@ -1,6 +1,22 @@
 import path from "path";
 import fs from "fs";
+import { createRequire } from "node:module";
 import type { Plugin } from "vite";
+
+const requireFromHelper = createRequire(path.join(__dirname, "helper.ts"));
+
+const interFontAssets = [
+  {
+    source: "Inter (web)/Inter-roman.var.woff2",
+    output: "Inter-roman.woff2",
+  },
+  {
+    source: "Inter (web)/Inter-italic.var.woff2",
+    output: "Inter-italic.woff2",
+  },
+];
+
+const interFontOutputDirectory = "assets/fonts";
 
 // Helper to convert kebab-case to PascalCase
 export function toPascalCase(str: string): string {
@@ -43,6 +59,98 @@ export function getAllComponents() {
   return components;
 }
 
+function toRelativeImportPath(fromFileName: string, toFileName: string): string {
+  let relativePath = path.posix.relative(path.posix.dirname(fromFileName), toFileName);
+
+  if (!relativePath.startsWith(".")) {
+    relativePath = `./${relativePath}`;
+  }
+
+  return relativePath;
+}
+
+function getInterUiPackageDirectory(): string {
+  return path.dirname(requireFromHelper.resolve("inter-ui/package.json"));
+}
+
+function getInterFontCss(): string {
+  const cssPath = path.resolve(__dirname, "../src/components/assets/css/fonts/inter.font.css");
+  let css = fs.readFileSync(cssPath, "utf-8");
+
+  for (const fontAsset of interFontAssets) {
+    css = css.replaceAll(
+      `~inter-ui/${fontAsset.source}?v=3.19`,
+      `./${interFontOutputDirectory}/${fontAsset.output}`,
+    );
+  }
+
+  if (css.includes("~inter-ui")) {
+    throw new Error("The generated font CSS still contains unresolved inter-ui asset references.");
+  }
+
+  return css;
+}
+
+function readFileAsUint8Array(filePath: string): Uint8Array<ArrayBuffer> {
+  const buffer = fs.readFileSync(filePath);
+  const bytes = new Uint8Array(buffer.byteLength);
+  bytes.set(buffer);
+
+  return bytes;
+}
+
+/**
+ * Emits the public font.css stylesheet and its WOFF2 files without passing
+ * font URLs through Vite library mode, where assets are always inlined.
+ */
+export function emitInterFontAssets(): Plugin {
+  return {
+    name: "emit-inter-font-assets",
+    apply: (config, { command }) => {
+      return command === "build" && !!config.build?.lib;
+    },
+    generateBundle(_options, bundle) {
+      const fontCssFileName = "fonts.css";
+      const interUiPackageDirectory = getInterUiPackageDirectory();
+
+      this.emitFile({
+        type: "asset",
+        fileName: fontCssFileName,
+        source: getInterFontCss(),
+      });
+
+      for (const fontAsset of interFontAssets) {
+        this.emitFile({
+          type: "asset",
+          fileName: `${interFontOutputDirectory}/${fontAsset.output}`,
+          source: readFileAsUint8Array(path.join(interUiPackageDirectory, fontAsset.source)),
+        });
+      }
+
+      this.emitFile({
+        type: "asset",
+        fileName: `${interFontOutputDirectory}/LICENSE.txt`,
+        source: fs.readFileSync(path.join(interUiPackageDirectory, "LICENSE.txt"), "utf-8"),
+      });
+
+      for (const key in bundle) {
+        const chunk = bundle[key];
+
+        if (chunk.type !== "chunk" || path.basename(chunk.fileName) !== "fonts.js") {
+          continue;
+        }
+
+        const relativePath = toRelativeImportPath(chunk.fileName, fontCssFileName);
+        const importStatement = `import '${relativePath}';`;
+
+        if (!chunk.code.includes(importStatement)) {
+          chunk.code = `${importStatement}\n${chunk.code}`;
+        }
+      }
+    },
+  };
+}
+
 /**
  * Vite/Rollup plugin to inject CSS imports into JS chunks during build.
  * Ensures that any CSS imported by a chunk is also imported at runtime.
@@ -54,7 +162,7 @@ export function libInjectCss(): Plugin {
       return command === "build" && !!config.build?.lib;
     },
     enforce: "post",
-    generateBundle(options, bundle) {
+    generateBundle(_options, bundle) {
       for (const key in bundle) {
         const chunk = bundle[key];
 
@@ -87,17 +195,12 @@ export function libInjectCss(): Plugin {
 
           // 3. Inject the import if a matching CSS file was found
           if (cssFileName) {
-            // Calculate relative path from JS to CSS
-            // From "esm/MtButton.js" (dir: "esm") to "mt-button.css" -> "../mt-button.css"
-            let relativePath = path.posix.relative(path.posix.dirname(jsFileName), cssFileName);
+            const relativePath = toRelativeImportPath(jsFileName, cssFileName);
+            const importStatement = `import '${relativePath}';`;
 
-            // Ensure path starts with ./ or ../
-            if (!relativePath.startsWith(".")) {
-              relativePath = `./${relativePath}`;
+            if (!chunk.code.includes(importStatement)) {
+              chunk.code = `${importStatement}\n${chunk.code}`;
             }
-
-            // Inject import at the top
-            chunk.code = `import '${relativePath}';\n${chunk.code}`;
           }
         }
       }

--- a/packages/component-library/build/helper.ts
+++ b/packages/component-library/build/helper.ts
@@ -5,17 +5,7 @@ import type { Plugin } from "vite";
 
 const requireFromHelper = createRequire(path.join(__dirname, "helper.ts"));
 
-const interFontAssets = [
-  {
-    source: "Inter (web)/Inter-roman.var.woff2",
-    output: "Inter-roman.woff2",
-  },
-  {
-    source: "Inter (web)/Inter-italic.var.woff2",
-    output: "Inter-italic.woff2",
-  },
-];
-
+const interFontNames = ["Inter-roman", "Inter-italic"] as const;
 const interFontOutputDirectory = "assets/fonts";
 
 // Helper to convert kebab-case to PascalCase
@@ -77,10 +67,10 @@ function getInterFontCss(): string {
   const cssPath = path.resolve(__dirname, "../src/components/assets/css/fonts/inter.font.css");
   let css = fs.readFileSync(cssPath, "utf-8");
 
-  for (const fontAsset of interFontAssets) {
+  for (const fontName of interFontNames) {
     css = css.replaceAll(
-      `~inter-ui/${fontAsset.source}?v=3.19`,
-      `./${interFontOutputDirectory}/${fontAsset.output}`,
+      `~inter-ui/Inter (web)/${fontName}.var.woff2?v=3.19`,
+      `./${interFontOutputDirectory}/${fontName}.woff2`,
     );
   }
 
@@ -100,8 +90,8 @@ function readFileAsUint8Array(filePath: string): Uint8Array<ArrayBuffer> {
 }
 
 /**
- * Emits the public font.css stylesheet and its WOFF2 files without passing
- * font URLs through Vite library mode, where assets are always inlined.
+ * Emits dist/fonts.css, which backs the public "./font.css" export, plus
+ * its WOFF2 files without passing font URLs through Vite library mode.
  */
 export function emitInterFontAssets(): Plugin {
   return {
@@ -109,7 +99,7 @@ export function emitInterFontAssets(): Plugin {
     apply: (config, { command }) => {
       return command === "build" && !!config.build?.lib;
     },
-    generateBundle(_options, bundle) {
+    generateBundle() {
       const fontCssFileName = "fonts.css";
       const interUiPackageDirectory = getInterUiPackageDirectory();
 
@@ -119,11 +109,13 @@ export function emitInterFontAssets(): Plugin {
         source: getInterFontCss(),
       });
 
-      for (const fontAsset of interFontAssets) {
+      for (const fontName of interFontNames) {
         this.emitFile({
           type: "asset",
-          fileName: `${interFontOutputDirectory}/${fontAsset.output}`,
-          source: readFileAsUint8Array(path.join(interUiPackageDirectory, fontAsset.source)),
+          fileName: `${interFontOutputDirectory}/${fontName}.woff2`,
+          source: readFileAsUint8Array(
+            path.join(interUiPackageDirectory, `Inter (web)/${fontName}.var.woff2`),
+          ),
         });
       }
 
@@ -132,21 +124,6 @@ export function emitInterFontAssets(): Plugin {
         fileName: `${interFontOutputDirectory}/LICENSE.txt`,
         source: fs.readFileSync(path.join(interUiPackageDirectory, "LICENSE.txt"), "utf-8"),
       });
-
-      for (const key in bundle) {
-        const chunk = bundle[key];
-
-        if (chunk.type !== "chunk" || path.basename(chunk.fileName) !== "fonts.js") {
-          continue;
-        }
-
-        const relativePath = toRelativeImportPath(chunk.fileName, fontCssFileName);
-        const importStatement = `import '${relativePath}';`;
-
-        if (!chunk.code.includes(importStatement)) {
-          chunk.code = `${importStatement}\n${chunk.code}`;
-        }
-      }
     },
   };
 }

--- a/packages/component-library/src/fonts.ts
+++ b/packages/component-library/src/fonts.ts
@@ -1,3 +1,4 @@
-import "./components/assets/css/fonts/inter.font.css";
-
+// Placeholder entry for the package "./fonts" export.
+// The build plugin injects dist/fonts.css into this chunk.
+// Consumers still import the stylesheet through the public "./font.css" export.
 export {};

--- a/packages/component-library/vite.config.ts
+++ b/packages/component-library/vite.config.ts
@@ -6,7 +6,7 @@ import vue from "@vitejs/plugin-vue";
 // @ts-expect-error - not typed
 import svg from "vite-plugin-svgstring";
 import dts from "vite-plugin-dts";
-import { getAllComponents, libInjectCss, toPascalCase } from "./build/helper";
+import { emitInterFontAssets, getAllComponents, libInjectCss, toPascalCase } from "./build/helper";
 
 // Get all components and their paths
 const allComponents = getAllComponents();
@@ -65,6 +65,7 @@ export default defineConfig({
       },
     }),
     libInjectCss(),
+    emitInterFontAssets(),
   ],
   resolve: {
     alias: [
@@ -90,7 +91,7 @@ export default defineConfig({
         ...allComponents,
       },
       formats: ["es", "cjs"],
-      fileName: (format, entryName) => `${{ es: "esm", cjs: "common" }[format]}/${entryName}.js`,
+      fileName: (format, entryName) => `${format === "es" ? "esm" : "common"}/${entryName}.js`,
     },
     cssCodeSplit: true,
     rollupOptions: {


### PR DESCRIPTION
## What?
Adjusted font loading by skipping vite bundling for fonts

## Why?
Vite library mode will always inline all assets which leads to it bundling the fonts into base64, which increases the bundle size unnecessarily. With this change we are loading the actual font files instead and relying purely on css. We are required to add a small call in the build step to copy the font assets into the dist folder manually to avoid vite to handle and inline those.

## How?
Custom build script copies assets, paths of fonts are set in the css - the final usage path for consumers stays the same - it's still font.css

## Testing?
Tested it manually and the output dist from the build contains the correct files and paths.
