### PR TITLE
fix: clip mt-card content to its rounded corners (#1108)

### DIFF
--- a/.changeset/fix-mt-card-overflow-hidden.md
+++ b/.changeset/fix-mt-card-overflow-hidden.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": patch
+---
+
+Fixed `mt-card` letting full-bleed content overflow its rounded corners by clipping content with `overflow: hidden`.

--- a/packages/component-library/src/components/layout/mt-card/mt-card.vue
+++ b/packages/component-library/src/components/layout/mt-card/mt-card.vue
@@ -182,7 +182,8 @@ const cardClasses = computed(() => ({
   position: relative;
   background: var(--color-elevation-surface-raised);
   border: 1px solid var(--color-border-secondary-default);
-  border-radius: var(--border-radius-card); /* Added here */
+  border-radius: var(--border-radius-card);
+  overflow: hidden;
 
   &:not(:has(.mt-card__tabs:empty)) .mt-card__header {
     border-bottom: none;


### PR DESCRIPTION
## What?

Adds `overflow: hidden` to `.mt-card` so full-bleed content (header borders, data grids, images) is clipped to the card's rounded corners instead of poking past them.

Closes #1108

## Why?

`.mt-card` had `border-radius` but no `overflow`, so square-cornered content could overflow the rounded corners.

## How?

One declaration on `.mt-card`:

```css
.mt-card {
  border-radius: var(--border-radius-card);
  overflow: hidden;
}
```

## Testing?

- Manually smoke tested in Admin. No issues found.