### PR TITLE
fix: remove global html/body height rule from styles.css

### DIFF
--- a/.changeset/remove-global-html-body-height.md
+++ b/.changeset/remove-global-html-body-height.md
@@ -1,0 +1,21 @@
+---
+"@shopware-ag/meteor-component-library": patch
+---
+
+Remove the global `html, body` height rule from `styles.css` entirely, restoring the pre-5.2.0 behavior where consumers own their document-level layout.
+
+The rule has caused problems in both of its variants:
+
+- `height: 100dvh` (introduced in 5.2.0) deadlocked apps rendered in the Administration's auto-sized iframes at the 150px browser fallback, because the admin-sdk reported the pinned viewport height back to `sw-iframe-renderer`.
+- `min-height: 100dvh` (5.3.0) fixed the deadlock but made iframe auto-resizing a one-way ratchet: `body` never shrinks below the iframe's current height, so `location.startAutoResizer()` never reports a smaller height when content shrinks, and small widgets stay floored at the 150px fallback.
+
+With the rule removed, auto-sized iframe locations grow **and** shrink with their content again, exactly as on ≤5.1.x.
+
+If your app relied on the implicit full-viewport height for a percentage-based layout (introduced accidentally in 5.2.0), declare it yourself:
+
+```css
+html,
+body {
+  height: 100dvh;
+}
+```

--- a/packages/component-library/src/assets/css/global.css
+++ b/packages/component-library/src/assets/css/global.css
@@ -22,13 +22,6 @@ body {
   color-scheme: dark;
 }
 
-/* min-height, not fixed height: in the admin's auto-sized iframe a fixed
-   100dvh collapses to the 150px fallback that the admin-sdk reports back. */
-html,
-body {
-  min-height: 100dvh;
-}
-
 /** @TODO move to tokens file once we find a solution for non figma-sync tokens **/
 :root {
   --color-elevation-shadow-default: #1010131a !important;


### PR DESCRIPTION
## What?

Removes the `html, body` height rule from the component library's global.css entirely, restoring the pre-5.2.0 behavior where consumers own their document-level layout. Ships as a patch (`5.3.1`) via changeset.

## Why?

The rule has broken embedded apps in both of its variants:

- **`height: 100dvh` (5.2.0, #1155):** apps rendered in the Administration's auto-sized iframes deadlock at the 150px browser fallback — the admin-sdk reports the pinned viewport height back to `sw-iframe-renderer` (reported by ShopwarePayments, fixed downstream in ShopwarePayments#1230).
- **`min-height: 100dvh` (5.3.0, #1262):** fixes the deadlock, but makes iframe auto-resizing a one-way ratchet — `body` never renders smaller than the iframe's current height, so `location.startAutoResizer()` never fires when content shrinks, and small widgets stay floored at the 150px fallback. It also broke the Administration's percentage-height layout chain (worked around in shopware/shopware#18087).

No single `html/body` rule can serve both consumer types: embedded documents need `height: auto` so real content height is measurable, while app-shell layouts need a definite height chain. So the library should set neither — each consumer declares its own contract, exactly as before 5.2.0.

## Impact

Verified in a headless-browser matrix replicating `sw-iframe-renderer` + admin-sdk mechanics against the published 5.1.0/5.2.0/5.3.0 artifacts and this branch's build:

| auto-sized iframe scenario | 5.1.0 | 5.2.0 | 5.3.0 | this PR |
|---|---|---|---|---|
| content grows (400px) | ✅ 400 | ❌ 150 deadlock | ✅ 400 | ✅ 400 |
| content shrinks (800→200px) | ✅ 200 | ❌ 150 deadlock | ⚠️ stuck at 800 | ✅ 200 |
| small widget (60px) | ✅ 60 | ❌ 150 | ⚠️ floored at 150 | ✅ 60 |

Consumers that relied on the (accidental) implicit viewport height from 5.2.0 for percentage-based layouts must declare it themselves:

```css
html,
body {
  height: 100dvh;
}
```

The Administration already does this via shopware/shopware#18087.

## Testing?

- Built the library and confirmed `dist/index.css` no longer contains the rule.
- Ran the built CSS through the iframe grow/shrink/small-widget matrix above — behavior is identical to 5.1.0 in every scenario.

🤖 Generated with [Claude Code](https://claude.com/claude-code)