### PR TITLE
draft: replace ApexCharts with Chart.js

### DIFF
--- a/.changeset/mt-chart-chartjs.md
+++ b/.changeset/mt-chart-chartjs.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": minor
+---
+
+Replaced ApexCharts with Chart.js as the `mt-chart` rendering engine (license change). The props keep their ApexCharts-style shape and visual output was matched against the previous rendering, so no changes are required in consuming code. Supported types: line, area, bar, pie, donut, radar, polarArea, scatter, bubble.

--- a/packages/component-library/.storybook/ThemeProvider.ts
+++ b/packages/component-library/.storybook/ThemeProvider.ts
@@ -1,15 +1,18 @@
-import { useGlobals, useEffect } from "@storybook/preview-api";
+import { addons } from "@storybook/preview-api";
+import { GLOBALS_UPDATED, SET_GLOBALS } from "storybook/internal/core-events";
 
-export function ThemeProvider(Story) {
-  const [globals] = useGlobals();
-  const theme: "light" | "dark" = globals.theme ?? "light";
-
-  useEffect(() => {
-    const body = document.querySelector("body");
-    if (!body) throw new Error("Failed to render story: Root element not found");
-    body.setAttribute("data-theme", theme);
-    body.style.backgroundColor = "var(--color-elevation-surface-default)";
-  }, [theme]);
-
-  return Story();
+function applyTheme(theme: string) {
+  const body = document.querySelector("body");
+  if (!body) return;
+  body.setAttribute("data-theme", theme);
+  body.style.backgroundColor = "var(--color-elevation-surface-default)";
 }
+
+/*
+ * Channel-based on purpose: a decorator with useGlobals re-renders every
+ * story on globals changes, which docs pages do not support (they miss the
+ * update entirely). The events cover boot and later switches in every view mode.
+ */
+const channel = addons.getChannel();
+channel.on(SET_GLOBALS, ({ globals }) => applyTheme((globals.theme as string) ?? "light"));
+channel.on(GLOBALS_UPDATED, ({ globals }) => applyTheme((globals.theme as string) ?? "light"));

--- a/packages/component-library/.storybook/docs-theme.css
+++ b/packages/component-library/.storybook/docs-theme.css
@@ -1,0 +1,13 @@
+/* Docs pages: only the story preview cards follow data-theme; the
+   surrounding docs UI keeps Storybook's default look. */
+
+[data-theme="dark"] .sbdocs-preview {
+  background: var(--color-elevation-surface-default);
+  border-color: var(--color-border-primary-default);
+}
+
+[data-theme="dark"] .sbdocs-preview :is(.sb-bar, [class^="css-"]) {
+  background-color: transparent;
+  border-color: var(--color-border-primary-default);
+  box-shadow: none;
+}

--- a/packages/component-library/.storybook/preview.ts
+++ b/packages/component-library/.storybook/preview.ts
@@ -1,12 +1,13 @@
 import type { Preview } from "@storybook/vue3";
 import "~/src/assets/scss/all.scss";
 import "~/src/assets/css/fonts/inter.font.css";
+import "./docs-theme.css";
 import { setup } from "@storybook/vue3";
 import { createI18n } from "vue-i18n";
 import DeviceHelperPlugin from "../src/plugin/device-helper.plugin";
 import MtThemeProvider from "../src/components/mt-theme-provider/mt-theme-provider.vue";
 
-import { ThemeProvider } from "./ThemeProvider";
+import "./ThemeProvider";
 
 // importing meteor tokens
 import "@shopware-ag/meteor-tokens/primitives.css";
@@ -68,7 +69,6 @@ const preview: Preview = {
   },
 
   decorators: [
-    ThemeProvider,
     () => ({
       components: { MtThemeProvider },
       template: `

--- a/packages/component-library/package.json
+++ b/packages/component-library/package.json
@@ -91,7 +91,7 @@
     "@vuepic/vue-datepicker": "^12.1.0",
     "@vueuse/components": "^12.4.0",
     "@vueuse/core": "^13.1.0",
-    "apexcharts": "^5.2.0",
+    "chart.js": "^4.5.1",
     "codemirror": "^6.0.1",
     "convert-units": "^2.3.4",
     "date-fns": "4.1.0",

--- a/packages/component-library/src/components/mt-chart/mt-chart-adapter.spec.ts
+++ b/packages/component-library/src/components/mt-chart/mt-chart-adapter.spec.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from "vitest";
+import { toChartConfig } from "./mt-chart-adapter";
+import { getDefaultOptions } from "./mt-chart-default-options";
+import { deepMergeObjects } from "@/utils/object";
+import type { ChartOptions } from "./mt-chart-types";
+
+const series = [{ name: "Sample", data: [30, 55, 65] }];
+
+function areaConfig(options: ChartOptions = {}) {
+  const merged = deepMergeObjects<ChartOptions>(getDefaultOptions("area"), options);
+  return toChartConfig("area", series, merged);
+}
+
+describe("mt-chart adapter", () => {
+  it("maps an area chart to a filled line", () => {
+    const config = areaConfig();
+    expect(config.type).toBe("line");
+    const dataset = config.data.datasets[0] as { fill?: boolean; borderColor?: string };
+    expect(dataset.fill).toBe(true);
+    expect(dataset.borderColor).toBe("#0870ff");
+  });
+
+  it("uses xaxis.categories as labels", () => {
+    const config = areaConfig({ xaxis: { categories: ["Jan", "Feb", "Mar"] } });
+    expect(config.data.labels).toEqual(["Jan", "Feb", "Mar"]);
+  });
+
+  it("falls back to index labels without categories", () => {
+    const config = areaConfig();
+    expect(config.data.labels).toEqual(["1", "2", "3"]);
+  });
+
+  it("draws a smooth curve with the Apex algorithm and a straight curve with none", () => {
+    const smooth = areaConfig({ stroke: { curve: "smooth" } }).data.datasets[0] as {
+      mtApexSmooth?: boolean;
+      tension: number;
+    };
+    // the plugin draws the curve; tension only routes Chart.js to the bezier path
+    expect(smooth.mtApexSmooth).toBe(true);
+    expect(smooth.tension).toBeGreaterThan(0);
+    expect((areaConfig({ stroke: { curve: "straight" } }).data.datasets[0] as { tension: number }).tension).toBe(0);
+  });
+
+  it("computes an Apex-style nice y scale from the data", () => {
+    const config = toChartConfig("area", [{ name: "A", data: [30, 55, 65, 60, 45, 40, 55, 80] }], {});
+    const y = (config.options?.scales as any).y;
+    expect(y.min).toBe(30);
+    expect(y.max).toBe(80);
+    expect(y.ticks.stepSize).toBe(10);
+  });
+
+  it("includes zero in the bar chart y scale", () => {
+    const config = toChartConfig("bar", [{ name: "A", data: [21, 43, 67] }], {});
+    expect((config.options?.scales as any).y.min).toBe(0);
+  });
+
+  it("translates stepline and monotoneCubic curves", () => {
+    expect((areaConfig({ stroke: { curve: "stepline" } }).data.datasets[0] as { stepped: string }).stepped).toBe(
+      "after",
+    );
+    expect(
+      (areaConfig({ stroke: { curve: "monotoneCubic" } }).data.datasets[0] as { cubicInterpolationMode: string })
+        .cubicInterpolationMode,
+    ).toBe("monotone");
+  });
+
+  it("honors a custom color and stroke width", () => {
+    const dataset = areaConfig({ colors: ["#ff7008"], stroke: { width: 4 } })
+      .data.datasets[0] as { borderColor: string; borderWidth: number };
+    expect(dataset.borderColor).toBe("#ff7008");
+    expect(dataset.borderWidth).toBe(4);
+  });
+
+  it("uses a gradient background function when fill is a gradient", () => {
+    const dataset = areaConfig().data.datasets[0] as { backgroundColor: unknown };
+    expect(typeof dataset.backgroundColor).toBe("function");
+  });
+
+  it("disables animation when chart.animations.enabled is false", () => {
+    expect(areaConfig().options?.animation).toBe(false);
+  });
+
+  it("hides the legend for a single series and shows it for multiple", () => {
+    expect(areaConfig().options?.plugins?.legend?.display).toBe(false);
+    const multi = toChartConfig("area", [series[0], { name: "B", data: [1, 2, 3] }], {});
+    expect(multi.options?.plugins?.legend?.display).toBe(true);
+  });
+
+  it("maps type=bar to a bar chart", () => {
+    expect(toChartConfig("bar", series, {}).type).toBe("bar");
+  });
+
+  it("maps donut to doughnut and takes the Apex numeric series shape", () => {
+    const config = toChartConfig("donut", [44, 55, 13], {
+      labels: ["A", "B", "C"],
+      colors: ["#111111", "#222222", "#333333"],
+    });
+
+    expect(config.type).toBe("doughnut");
+    expect(config.data.labels).toEqual(["A", "B", "C"]);
+    expect(config.data.datasets[0].data).toEqual([44, 55, 13]);
+    expect(config.data.datasets[0].backgroundColor).toEqual(["#111111", "#222222", "#333333"]);
+    // circular charts have no x/y scales and show the legend by default
+    expect(config.options?.scales).toBeUndefined();
+    expect(config.options?.plugins?.legend?.display).toBe(true);
+  });
+
+  it("maps radar, polarArea, scatter and bubble to native Chart.js types", () => {
+    expect(toChartConfig("radar", series, {}).type).toBe("radar");
+    expect(toChartConfig("polarArea", [1, 2, 3], {}).type).toBe("polarArea");
+    expect(toChartConfig("scatter", series, {}).type).toBe("scatter");
+    expect(toChartConfig("bubble", series, {}).type).toBe("bubble");
+  });
+
+  it("translates scatter/bubble data pairs to point objects", () => {
+    const config = toChartConfig("bubble", [{ name: "A", data: [[1, 2, 3]] as any }], {});
+    expect(config.data.datasets[0].data).toEqual([{ x: 1, y: 2, r: 3 }]);
+  });
+
+  it("honors a series-level color", () => {
+    const config = toChartConfig("area", [{ name: "A", data: [1], color: "#ff0000" }], {});
+    expect((config.data.datasets[0] as { borderColor: string }).borderColor).toBe("#ff0000");
+  });
+
+  it("applies stacking and yaxis min/max to the scales", () => {
+    const config = areaConfig({ chart: { stacked: true }, yaxis: { min: 0, max: 100 } });
+    const scales = config.options?.scales as {
+      x?: { stacked?: boolean };
+      y?: { stacked?: boolean; min?: number; max?: number };
+    };
+    expect(scales.x?.stacked).toBe(true);
+    expect(scales.y?.stacked).toBe(true);
+    expect(scales.y?.min).toBe(0);
+    expect(scales.y?.max).toBe(100);
+  });
+
+  it("resolves css-variable colors through the resolver", () => {
+    const config = toChartConfig(
+      "area",
+      series,
+      { grid: { borderColor: "var(--color-border-primary-default)" } },
+      (value) => (value?.includes("var(") ? "#abcdef" : value),
+    );
+    const scales = config.options?.scales as any;
+    expect(scales.y.grid.color).toBe("#abcdef");
+  });
+});

--- a/packages/component-library/src/components/mt-chart/mt-chart-adapter.ts
+++ b/packages/component-library/src/components/mt-chart/mt-chart-adapter.ts
@@ -1,0 +1,299 @@
+import type {
+  ChartConfiguration,
+  ChartDataset,
+  ChartType,
+  Plugin,
+  ScriptableContext,
+} from "chart.js";
+import type { ChartFillGradient, ChartOptions, ChartSeries } from "./mt-chart-types";
+
+/** resolves `var(--token)` strings to concrete colors (canvas cannot read CSS vars) */
+export type ColorResolver = (value?: string) => string | undefined;
+
+const DEFAULT_COLOR = "#0870ff";
+
+// Apex type names -> Chart.js; unknown types fall back to a filled line (area)
+const TYPE_MAP: Record<string, ChartType> = {
+  line: "line",
+  bar: "bar",
+  pie: "pie",
+  donut: "doughnut",
+  radar: "radar",
+  polarArea: "polarArea",
+  scatter: "scatter",
+  bubble: "bubble",
+};
+
+const CIRCULAR_TYPES = new Set<ChartType>(["pie", "doughnut", "polarArea"]);
+
+function toChartType(type: string): { chartType: ChartType; area: boolean } {
+  const chartType = TYPE_MAP[type];
+  if (chartType) return { chartType, area: false };
+  return { chartType: "line", area: true };
+}
+
+function withAlpha(color: string, alpha: number): string {
+  const hex = color.replace("#", "");
+  const full = hex.length === 3 ? hex.replace(/./g, "$&$&") : hex;
+  if (!/^[0-9a-fA-F]{6}$/.test(full)) return color;
+  const r = parseInt(full.slice(0, 2), 16);
+  const g = parseInt(full.slice(2, 4), 16);
+  const b = parseInt(full.slice(4, 6), 16);
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
+
+/** mixes a hex color toward white; used for Apex's gradient shading */
+function lighten(color: string, amount: number): string {
+  const hex = color.replace("#", "");
+  const full = hex.length === 3 ? hex.replace(/./g, "$&$&") : hex;
+  if (!/^[0-9a-fA-F]{6}$/.test(full)) return color;
+  const channel = (offset: number) => {
+    const value = parseInt(full.slice(offset, offset + 2), 16);
+    return Math.round(value + (255 - value) * amount)
+      .toString(16)
+      .padStart(2, "0");
+  };
+  return `#${channel(0)}${channel(2)}${channel(4)}`;
+}
+
+function gradientFill(color: string, gradient: ChartFillGradient | undefined) {
+  // measured from Apex's rendered output: it lightens the end color by 50%
+  // and applies ~0.7 path fill-opacity on top of opacityFrom
+  const from = (gradient?.opacityFrom ?? 0.7) * 0.7;
+  const to = gradient?.opacityTo ?? 0;
+
+  return (ctx: ScriptableContext<"line">) => {
+    const { chartArea, ctx: canvasCtx } = ctx.chart;
+    if (!chartArea) return withAlpha(color, from);
+
+    const linear = canvasCtx.createLinearGradient(0, chartArea.top, 0, chartArea.bottom);
+    linear.addColorStop(0, withAlpha(color, from));
+    linear.addColorStop(1, withAlpha(lighten(color, 0.5), to));
+    return linear;
+  };
+}
+
+type SmoothablePoint = {
+  x: number;
+  y: number;
+  cp1x?: number;
+  cp1y?: number;
+  cp2x?: number;
+  cp2y?: number;
+};
+
+function applyApexSmooth(meta: { data: unknown; dataset?: unknown }): void {
+  if (!meta.dataset) return;
+  const points = meta.data as SmoothablePoint[];
+
+  for (let i = 0; i < points.length; i++) {
+    const point = points[i];
+    const prev = points[i - 1];
+    const next = points[i + 1];
+    point.cp1x = prev ? point.x - (point.x - prev.x) * 0.35 : point.x;
+    point.cp1y = point.y;
+    point.cp2x = next ? point.x + (next.x - point.x) * 0.35 : point.x;
+    point.cp2y = point.y;
+  }
+
+  // keep Chart.js from recomputing its own control points afterwards
+  (meta.dataset as { _pointsUpdated: boolean })._pointsUpdated = true;
+}
+
+const isSmoothDataset = (dataset: unknown): boolean =>
+  (dataset as { mtApexSmooth?: boolean })?.mtApexSmooth === true;
+
+/**
+ * Apex's "smooth" curve: horizontal tangents with handles at 0.35 * dx
+ * (reverse-engineered from its SVG). Chart.js has no such mode, so the
+ * plugin overwrites the computed control points of flagged datasets.
+ * afterUpdate covers the fill path, beforeDatasetDraw the animated stroke.
+ */
+export const apexSmoothPlugin: Plugin = {
+  id: "mtApexSmooth",
+  afterUpdate(chart) {
+    for (const meta of chart.getSortedVisibleDatasetMetas()) {
+      if (isSmoothDataset(chart.data.datasets[meta.index])) applyApexSmooth(meta);
+    }
+  },
+  beforeDatasetDraw(chart, args) {
+    if (isSmoothDataset(chart.data.datasets[args.index])) applyApexSmooth(args.meta);
+  },
+};
+
+/** Apex-style nice scale: five 1/2/5/10-magnitude steps with rounded bounds. */
+function niceScale(min: number, max: number): { min: number; max: number; step: number } {
+  if (min === max) {
+    min -= 1;
+    max += 1;
+  }
+  const raw = (max - min) / 5;
+  const magnitude = Math.pow(10, Math.floor(Math.log10(raw)));
+  const normalized = raw / magnitude;
+  const step = (normalized <= 1 ? 1 : normalized <= 2 ? 2 : normalized <= 5 ? 5 : 10) * magnitude;
+  return { min: Math.floor(min / step) * step, max: Math.ceil(max / step) * step, step };
+}
+
+/** Apex scatter/bubble data pairs ([x, y] / [x, y, z]) -> Chart.js point objects */
+function toPoints(data: unknown[]): unknown[] {
+  return data.map((point) =>
+    Array.isArray(point)
+      ? { x: point[0], y: point[1], ...(point.length > 2 ? { r: point[2] } : {}) }
+      : point,
+  );
+}
+
+export function toChartConfig(
+  type: string,
+  series: ChartSeries[] | number[],
+  options: ChartOptions,
+  resolve: ColorResolver = (value) => value,
+): ChartConfiguration {
+  const { chartType, area } = toChartType(type);
+  const circular = CIRCULAR_TYPES.has(chartType);
+
+  const colors = options.colors?.length ? options.colors : [DEFAULT_COLOR];
+  const borderWidth = options.stroke?.width ?? 2;
+  const gridColor = resolve(options.grid?.borderColor);
+  const tickColor = resolve("var(--color-text-secondary-default)");
+
+  // "smooth" is drawn by apexSmoothPlugin; the nonzero tension only routes
+  // Chart.js to the bezier path so the plugin's control points apply
+  const curve = options.stroke?.curve;
+  const lineStyle =
+    curve === "smooth"
+      ? { tension: 0.35, mtApexSmooth: true }
+      : curve === "monotoneCubic"
+        ? { cubicInterpolationMode: "monotone" as const }
+        : curve === "stepline"
+          ? { stepped: "after" as const }
+          : { tension: 0 };
+
+  let labels: (string | number)[];
+  let datasets: ChartDataset[];
+
+  if (circular) {
+    // Apex circular series are plain numbers, colored per slice
+    const values = (series as unknown[]).map((entry) =>
+      typeof entry === "number" ? entry : ((entry as ChartSeries).data?.[0] ?? 0),
+    );
+    labels = options.labels ?? values.map((_, index) => String(index + 1));
+    datasets = [
+      {
+        data: values,
+        backgroundColor: values.map((_, index) => colors[index % colors.length] ?? DEFAULT_COLOR),
+        borderWidth: 0,
+      } as ChartDataset,
+    ];
+  } else {
+    const namedSeries = series as ChartSeries[];
+
+    datasets = namedSeries.map((entry, index): ChartDataset => {
+      const color =
+        (typeof entry.color === "string" ? entry.color : undefined) ??
+        colors[index % colors.length] ??
+        DEFAULT_COLOR;
+      const data =
+        chartType === "scatter" || chartType === "bubble" ? toPoints(entry.data) : entry.data;
+      const base = {
+        label: entry.name,
+        data,
+        borderColor: color,
+        borderWidth,
+        ...lineStyle,
+        pointRadius: 0,
+        pointHoverRadius: 4,
+        pointBackgroundColor: color,
+      };
+
+      if (area) {
+        return {
+          ...base,
+          fill: true,
+          backgroundColor:
+            options.fill?.type === "gradient" || options.fill?.gradient
+              ? gradientFill(color, options.fill?.gradient)
+              : withAlpha(color, 0.3),
+        } as ChartDataset;
+      }
+
+      return { ...base, fill: false, backgroundColor: color } as ChartDataset;
+    });
+
+    labels =
+      options.xaxis?.categories ??
+      namedSeries[0]?.data.map((_, index) => String(index + 1)) ??
+      [];
+  }
+
+  const showScales = !circular && chartType !== "radar";
+  const stacked = options.chart?.stacked === true;
+  const yAxis = Array.isArray(options.yaxis) ? options.yaxis[0] : options.yaxis;
+
+  // Apex-style y scale from the data; user yaxis min/max win, stacked charts
+  // fall back to auto scaling (their range depends on per-point sums)
+  let yMin = yAxis?.min as number | undefined;
+  let yMax = yAxis?.max as number | undefined;
+  let yStep: number | undefined;
+  const numericValues =
+    showScales && !stacked && chartType !== "scatter" && chartType !== "bubble"
+      ? (series as ChartSeries[])
+          .flatMap((entry) => entry.data ?? [])
+          .filter((value): value is number => typeof value === "number")
+      : [];
+  if (numericValues.length) {
+    const dataMin =
+      chartType === "bar" ? Math.min(0, ...numericValues) : Math.min(...numericValues);
+    const nice = niceScale(dataMin, Math.max(...numericValues));
+    yMin ??= nice.min;
+    yMax ??= nice.max;
+    yStep = nice.step;
+  }
+
+  return {
+    type: chartType,
+    data: { labels, datasets },
+    plugins: [apexSmoothPlugin],
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      // plot-area geometry measured from Apex (30px top, 37.7px bottom)
+      layout: showScales ? { padding: { top: 30, bottom: 3 } } : undefined,
+      animation: options.chart?.animations?.enabled === false ? false : undefined,
+      interaction: { mode: "index", intersect: false },
+      plugins: {
+        legend: { display: options.legend?.show ?? (circular || series.length > 1) },
+      },
+      // axis fonts, tick stubs and label gaps measured from Apex
+      scales: showScales
+        ? {
+            x: {
+              stacked,
+              grid: {
+                display: true,
+                drawOnChartArea: false,
+                drawTicks: true,
+                tickLength: 6,
+                tickColor: gridColor,
+              },
+              border: { color: gridColor },
+              ticks: { color: tickColor, padding: 7, font: { size: 12 } },
+            },
+            y: {
+              stacked,
+              min: yMin,
+              max: yMax,
+              grid: { color: gridColor, drawTicks: false },
+              border: { display: false },
+              ticks: {
+                color: tickColor,
+                padding: 13,
+                font: { size: 11 },
+                ...(yStep ? { stepSize: yStep } : { maxTicksLimit: 7 }),
+              },
+            },
+          }
+        : undefined,
+    },
+  };
+}

--- a/packages/component-library/src/components/mt-chart/mt-chart-default-options.ts
+++ b/packages/component-library/src/components/mt-chart/mt-chart-default-options.ts
@@ -1,12 +1,12 @@
-import type { ApexOptions } from "apexcharts";
+import type { ChartOptions } from "./mt-chart-types";
 
-export function getDefaultOptions(type: string): ApexOptions {
+export function getDefaultOptions(type: string): ChartOptions {
   const options = createOptions();
 
   return options[type] ?? {};
 }
 
-function createOptions(): Record<string, ApexOptions> {
+function createOptions(): Record<string, ChartOptions> {
   return {
     area: {
       noData: {

--- a/packages/component-library/src/components/mt-chart/mt-chart-tooltip.spec.ts
+++ b/packages/component-library/src/components/mt-chart/mt-chart-tooltip.spec.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { ref } from "vue";
+import { createTooltipHandler, hiddenTooltip } from "./mt-chart-tooltip";
+
+const chart = { canvas: { offsetLeft: 10, offsetTop: 20 } } as any;
+
+describe("mt-chart tooltip", () => {
+  it("maps the tooltip model to visible state", () => {
+    const state = ref(hiddenTooltip());
+    const handler = createTooltipHandler(state);
+
+    handler({
+      chart,
+      tooltip: {
+        opacity: 1,
+        caretX: 100,
+        caretY: 50,
+        title: ["Jan"],
+        dataPoints: [{ dataset: { borderColor: "#0870ff" }, formattedValue: "42" }],
+      } as any,
+    });
+
+    expect(state.value).toEqual({
+      visible: true,
+      x: 110,
+      y: 70,
+      title: "Jan",
+      rows: [{ color: "#0870ff", value: "42" }],
+    });
+  });
+
+  it("hides on zero opacity and keeps the last position", () => {
+    const state = ref({ ...hiddenTooltip(), visible: true, x: 5, y: 6 });
+    const handler = createTooltipHandler(state);
+
+    handler({ chart, tooltip: { opacity: 0 } as any });
+
+    expect(state.value.visible).toBe(false);
+    expect(state.value.x).toBe(5);
+  });
+});

--- a/packages/component-library/src/components/mt-chart/mt-chart-tooltip.ts
+++ b/packages/component-library/src/components/mt-chart/mt-chart-tooltip.ts
@@ -1,0 +1,42 @@
+import type { Chart, TooltipModel } from "chart.js";
+import type { Ref } from "vue";
+
+export interface ChartTooltipState {
+  visible: boolean;
+  x: number;
+  y: number;
+  title: string;
+  rows: { color: string; value: string }[];
+}
+
+export const hiddenTooltip = (): ChartTooltipState => ({
+  visible: false,
+  x: 0,
+  y: 0,
+  title: "",
+  rows: [],
+});
+
+/**
+ * Chart.js external tooltip handler that maps the tooltip model onto plain
+ * state; mt-chart renders it as a normal Vue element with scoped styles.
+ */
+export function createTooltipHandler(state: Ref<ChartTooltipState>) {
+  return ({ chart, tooltip }: { chart: Chart; tooltip: TooltipModel<"line"> }): void => {
+    if (tooltip.opacity === 0) {
+      state.value = { ...state.value, visible: false };
+      return;
+    }
+
+    state.value = {
+      visible: true,
+      x: chart.canvas.offsetLeft + tooltip.caretX,
+      y: chart.canvas.offsetTop + tooltip.caretY,
+      title: tooltip.title?.[0] ?? "",
+      rows: tooltip.dataPoints.map((point) => ({
+        color: String(point.dataset.borderColor ?? ""),
+        value: point.formattedValue,
+      })),
+    };
+  };
+}

--- a/packages/component-library/src/components/mt-chart/mt-chart-types.ts
+++ b/packages/component-library/src/components/mt-chart/mt-chart-types.ts
@@ -1,0 +1,51 @@
+// ApexCharts-shaped options kept for API compatibility; the adapter maps the
+// supported subset to Chart.js. Permissive so existing consumers keep compiling.
+
+export interface ChartFillGradient {
+  type?: string;
+  opacityFrom?: number;
+  opacityTo?: number;
+  stops?: number[];
+  [key: string]: unknown;
+}
+
+export interface ChartOptions {
+  chart?: {
+    type?: string;
+    width?: string | number;
+    height?: string | number;
+    stacked?: boolean;
+    toolbar?: { show?: boolean };
+    zoom?: { enabled?: boolean };
+    animations?: { enabled?: boolean };
+    [key: string]: unknown;
+  };
+  colors?: string[];
+  /** slice labels for circular charts (pie, donut, polarArea) */
+  labels?: (string | number)[];
+  stroke?: {
+    curve?: "smooth" | "straight" | "stepline" | string;
+    width?: number;
+    [key: string]: unknown;
+  };
+  fill?: {
+    type?: string;
+    gradient?: ChartFillGradient;
+    [key: string]: unknown;
+  };
+  xaxis?: { categories?: (string | number)[]; [key: string]: unknown };
+  yaxis?: Record<string, unknown> | Record<string, unknown>[];
+  grid?: { show?: boolean; borderColor?: string; [key: string]: unknown };
+  dataLabels?: { enabled?: boolean; [key: string]: unknown };
+  legend?: { show?: boolean; [key: string]: unknown };
+  tooltip?: { enabled?: boolean; [key: string]: unknown };
+  markers?: Record<string, unknown>;
+  noData?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+export interface ChartSeries {
+  name?: string;
+  data: number[];
+  [key: string]: unknown;
+}

--- a/packages/component-library/src/components/mt-chart/mt-chart.interactive.stories.ts
+++ b/packages/component-library/src/components/mt-chart/mt-chart.interactive.stories.ts
@@ -25,7 +25,7 @@ export const VisualTestRenderChart: MtChartStory = {
     const canvas = within(canvasElement);
 
     // wait until chart is loaded and rendered
-    await waitUntil(() => document.querySelector(".apexcharts-canvas"));
+    await waitUntil(() => document.querySelector("[data-testid=\"mt-chart\"] canvas"));
 
     expect(canvas.findByTestId("mt-chart")).toBeDefined();
   },
@@ -48,7 +48,7 @@ export const VisualTestRenderChartWithCorrectSize: MtChartStory = {
     const canvas = within(canvasElement);
 
     // wait until chart is loaded and rendered
-    await waitUntil(() => document.querySelector(".apexcharts-canvas"));
+    await waitUntil(() => document.querySelector("[data-testid=\"mt-chart\"] canvas"));
 
     expect(canvas.findByTestId("mt-chart")).toBeDefined();
   },
@@ -75,7 +75,7 @@ export const VisualTestRenderChartWithSeries: MtChartStory = {
     const canvas = within(canvasElement);
 
     // wait until chart is loaded and rendered
-    await waitUntil(() => document.querySelector(".apexcharts-canvas"));
+    await waitUntil(() => document.querySelector("[data-testid=\"mt-chart\"] canvas"));
 
     expect(canvas.findByTestId("mt-chart")).toBeDefined();
   },
@@ -100,7 +100,7 @@ export const VisualTestRenderChartWithMergedOptions: MtChartStory = {
     const canvas = within(canvasElement);
 
     // wait until chart is loaded and rendered
-    await waitUntil(() => document.querySelector(".apexcharts-canvas"));
+    await waitUntil(() => document.querySelector("[data-testid=\"mt-chart\"] canvas"));
 
     expect(canvas.findByTestId("mt-chart")).toBeDefined();
   },

--- a/packages/component-library/src/components/mt-chart/mt-chart.spec.ts
+++ b/packages/component-library/src/components/mt-chart/mt-chart.spec.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, cleanup } from "@testing-library/vue";
+import flushPromises from "flush-promises";
+import MtChart from "./mt-chart.vue";
+
+// Chart.js needs a real canvas context (absent in jsdom), so mock it and
+// capture what the component feeds it. Hoisted because mt-chart imports
+// chart.js statically.
+const { instances, MockChart } = vi.hoisted(() => {
+  const instances: any[] = [];
+
+  class MockChart {
+    static register = vi.fn();
+    config: any;
+    data: any;
+    options: any;
+    update = vi.fn();
+    destroy = vi.fn();
+
+    constructor(_canvas: HTMLCanvasElement, config: any) {
+      this.config = config;
+      this.data = config.data;
+      this.options = config.options;
+      instances.push(this);
+    }
+  }
+
+  return { instances, MockChart };
+});
+
+vi.mock("chart.js", () => ({ Chart: MockChart, registerables: [] }));
+
+async function renderChart(props: Record<string, unknown>) {
+  const utils = render(MtChart, {
+    props: { series: [{ name: "A", data: [1, 2, 3] }], ...props },
+  });
+  await flushPromises();
+  const root = utils.container.querySelector('[data-testid="mt-chart"]') as HTMLElement;
+  return { ...utils, root };
+}
+
+describe("mt-chart", () => {
+  beforeEach(() => {
+    instances.length = 0;
+  });
+
+  afterEach(() => {
+    // unmount to disconnect the theme MutationObserver between tests
+    cleanup();
+    document.documentElement.removeAttribute("data-theme");
+  });
+
+  it("renders the container and canvas and instantiates a chart", async () => {
+    const { root, container } = await renderChart({ type: "area" });
+
+    expect(root.classList).toContain("mt-chart-area");
+    expect(container.querySelector("canvas")).not.toBeNull();
+    expect(instances).toHaveLength(1);
+  });
+
+  it("renders an area type as a filled line chart", async () => {
+    await renderChart({ type: "area" });
+
+    expect(instances[0].config.type).toBe("line");
+    expect(instances[0].config.data.datasets[0].fill).toBe(true);
+  });
+
+  it("maps the type prop to the Chart.js type and the css class", async () => {
+    const { root } = await renderChart({ type: "bar" });
+
+    expect(instances[0].config.type).toBe("bar");
+    expect(root.classList).toContain("mt-chart-bar");
+  });
+
+  it("applies width and height", async () => {
+    const { root } = await renderChart({ width: "300px", height: 200 });
+
+    expect(root.getAttribute("style")).toContain("width: 300px");
+    expect(root.getAttribute("style")).toContain("height: 200px");
+  });
+
+  it("updates the chart data when the series changes", async () => {
+    const { rerender } = await renderChart({ type: "area" });
+    const chart = instances[0];
+
+    await rerender({ type: "area", series: [{ name: "A", data: [9, 8, 7] }] });
+    await flushPromises();
+
+    expect(chart.update).toHaveBeenCalled();
+    expect(chart.data.datasets[0].data).toEqual([9, 8, 7]);
+  });
+
+  it("re-initializes when options change", async () => {
+    const { rerender } = await renderChart({ type: "area" });
+
+    await rerender({
+      type: "area",
+      series: [{ name: "A", data: [1, 2, 3] }],
+      options: { colors: ["#ff7008"] },
+    });
+    await flushPromises();
+
+    expect(instances).toHaveLength(2);
+    expect(instances[1].config.data.datasets[0].borderColor).toBe("#ff7008");
+  });
+
+  it("re-initializes when the theme changes", async () => {
+    await renderChart({ type: "area" });
+
+    document.documentElement.setAttribute("data-theme", "dark");
+    await flushPromises();
+    await flushPromises();
+
+    expect(instances.length).toBeGreaterThan(1);
+  });
+
+  it("disables the tooltip when options.tooltip.enabled is false", async () => {
+    await renderChart({ type: "area", options: { tooltip: { enabled: false } } });
+
+    const tooltip = instances[0].config.options.plugins.tooltip;
+    expect(tooltip.enabled).toBe(false);
+    expect(tooltip.external).toBeUndefined();
+  });
+
+  it("destroys the chart on unmount", async () => {
+    const { unmount } = await renderChart({ type: "area" });
+    const chart = instances[0];
+
+    unmount();
+
+    expect(chart.destroy).toHaveBeenCalled();
+  });
+});

--- a/packages/component-library/src/components/mt-chart/mt-chart.stories.ts
+++ b/packages/component-library/src/components/mt-chart/mt-chart.stories.ts
@@ -76,3 +76,51 @@ export const Default: MtChartStory = {
     },
   },
 };
+
+const months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug"];
+
+export const Line: MtChartStory = {
+  args: {
+    type: "line",
+    options: {
+      stroke: { curve: "smooth" },
+      xaxis: { categories: months },
+    },
+  },
+};
+
+export const Bar: MtChartStory = {
+  args: {
+    type: "bar",
+    series: [{ name: "Revenue", data: [44, 55, 41, 67, 22, 43, 21, 49] }],
+    options: {
+      xaxis: { categories: months },
+    },
+  },
+};
+
+export const Donut: MtChartStory = {
+  args: {
+    type: "donut",
+    series: [44, 25, 18, 13],
+    options: {
+      labels: ["Direct", "Organic", "Referral", "Social"],
+      colors: ["#0870ff", "#ff7008", "#00b894", "#a29bfe"],
+    },
+  },
+};
+
+export const MultipleSeries: MtChartStory = {
+  args: {
+    type: "area",
+    series: [
+      { name: "This year", data: [30, 55, 65, 60, 45, 40, 55, 80] },
+      { name: "Last year", data: [20, 35, 40, 50, 40, 30, 45, 60] },
+    ],
+    options: {
+      stroke: { curve: "smooth" },
+      colors: ["#0870ff", "#ff7008"],
+      xaxis: { categories: months },
+    },
+  },
+};

--- a/packages/component-library/src/components/mt-chart/mt-chart.vue
+++ b/packages/component-library/src/components/mt-chart/mt-chart.vue
@@ -1,25 +1,45 @@
 <template>
   <div
     ref="chartContainer"
+    data-testid="mt-chart"
     :class="`mt-chart mt-chart-${props.type}`"
-    :style="{ width: props.width, height: props.height }"
-  ></div>
+    :style="{ width: sizeToCss(props.width), height: sizeToCss(props.height) }"
+  >
+    <canvas ref="canvasEl"></canvas>
+
+    <div
+      v-if="tooltip.visible"
+      class="mt-chart__tooltip"
+      :style="{ left: `${tooltip.x}px`, top: `${tooltip.y}px` }"
+    >
+      <div v-if="tooltip.title" class="mt-chart__tooltip-title">{{ tooltip.title }}</div>
+      <div v-for="(row, index) in tooltip.rows" :key="index" class="mt-chart__tooltip-row">
+        <span class="mt-chart__tooltip-marker" :style="{ background: row.color }" />
+        <span class="mt-chart__tooltip-value">{{ row.value }}</span>
+      </div>
+    </div>
+  </div>
 </template>
 
 <script setup lang="ts">
-import type { ApexOptions } from "apexcharts";
+import { Chart, registerables, type ChartConfiguration } from "chart.js";
 import { getDefaultOptions } from "./mt-chart-default-options";
+import { toChartConfig } from "./mt-chart-adapter";
+import { createTooltipHandler, hiddenTooltip } from "./mt-chart-tooltip";
+import type { ChartOptions } from "./mt-chart-types";
 import { deepMergeObjects } from "@/utils/object";
-import { computed, defineProps, onMounted, ref, watch, onBeforeUnmount } from "vue";
+import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
 import { templateRef } from "@vueuse/core";
 
-export type ChartOptions = ApexOptions;
+export type { ChartOptions };
+
+Chart.register(...registerables);
 
 const props = withDefaults(
   defineProps<{
     series: any[];
     options?: ChartOptions;
-    type?: ApexChart["type"];
+    type?: string;
     width?: string | number;
     height?: string | number;
   }>(),
@@ -31,117 +51,121 @@ const props = withDefaults(
   },
 );
 
-const chartContainer = templateRef("chartContainer");
-const chart = ref<ApexCharts>();
+const chartContainer = templateRef<HTMLElement>("chartContainer");
+const canvasEl = templateRef<HTMLCanvasElement>("canvasEl");
 
-const init = async () => {
-  const ApexCharts = (await import("apexcharts")).default;
-  if (!chartContainer.value) {
-    throw new Error("Chart container is not defined");
-  }
-  if (!chartOptions.value) {
-    throw new Error("Chart options are not defined");
-  }
-  if (chart.value) {
-    chart.value.destroy();
-  }
-  chart.value = new ApexCharts(chartContainer.value, { ...chartOptions.value, series: [] });
-  chart.value.render();
-  chart.value.updateSeries(props.series);
+// plain variable on purpose: a reactive ref would proxy the Chart.js instance
+// and break its identity-based internals (blank charts)
+let chart: Chart | undefined;
+
+const sizeToCss = (value: string | number) => (typeof value === "number" ? `${value}px` : value);
+
+const resolveCssVar = (value?: string) => {
+  const token = value?.match(/var\((--[^)]+)\)/)?.[1];
+  if (!token || !chartContainer.value) return value;
+  return getComputedStyle(chartContainer.value).getPropertyValue(token).trim() || value;
 };
 
-const destroy = () => {
-  if (chart.value) {
-    chart.value.destroy();
-    chart.value = undefined;
-  }
+const chartOptions = computed<ChartOptions>(() =>
+  deepMergeObjects<ChartOptions>(getDefaultOptions(props.type), props.options),
+);
+
+const tooltip = ref(hiddenTooltip());
+const tooltipHandler = createTooltipHandler(tooltip);
+
+const buildConfig = (): ChartConfiguration => {
+  const config = toChartConfig(props.type, props.series, chartOptions.value, resolveCssVar);
+  config.options ??= {};
+  config.options.plugins ??= {};
+  config.options.plugins.tooltip =
+    chartOptions.value.tooltip?.enabled === false
+      ? { enabled: false }
+      : { enabled: false, external: tooltipHandler };
+  return config;
 };
 
-onMounted(init);
-onBeforeUnmount(destroy);
+const createChart = () => {
+  if (!canvasEl.value) return;
+  chart?.destroy();
+  chart = new Chart(canvasEl.value, buildConfig());
+};
 
-const chartOptions = computed<ApexOptions>(() => {
-  const options = props.options;
-  const defaultOptions = getDefaultOptions(props.type);
+let themeObserver: MutationObserver | undefined;
 
-  const mergedOptions = deepMergeObjects<ApexOptions>(defaultOptions, options);
+onMounted(() => {
+  createChart();
 
-  return {
-    ...mergedOptions,
-    chart: {
-      type: props.type,
-      width: props.width,
-      height: props.height,
-      ...mergedOptions.chart,
-    },
-  };
+  // colors are baked into the canvas, so recreate when the theme changes
+  themeObserver = new MutationObserver(createChart);
+  themeObserver.observe(document.documentElement, {
+    subtree: true,
+    attributes: true,
+    attributeFilter: ["data-theme"],
+  });
 });
 
-watch(
-  () => props.options,
-  () => {
-    if (chart.value) {
-      chart.value.updateOptions(chartOptions.value);
-    }
-  },
-  { deep: true },
-);
+onBeforeUnmount(() => {
+  themeObserver?.disconnect();
+  chart?.destroy();
+  chart = undefined;
+});
 
 watch(
   () => props.series,
   () => {
-    if (chart.value) {
-      chart.value.updateSeries(props.series);
-    }
+    if (!chart) return;
+    chart.data = buildConfig().data;
+    chart.update();
   },
   { deep: true },
 );
 
-watch([() => props.type, () => props.width, () => props.height], init);
+watch([() => props.options, () => props.type, () => props.width, () => props.height], createChart, {
+  deep: true,
+});
 </script>
 
 <style scoped>
-.mt-chart :deep(.apexcharts-text) {
-  fill: var(--color-text-secondary-default) !important;
+.mt-chart {
+  position: relative;
 }
 
-.mt-chart-area :deep(.apexcharts-tooltip) {
+.mt-chart__tooltip {
+  position: absolute;
+  transform: translate(-50%, -100%);
+  pointer-events: none;
+  overflow: hidden;
   background-color: var(--color-elevation-surface-overlay);
   border: 1px solid var(--color-border-primary-default);
   border-radius: var(--border-radius-l);
   box-shadow: 0 4px 12px -4px rgba(0, 0, 0, 10%);
   color: var(--color-text-primary-default);
+  font-family: var(--font-family-body);
+  font-size: var(--font-size-xs);
+  z-index: 1;
+}
 
-  .apexcharts-tooltip-title {
-    font-family: var(--font-family-body) !important;
-    font-size: var(--font-size-xs) !important;
-    font-weight: var(--font-weight-bold);
-    background: var(--color-interaction-secondary-default) !important;
-    border-bottom: 1px solid var(--color-border-primary-default);
-    padding: 10px 16px;
-    margin-bottom: 0;
-  }
+.mt-chart__tooltip-title {
+  font-weight: var(--font-weight-bold);
+  background-color: var(--color-interaction-secondary-default);
+  border-bottom: 1px solid var(--color-border-primary-default);
+  padding: var(--scale-size-10) var(--scale-size-16);
+}
 
-  .apexcharts-tooltip-series-group {
-    padding: 10px 16px;
-  }
+.mt-chart__tooltip-row {
+  display: flex;
+  align-items: center;
+  gap: var(--scale-size-8);
+  padding: var(--scale-size-10) var(--scale-size-16);
+}
 
-  .apexcharts-tooltip-marker {
-    margin-right: 0;
-  }
+.mt-chart__tooltip-marker {
+  width: var(--scale-size-8);
+  height: var(--scale-size-8);
+  border-radius: var(--border-radius-round);
+}
 
-  .apexcharts-tooltip-text-y-label {
-    display: none;
-  }
-
-  .apexcharts-tooltip-text-y-value {
-    font-family: var(--font-family-body);
-    font-size: var(--font-size-xs);
-    font-weight: var(--font-weight-medium);
-  }
-
-  .apexcharts-tooltip-y-group {
-    padding: 0;
-  }
+.mt-chart__tooltip-value {
+  font-weight: var(--font-weight-medium);
 }
 </style>

--- a/packages/component-library/vite.config.ts
+++ b/packages/component-library/vite.config.ts
@@ -11,7 +11,7 @@ import { emitInterFontAssets, getAllComponents, libInjectCss, toPascalCase } fro
 // Get all components and their paths
 const allComponents = getAllComponents();
 
-export const external = ["vue", "apexcharts", "vue-i18n"];
+export const external = ["vue", "chart.js", "vue-i18n"];
 
 // https://vitejs.dev/config/
 export default defineConfig({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -393,9 +393,9 @@ importers:
       '@vueuse/core':
         specifier: ^13.1.0
         version: 13.1.0(vue@3.5.37(typescript@5.7.3))
-      apexcharts:
-        specifier: ^5.2.0
-        version: 5.2.0
+      chart.js:
+        specifier: ^4.5.1
+        version: 4.5.1
       codemirror:
         specifier: ^6.0.1
         version: 6.0.1(@lezer/common@1.2.3)
@@ -3244,6 +3244,9 @@ packages:
   '@keyv/serialize@1.1.1':
     resolution: {integrity: sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==}
 
+  '@kurkle/color@0.3.4':
+    resolution: {integrity: sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==}
+
   '@kwsites/file-exists@1.1.1':
     resolution: {integrity: sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==}
 
@@ -5554,31 +5557,6 @@ packages:
     resolution: {integrity: sha512-O9CMipBlq5OObdt1uKJGIzm9cdjpPWfj+a+Zw9EgWKxaMNHKC7EU7X9taj3H0EGQNLOSq2jAcOa3EzxlfHsD6w==}
     engines: {node: '>=8'}
 
-  '@svgdotjs/svg.draggable.js@3.0.6':
-    resolution: {integrity: sha512-7iJFm9lL3C40HQcqzEfezK2l+dW2CpoVY3b77KQGqc8GXWa6LhhmX5Ckv7alQfUXBuZbjpICZ+Dvq1czlGx7gA==}
-    peerDependencies:
-      '@svgdotjs/svg.js': ^3.2.4
-
-  '@svgdotjs/svg.filter.js@3.0.9':
-    resolution: {integrity: sha512-/69XMRCDoam2HgC4ldHIaDgeQf1ViHIsa0Ld4uWgiXtZ+E24DWHe/9Ib6kbNiZ7WRIdlVokUDR1Fg0kjIpkfbw==}
-    engines: {node: '>= 0.8.0'}
-
-  '@svgdotjs/svg.js@3.2.4':
-    resolution: {integrity: sha512-BjJ/7vWNowlX3Z8O4ywT58DqbNRyYlkk6Yz/D13aB7hGmfQTvGX4Tkgtm/ApYlu9M7lCQi15xUEidqMUmdMYwg==}
-
-  '@svgdotjs/svg.resize.js@2.0.5':
-    resolution: {integrity: sha512-4heRW4B1QrJeENfi7326lUPYBCevj78FJs8kfeDxn5st0IYPIRXoTtOSYvTzFWgaWWXd3YCDE6ao4fmv91RthA==}
-    engines: {node: '>= 14.18'}
-    peerDependencies:
-      '@svgdotjs/svg.js': ^3.2.4
-      '@svgdotjs/svg.select.js': ^4.0.1
-
-  '@svgdotjs/svg.select.js@4.0.3':
-    resolution: {integrity: sha512-qkMgso1sd2hXKd1FZ1weO7ANq12sNmQJeGDjs46QwDVsxSRcHmvWKL2NDF7Yimpwf3sl5esOLkPqtV2bQ3v/Jg==}
-    engines: {node: '>= 14.18'}
-    peerDependencies:
-      '@svgdotjs/svg.js': ^3.2.4
-
   '@swc/core-darwin-arm64@1.6.1':
     resolution: {integrity: sha512-u6GdwOXsOEdNAdSI6nWq6G2BQw5HiSNIZVcBaH1iSvBnxZvWbnIKyDiZKaYnDwTLHLzig2GuUjjE2NaCJPy4jg==}
     engines: {node: '>=10'}
@@ -7289,9 +7267,6 @@ packages:
   '@webcontainer/env@1.1.1':
     resolution: {integrity: sha512-6aN99yL695Hi9SuIk1oC88l9o0gmxL1nGWWQ/kNy81HigJ0FoaoTXpytCj6ItzgyCEwA9kF1wixsTuv5cjsgng==}
 
-  '@yr/monotone-cubic-spline@1.0.3':
-    resolution: {integrity: sha512-FQXkOta0XBSUPHndIKON2Y9JeQz5ZeMqLYZVVK93FliNBFm7LNMIZmY6FrMEB9XPcDbE2bekMbZD6kzDkxwYjA==}
-
   abab@2.0.6:
     resolution: {integrity: sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==}
     deprecated: Use your platform's native atob() and btoa() methods instead
@@ -7478,9 +7453,6 @@ packages:
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
-
-  apexcharts@5.2.0:
-    resolution: {integrity: sha512-BZ+v4Wqf4BKVRKBatVghDVu9vu2SXhl/F7ujT2awnf7Zv6RT39FQWtAAV3bpH+G5c8IADw0PyOKG00+rN1UoNg==}
 
   apisauce@3.2.2:
     resolution: {integrity: sha512-YvZ6v7KgGWSjqHEDcGxE+U5bI8U8ckVqVFvfs0SKGtMrvbX0o3MDMlMzlL9lvWgg9hb//162vAHPconN/Ed1oA==}
@@ -7946,6 +7918,10 @@ packages:
 
   chardet@2.1.1:
     resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
+
+  chart.js@4.5.1:
+    resolution: {integrity: sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==}
+    engines: {pnpm: '>=8'}
 
   check-error@2.1.1:
     resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
@@ -15977,6 +15953,9 @@ packages:
   vue-component-type-helpers@3.3.6:
     resolution: {integrity: sha512-FkljacAwJ9BUoSUdpFe3VDy0sGigNlTH9+2zcXUWmZOjN8swiCkl3t48wOJun0OsUd2cEIda1l04tsxMiKIIrQ==}
 
+  vue-component-type-helpers@3.3.7:
+    resolution: {integrity: sha512-Skkhw9agYSgsWqv7bxSOGJZa9SaiJbZVGdXuFWnrzKaQYHnw9qbjD630rw6RyMqDbp54nfLCLw5SZA55if7JLg==}
+
   vue-demi@0.14.10:
     resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
     engines: {node: '>=12'}
@@ -19098,6 +19077,8 @@ snapshots:
 
   '@keyv/serialize@1.1.1': {}
 
+  '@kurkle/color@0.3.4': {}
+
   '@kwsites/file-exists@1.1.1':
     dependencies:
       debug: 4.4.3
@@ -21688,28 +21669,9 @@ snapshots:
       ts-dedent: 2.2.0
       type-fest: 2.19.0
       vue: 3.5.37(typescript@5.7.3)
-      vue-component-type-helpers: 3.3.6
+      vue-component-type-helpers: 3.3.7
 
   '@supercharge/promise-pool@2.4.0': {}
-
-  '@svgdotjs/svg.draggable.js@3.0.6(@svgdotjs/svg.js@3.2.4)':
-    dependencies:
-      '@svgdotjs/svg.js': 3.2.4
-
-  '@svgdotjs/svg.filter.js@3.0.9':
-    dependencies:
-      '@svgdotjs/svg.js': 3.2.4
-
-  '@svgdotjs/svg.js@3.2.4': {}
-
-  '@svgdotjs/svg.resize.js@2.0.5(@svgdotjs/svg.js@3.2.4)(@svgdotjs/svg.select.js@4.0.3(@svgdotjs/svg.js@3.2.4))':
-    dependencies:
-      '@svgdotjs/svg.js': 3.2.4
-      '@svgdotjs/svg.select.js': 4.0.3(@svgdotjs/svg.js@3.2.4)
-
-  '@svgdotjs/svg.select.js@4.0.3(@svgdotjs/svg.js@3.2.4)':
-    dependencies:
-      '@svgdotjs/svg.js': 3.2.4
 
   '@swc/core-darwin-arm64@1.6.1':
     optional: true
@@ -23979,8 +23941,6 @@ snapshots:
 
   '@webcontainer/env@1.1.1': {}
 
-  '@yr/monotone-cubic-spline@1.0.3': {}
-
   abab@2.0.6: {}
 
   abbrev@2.0.0: {}
@@ -24145,15 +24105,6 @@ snapshots:
     dependencies:
       normalize-path: 3.0.0
       picomatch: 2.3.1
-
-  apexcharts@5.2.0:
-    dependencies:
-      '@svgdotjs/svg.draggable.js': 3.0.6(@svgdotjs/svg.js@3.2.4)
-      '@svgdotjs/svg.filter.js': 3.0.9
-      '@svgdotjs/svg.js': 3.2.4
-      '@svgdotjs/svg.resize.js': 2.0.5(@svgdotjs/svg.js@3.2.4)(@svgdotjs/svg.select.js@4.0.3(@svgdotjs/svg.js@3.2.4))
-      '@svgdotjs/svg.select.js': 4.0.3(@svgdotjs/svg.js@3.2.4)
-      '@yr/monotone-cubic-spline': 1.0.3
 
   apisauce@3.2.2:
     dependencies:
@@ -24733,6 +24684,10 @@ snapshots:
   character-reference-invalid@2.0.1: {}
 
   chardet@2.1.1: {}
+
+  chart.js@4.5.1:
+    dependencies:
+      '@kurkle/color': 0.3.4
 
   check-error@2.1.1: {}
 
@@ -35847,6 +35802,8 @@ snapshots:
   vue-component-type-helpers@2.2.12: {}
 
   vue-component-type-helpers@3.3.6: {}
+
+  vue-component-type-helpers@3.3.7: {}
 
   vue-demi@0.14.10(vue@3.5.13(typescript@5.7.3)):
     dependencies:


### PR DESCRIPTION
## What?

Replaces ApexCharts with Chart.js as the `mt-chart` rendering engine.

## Why?

ApexCharts changed its license (#1183).

## How?

The public props keep their ApexCharts-style shape; an internal adapter translates them to a Chart.js config, so consuming code is unchanged. Visual output was matched against measured ApexCharts rendering: smooth curve (reproduced exactly via a small plugin), gradient fill, y-axis scale, label geometry, and plot-area padding. Types line, area, bar, pie, donut, radar, polarArea, scatter, and bubble map natively.

Not supported (fail soft): Apex formatter callbacks, datetime axes, `dataLabels`.

Also fixes Storybook theme switching on docs pages (channel-based ThemeProvider).

## Testing?

29 unit tests (adapter, component, tooltip). Curve verified numerically against Apex's SVG path (RMS 0.001), gradient pixel-matched (±1 RGB), axis/plot geometry measured from Apex output.
