### PR TITLE
chore: use public repository metadata for stylelint plugin

### DIFF
--- a/packages/stylelint-plugin-meteor/package.json
+++ b/packages/stylelint-plugin-meteor/package.json
@@ -3,7 +3,7 @@
   "version": "5.0.0",
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com:shopware/meteor.git"
+    "url": "git+https://github.com/shopware/meteor.git"
   },
   "main": "./dist/commonjs/index.js",
   "files": [


### PR DESCRIPTION
## Summary

- switch `@shopware-ag/stylelint-plugin-meteor` repository metadata from SSH-style GitHub URL to public `git+https`

## Validation

- `node` metadata assertion passed
- `git diff --check`
- `npm pack --dry-run --ignore-scripts --json ./packages/stylelint-plugin-meteor`
