### PR TITLE
fix: component library icon-kit peer major bump

### DIFF
--- a/.changeset/component-library-icon-kit-peer-major-bump.md
+++ b/.changeset/component-library-icon-kit-peer-major-bump.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": patch
+---
+
+Removed `@shopware-ag/meteor-icon-kit` from `peerDependencies` to prevent unwanted major version bumps. Because Changesets treats any non-patch bump of a peer dependency as a breaking change for the dependent package, a minor release of the icon kit forced a major release of the component library. The icon kit remains a regular dependency, so resolution is unchanged.

--- a/packages/component-library/package.json
+++ b/packages/component-library/package.json
@@ -169,8 +169,5 @@
     "vite-plugin-svgstring": "^1.0.0",
     "vitest": "^3.0.5",
     "vue-tsc": "^2.2.4"
-  },
-  "peerDependencies": {
-    "@shopware-ag/meteor-icon-kit": "workspace:*"
   }
 }


### PR DESCRIPTION
## What? 
Removed @shopware-ag/meteor-icon-kit from the component library's peerDependencies.

## Why?
Changesets treats any non-patch bump of a peer dependency as breaking, so an icon-kit minor release wrongly forced a major release of the component library.

## How? 
Dropping the peer entry lets updateInternalDependencies: "patch" apply instead, so icon-kit minor bumps passed through as patch in component-library. Risks are minimal because the icon kit is still a normal dependency, so it's installed and works exactly as before — nothing about how the icons load actually changes.