### PR TITLE
feat: expose align on mt-action-menu

### DIFF
--- a/packages/component-library/src/components/mt-action-menu/mt-action-menu.interactive.stories.ts
+++ b/packages/component-library/src/components/mt-action-menu/mt-action-menu.interactive.stories.ts
@@ -666,9 +666,9 @@ export const VisualTestUserProfileTrigger: MtActionMenuStory = {
 <dropdown-menu-root open>
     <dropdown-menu-trigger as-child>
         <button style="display: flex; align-items: center;" class="user-profile-trigger">
-          <mt-avatar 
-            first-name="John" 
-            last-name="Doe" 
+          <mt-avatar
+            first-name="John"
+            last-name="Doe"
             size="s"
           />
 
@@ -682,9 +682,9 @@ export const VisualTestUserProfileTrigger: MtActionMenuStory = {
 
           <div style="padding-left: var(--scale-size-32);" />
 
-          <mt-icon 
-            name="chevron-down-s" 
-            size="12" 
+          <mt-icon
+            name="chevron-down-s"
+            size="12"
             color="var(--color-icon-primary-default)"
           />
         </button>
@@ -753,5 +753,47 @@ export const TestMenuItemClick: MtActionMenuStory = {
 
     const menuItem = document.querySelector('[data-testid="menu-item"]');
     expect(menuItem).toBeInTheDocument();
+  },
+};
+
+// Interaction test: align prop is forwarded to reka's content element
+export const TestAlignForwarded: MtActionMenuStory = {
+  name: "Align prop is forwarded to the menu content",
+  render: () => ({
+    components: {
+      DropdownMenuRoot,
+      DropdownMenuPortal,
+      MtActionMenuItem,
+      MtActionMenu,
+      DropdownMenuTrigger,
+      MtButton,
+    },
+    template: `
+<dropdown-menu-root>
+    <dropdown-menu-trigger as-child>
+        <mt-button data-testid="trigger">Open menu</mt-button>
+    </dropdown-menu-trigger>
+
+    <dropdown-menu-portal>
+        <mt-action-menu align="end">
+          <mt-action-menu-item icon="file-text">
+            Documentation
+          </mt-action-menu-item>
+        </mt-action-menu>
+    </dropdown-menu-portal>
+</dropdown-menu-root>
+`,
+  }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByTestId("trigger");
+
+    await userEvent.click(trigger);
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    const menu = document.querySelector(".mt-action-menu");
+    expect(menu).toBeInTheDocument();
+    expect(menu).toHaveAttribute("data-align", "end");
   },
 };

--- a/packages/component-library/src/components/mt-action-menu/mt-action-menu.mdx
+++ b/packages/component-library/src/components/mt-action-menu/mt-action-menu.mdx
@@ -64,6 +64,10 @@ import StorybookPageHeader from "../../docs/_components/storybook-page-header.js
 
 <Canvas of={ActionMenuStories.MatchTriggerWidth} />
 
+### Alignment
+
+<Canvas of={ActionMenuStories.Alignment} />
+
 ## Anatomy
 
 **Action Menu** is built from a small set of companion exports that work together:
@@ -115,6 +119,7 @@ These parts are exported together so the parent page can document the full patte
 - `mt-action-menu-item` with a `link` prop renders as an external anchor and opens in a new tab.
 - `is-sub-menu` on `mt-action-menu` and `is-sub-trigger` on `mt-action-menu-item` are used together for nested submenu patterns.
 - `match-trigger-width` is useful when the menu should align visually with a wider trigger such as a row action or account switcher.
+- `align` controls how the menu lines up with its trigger (`start`, `center`, or `end`). It has no effect on submenus, which reka positions relative to their parent item.
 - Keep nesting shallow. One submenu level is usually enough, and more than two levels should be avoided.
 
 ## Accessibility notes

--- a/packages/component-library/src/components/mt-action-menu/mt-action-menu.stories.ts
+++ b/packages/component-library/src/components/mt-action-menu/mt-action-menu.stories.ts
@@ -234,6 +234,12 @@ const meta: MtActionMenuMeta = {
       control: { type: "boolean" },
       description: "Matches the menu width to the trigger width.",
     },
+    align: {
+      control: { type: "inline-radio" },
+      options: ["start", "center", "end"],
+      description:
+        "How the menu aligns against the trigger. Ignored for submenus, which are positioned relative to their parent item.",
+    },
   },
 };
 
