### PR TITLE
fix(docs): disable Docus AI assistant

### DIFF
--- a/apps/docs/app/app.config.ts
+++ b/apps/docs/app/app.config.ts
@@ -8,6 +8,10 @@ export default defineAppConfig({
     // Scope the docs sidebar to the current top-level section only.
     sub: "aside",
   },
+  assistant: {
+    floatingInput: false,
+    explainWithAi: false,
+  },
   header: {
     title: "Meteor Design System",
     logo: {


### PR DESCRIPTION
## What

Disables the Docus AI assistant on the deployed docs site by turning off both entry points in \`apps/docs/app/app.config.ts\`:

- \`floatingInput: false\` — hides the floating chat box
- \`explainWithAi: false\` — hides the "Explain with AI" sidebar button

## Why

The AI chat should not be surfaced on the deployed docs. Using config rather than removing \`AI_GATEWAY_API_KEY\` makes the intent explicit and independent of deployment env vars.

Ref: https://docus.dev/raw/en/ai/assistant.md