### PR TITLE
fix(component-library): round number field step values

### DIFF
--- a/.changeset/bright-kings-float.md
+++ b/.changeset/bright-kings-float.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": patch
+---
+
+Fix floating-point rounding after stepping a number field.

--- a/packages/component-library/src/components/mt-number-field/mt-number-field.spec.ts
+++ b/packages/component-library/src/components/mt-number-field/mt-number-field.spec.ts
@@ -90,6 +90,43 @@ describe("mt-number-field", () => {
     expect(handler).not.toHaveBeenCalled();
   });
 
+  it("rounds floating point precision errors when incrementing with the keyboard", async () => {
+    const updateHandler = vi.fn();
+
+    render(MtNumberField, {
+      props: {
+        modelValue: 1.62,
+        step: 0.01,
+        digits: 2,
+        "onUpdate:modelValue": updateHandler,
+      },
+    });
+
+    await userEvent.click(screen.getByRole("textbox"));
+    await userEvent.keyboard("{ArrowUp}");
+
+    expect(updateHandler).toHaveBeenLastCalledWith(1.63);
+    expect((screen.getByRole("textbox") as HTMLInputElement).value).toBe("1.63");
+  });
+
+  it("rounds floating point precision errors when incrementing with the control", async () => {
+    const updateHandler = vi.fn();
+
+    render(MtNumberField, {
+      props: {
+        modelValue: 1.62,
+        step: 0.01,
+        digits: 2,
+        "onUpdate:modelValue": updateHandler,
+      },
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: "Increase" }));
+
+    expect(updateHandler).toHaveBeenLastCalledWith(1.63);
+    expect((screen.getByRole("textbox") as HTMLInputElement).value).toBe("1.63");
+  });
+
   it("is not possible to increment the value by pressing the increment button when inheritance is linked", async () => {
     // ASSERT
     const handler = vi.fn();

--- a/packages/component-library/src/components/mt-number-field/mt-number-field.vue
+++ b/packages/component-library/src/components/mt-number-field/mt-number-field.vue
@@ -380,15 +380,16 @@ export default defineComponent({
     },
 
     increaseNumberByStep() {
-      this.computeValue((Number(this.currentValue) + this.realStep).toString());
-      this.rawUserInput = null;
-
-      this.$emit("update:modelValue", this.currentValue);
+      this.changeNumberByStep(this.realStep);
     },
 
     decreaseNumberByStep() {
-      // @ts-expect-error - wrong type because of component extends
-      this.computeValue((this.currentValue - this.realStep).toString());
+      this.changeNumberByStep(-this.realStep);
+    },
+
+    changeNumberByStep(step: number) {
+      const steppedValue = Number(this.currentValue) + step;
+      this.computeValue(this.roundToDigits(steppedValue.toString(), this.digits).toString());
       this.rawUserInput = null;
 
       this.$emit("update:modelValue", this.currentValue);


### PR DESCRIPTION
## What?

Normalize number-field values after an increment or decrement.

## Why?

JavaScript floating-point arithmetic can otherwise emit precision artifacts such as `1.6300000000000001` for a `1.62 + 0.01` step.

## How?

Route both step controls through a shared method that applies the field's configured digit rounding before parsing and emitting the value.

## Testing?

- `pnpm --dir packages/component-library test:unit --run src/components/mt-number-field/mt-number-field.spec.ts -t 'rounds floating point precision errors'`
- `pnpm --dir packages/component-library lint:eslint`
- `pnpm --dir packages/component-library format:check src/components/mt-number-field/mt-number-field.vue src/components/mt-number-field/mt-number-field.spec.ts`

## Screenshots (optional)

https://www.loom.com/share/6573f4a50a294107ae343df30a9d16f3

## Anything Else?

Adds a patch changeset for `@shopware-ag/meteor-component-library`.