@@ -276,4 +282,34 @@ export const ExternalLinks: MtActionMenuStory = {
 export const MatchTriggerWidth: MtActionMenuStory = {
   name: "Match trigger width",
   ...createStory(matchTriggerWidthTemplate),
+};
+
+const alignmentTemplate = `
+<div style="display: flex; justify-content: flex-end;">
+  <mt-dropdown-menu-root default-open>
+    <mt-dropdown-menu-trigger as-child>
+      <mt-button>Open menu</mt-button>
+    </mt-dropdown-menu-trigger>
+
+    <mt-dropdown-menu-portal>
+      <mt-action-menu v-bind="args">
+        <mt-action-menu-item icon="file-text">Documentation</mt-action-menu-item>
+        <mt-action-menu-item icon="solid-duplicate">Duplicate</mt-action-menu-item>
+        <mt-action-menu-item icon="copy">Copy</mt-action-menu-item>
+        <mt-action-menu-item icon="trash" variant="critical">Delete</mt-action-menu-item>
+      </mt-action-menu>
+    </mt-dropdown-menu-portal>
+  </mt-dropdown-menu-root>
+</div>
+`;
+
+export const Alignment: MtActionMenuStory = {
+  args: {
+    align: "end",
+  },
+  render: (args) => ({
+    components: sharedComponents,
+    setup: () => ({ args }),
+    template: alignmentTemplate,
+  }),
 };

--- a/packages/component-library/src/components/mt-action-menu/mt-action-menu.vue
+++ b/packages/component-library/src/components/mt-action-menu/mt-action-menu.vue
@@ -4,7 +4,8 @@
     :class="['mt-action-menu', { 'mt-action-menu--match-trigger-width': matchTriggerWidth }]"
     :side-offset="8"
     :align-offset="isSubMenu ? -5 : undefined"
-    align="start"
+    :align="align"
+    :collision-padding="8"
   >
     <slot name="default" />
   </component>
@@ -21,16 +22,21 @@ withDefaults(
      * Also constrains max-height to available viewport space.
      */
     matchTriggerWidth?: boolean;
+    /**
+     * How the menu aligns against the trigger. Ignored for sub-menus, which are
+     * positioned relative to their parent item.
+     */
+    align?: "start" | "center" | "end";
   }>(),
   {
     isSubMenu: false,
     matchTriggerWidth: false,
+    align: "start",
   },
 );
 </script>
 
 <style>
-/* Find out why we can't scope styles */
 .mt-action-menu {
   background-color: var(--color-elevation-surface-default);
   border: 1px solid var(--color-border-secondary-default);
@@ -45,7 +51,7 @@ withDefaults(
   max-height: var(--reka-dropdown-menu-content-available-height);
 }
 
-/* 
+/*
   When items outside a group have mixed icons (some with, some without),
   add left padding to items without icons to align text.
   Only applies when there's at least one item WITH icon AND one WITHOUT.


### PR DESCRIPTION
## What?

Expose `align` prop on `mt-action-menu`, forwarded to reka menu content.

## Why?

Consumers couldn't influence the menu's positioning. When a trigger sits close to the viewport edge, the menu touched the screen border with no way to push it off. Originates from https://github.com/shopware/shopware/pull/17810

## How?

- Added `align` prop, bound directly onto the reka content element.

## Testing?

- Storybook → Components → Action Menu → "Alignment & collision padding"
- Interaction test `TestAlignForwarded` verifies `align="end"` renders `data-align="end"` on the menu content.
- Existing visual snapshots cover the unchanged `side-offset` spacing.

## Screenshots 

Viewport edge behavior:

#### align="start" (default)

<img width="232" height="207" alt="before" src="https://github.com/user-attachments/assets/4c9fb869-a160-4dc7-9432-4e82ef369b9a" />

#### align="end"

<img width="232" height="207" alt="after" src="https://github.com/user-attachments/assets/b95c3f9f-1391-4bbf-b733-fa2693092094" />