### PR TITLE
fix: use min-height so the component library fills an embedded admin iframe

### DIFF
--- a/.changeset/embedded-admin-iframe-styling.md
+++ b/.changeset/embedded-admin-iframe-styling.md
@@ -1,0 +1,7 @@
+---
+"@shopware-ag/meteor-component-library": patch
+---
+
+Fixed the component library collapsing to a 150px iframe when embedded in the Shopware Administration: `html`/`body` now use `min-height: 100dvh` instead of a fixed `height`.
+
+Reverted the `body` background to its original hardcoded value. The background is now deprecated and will change in an upcoming major version (likely detecting the embedded context automatically so it can go transparent inside the Administration).

--- a/packages/component-library/src/assets/css/global.css
+++ b/packages/component-library/src/assets/css/global.css
@@ -13,7 +13,8 @@ body {
   -moz-osx-font-smoothing: grayscale;
   font-size: var(--font-size-xs);
   line-height: 1.5;
-  background: var(--color-elevation-surface-default);
+  /* @deprecated hardcoded background — to be revisited in the next major */
+  background: #f9fafb;
   color: var(--color-text-primary-default);
 }
 
@@ -21,9 +22,11 @@ body {
   color-scheme: dark;
 }
 
+/* min-height, not fixed height: in the admin's auto-sized iframe a fixed
+   100dvh collapses to the 150px fallback that the admin-sdk reports back. */
 html,
 body {
-  height: 100dvh;
+  min-height: 100dvh;
 }
 
 /** @TODO move to tokens file once we find a solution for non figma-sync tokens **/


### PR DESCRIPTION
## What?

- `html`/`body` use `min-height: 100dvh` instead of a fixed `height`.
- Reverted the `body` background to its original hardcoded value and marked it `@deprecated`.

## Why?

Inside the Administration's auto-sized iframe a fixed `100dvh` collapses to the browser's 150px fallback, so the admin-sdk reports 150px back to the host and the frame stays too short.

## How?

`min-height` lets the document grow to its real content height (reported correctly) while still filling the viewport standalone. The background revert keeps current visuals; a future major version will revisit it (likely auto-detecting the embedded context to go transparent).

## Testing?

Reproduced the SDK-report → iframe-resize loop in a headless browser: the old `height:100dvh` deadlocks at 150px, `min-height:100dvh` converges to the real content height.
