### PR TITLE
fix: align vue-i18n @intlify deps in docs build

### DIFF
--- a/apps/docs/nuxt.config.ts
+++ b/apps/docs/nuxt.config.ts
@@ -21,6 +21,17 @@ const vueI18nPath = fileURLToPath(
   ),
 );
 
+// vue-i18n@9 (aliased above) imports @intlify internals. Alias those to the
+// SAME nested v9 copies, otherwise the docs build mixes them with the root v11
+// @intlify (which removed `compileToFunction`) → SyntaxError at runtime on Vercel.
+const meteorIntlifyPath = (pkg: string) =>
+  fileURLToPath(
+    new URL(
+      `../../packages/component-library/node_modules/@intlify/${pkg}`,
+      import.meta.url,
+    ),
+  );
+
 // The meteor component library barrel (its index.js) imports a global CSS
 // reset (dist/index.css) that retargets bare elements (*, body, button,
 // h1-h6) and leaks onto the docs typography. The docs deliberately do not
@@ -226,6 +237,9 @@ export default defineNuxtConfig({
     resolve: {
       alias: {
         "vue-i18n": vueI18nPath,
+        "@intlify/core-base": meteorIntlifyPath("core-base"),
+        "@intlify/message-compiler": meteorIntlifyPath("message-compiler"),
+        "@intlify/shared": meteorIntlifyPath("shared"),
       },
     },
     optimizeDeps: {


### PR DESCRIPTION
## What

The docs aliases `vue-i18n` to the component library's nested **v9** copy (so the meteor components' `useI18n()` works), but its `@intlify/*` deps were still resolving to the **root v11** — which dropped `compileToFunction`. The Vercel SSR function then crashed at load with:

> `SyntaxError: The requested module '@intlify/core-base' does not provide an export named 'compileToFunction'`

This aliases `@intlify/core-base`, `@intlify/message-compiler` and `@intlify/shared` to the same nested **v9.13.1** copies, so the whole vue-i18n@9 + @intlify@9 stack stays consistent.

## Notes

- Follow-up to the vue/server-renderer fix already merged to `main`.
- Verified locally with a Vercel-preset build: the function entry imports without the SyntaxError (both load-time errors gone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)