### PR TITLE
fix: number field normalization

### DIFF
--- a/.changeset/fix-number-field-float-normalization.md
+++ b/.changeset/fix-number-field-float-normalization.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": patch
+---
+
+Fixed `mt-number-field` with `numberType="float"` rounding some values down due to binary floating-point errors (for example `1.035` normalized to `1.03` instead of `1.04`). Normalization now rounds on the decimal representation, so half-up rounding is consistent across values.

--- a/.changeset/fix-number-field-int-parsing.md
+++ b/.changeset/fix-number-field-int-parsing.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": patch
+---
+
+Fixed `mt-number-field` with `numberType="int"` mangling decimal input on blur (for example `1.05` became `105` instead of `1`). Decimal and exponent input is now parsed as a float and rounded to the nearest integer.

--- a/packages/component-library/src/components/form/mt-number-field/mt-number-field.spec.ts
+++ b/packages/component-library/src/components/form/mt-number-field/mt-number-field.spec.ts
@@ -444,6 +444,28 @@ describe("mt-number-field", () => {
     expect(input).toHaveValue("1.08");
   });
 
+  it("rounds half up without float precision errors on blur", async () => {
+    // ARRANGE
+    const updateHandler = vi.fn();
+
+    render(MtNumberField, {
+      props: {
+        "onUpdate:modelValue": updateHandler,
+      },
+    });
+
+    const input = screen.getByRole("textbox") as HTMLInputElement;
+
+    // ACT
+    await userEvent.click(input);
+    await userEvent.type(input, "1.035");
+    await userEvent.click(document.body);
+
+    // ASSERT
+    expect(updateHandler).toHaveBeenLastCalledWith(1.04);
+    expect(input).toHaveValue("1.04");
+  });
+
   it("normalizes fractional trailing zeros on blur", async () => {
     // ARRANGE
     const updateHandler = vi.fn();

--- a/packages/component-library/src/components/form/mt-number-field/mt-number-field.spec.ts
+++ b/packages/component-library/src/components/form/mt-number-field/mt-number-field.spec.ts
@@ -539,6 +539,109 @@ describe("mt-number-field", () => {
     expect(input).toHaveValue("1000");
   });
 
+  it("rounds a decimal value to an integer on blur for int type", async () => {
+    // ARRANGE
+    const updateHandler = vi.fn();
+
+    render(MtNumberField, {
+      props: {
+        numberType: "int",
+        "onUpdate:modelValue": updateHandler,
+      },
+    });
+
+    const input = screen.getByRole("textbox") as HTMLInputElement;
+
+    // ACT
+    await userEvent.click(input);
+    await userEvent.type(input, "1.05");
+
+    // ASSERT - raw value stays visible while editing, no normalization yet
+    expect(input).toHaveValue("1.05");
+    expect(updateHandler).not.toHaveBeenCalled();
+
+    // ACT
+    await userEvent.click(document.body);
+
+    // ASSERT - normalized to an integer on blur
+    expect(updateHandler).toHaveBeenLastCalledWith(1);
+    expect(input).toHaveValue("1");
+  });
+
+  it("normalizes exponent notation to an integer on blur for int type", async () => {
+    // ARRANGE
+    const updateHandler = vi.fn();
+
+    render(MtNumberField, {
+      props: {
+        numberType: "int",
+        "onUpdate:modelValue": updateHandler,
+      },
+    });
+
+    const input = screen.getByRole("textbox") as HTMLInputElement;
+
+    // ACT
+    await userEvent.click(input);
+    await userEvent.type(input, "1e3");
+
+    // ASSERT - raw value stays visible while editing
+    expect(input).toHaveValue("1e3");
+
+    // ACT
+    await userEvent.click(document.body);
+
+    // ASSERT
+    expect(updateHandler).toHaveBeenLastCalledWith(1000);
+    expect(input).toHaveValue("1000");
+  });
+
+  it("rounds a small exponent value down to zero on blur for int type", async () => {
+    // ARRANGE
+    const updateHandler = vi.fn();
+
+    render(MtNumberField, {
+      props: {
+        numberType: "int",
+        "onUpdate:modelValue": updateHandler,
+      },
+    });
+
+    const input = screen.getByRole("textbox") as HTMLInputElement;
+
+    // ACT
+    await userEvent.click(input);
+    await userEvent.type(input, "2e-3");
+    await userEvent.click(document.body);
+
+    // ASSERT
+    expect(updateHandler).toHaveBeenLastCalledWith(0);
+    expect(input).toHaveValue("0");
+  });
+
+  it("rounds halves up to the nearest integer on blur for int type", async () => {
+    // ARRANGE
+    const updateHandler = vi.fn();
+
+    render(MtNumberField, {
+      props: {
+        numberType: "int",
+        "onUpdate:modelValue": updateHandler,
+      },
+    });
+
+    const input = screen.getByRole("textbox") as HTMLInputElement;
+
+    // ACT
+    await userEvent.click(input);
+    await userEvent.type(input, "1.5");
+    await userEvent.click(document.body);
+
+    // ASSERT
+    expect(updateHandler).toHaveBeenLastCalledWith(2);
+    expect(input).toHaveValue("2");
+  });
+
   it("warns when allowEmpty is set to false", () => {
     // ARRANGE
     vi.spyOn(console, "warn").mockImplementation(() => {});

--- a/packages/component-library/src/components/form/mt-number-field/mt-number-field.vue
+++ b/packages/component-library/src/components/form/mt-number-field/mt-number-field.vue
@@ -450,10 +450,16 @@ export default defineComponent({
       }
       const decimals = splits[splits.length - 1].length;
       const float = parseFloat(splits.join(".")).toFixed(decimals);
-      return decimals > this.digits
-        ? // @ts-expect-error - can be calculated
-          Math.round(float * 10 ** this.digits) / 10 ** this.digits
-        : Number(float);
+
+      return decimals > this.digits ? this.roundToDigits(float, this.digits) : Number(float);
+    },
+
+    roundToDigits(value: string, digits: number): number {
+      // Round on the decimal string instead of computing `value * 10 ** digits`,
+      // whose binary float error would otherwise drop e.g. 1.035 to 1.03 instead
+      // of 1.04. `Number("1.035e2")` parses straight to 103.5, so Math.round acts
+      // on the intended decimal value.
+      return Number(`${Math.round(Number(`${value}e${digits}`))}e-${digits}`);
     },
 
     checkForInteger(value: number) {

--- a/packages/component-library/src/components/form/mt-number-field/mt-number-field.vue
+++ b/packages/component-library/src/components/form/mt-number-field/mt-number-field.vue
@@ -446,7 +446,9 @@ export default defineComponent({
       }
 
       if (this.numberType === "int") {
-        return parseInt(splits.join(""), 10);
+        // Keep the decimal point and let checkForInteger round the result. Joining
+        // without "." would concatenate the digit groups and turn 1.05 into 105.
+        return parseFloat(splits.join("."));
       }
       const decimals = splits[splits.length - 1].length;
       const float = parseFloat(splits.join(".")).toFixed(decimals);
@@ -467,13 +469,13 @@ export default defineComponent({
         return value;
       }
 
-      const floor = Math.floor(value);
-      if (floor !== value) {
+      const rounded = Math.round(value);
+      if (rounded !== value) {
         this.$nextTick(() => {
           this.$forceUpdate();
         });
       }
-      return floor;
+      return rounded;
     },
   },
 });


### PR DESCRIPTION
## What?

Two related normalization fixes for `mt-number-field`:

- **#1159 (float):** `1.035` no longer normalizes to `1.03` (now `1.04`).
- **#1158 (int):** decimal input no longer mangles (`1.05` was becoming `105`, now `1`); decimals/exponents parse as float and round to the nearest integer.

Closes #1159
Closes #1158