### PR TITLE
fix(component-library): preserve number field step precision

### DIFF
--- a/.changeset/blue-steps-round.md
+++ b/.changeset/blue-steps-round.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": patch
+---
+
+Fix number field stepping for values with high fractional precision limits.

--- a/packages/component-library/src/components/mt-number-field/mt-number-field.spec.ts
+++ b/packages/component-library/src/components/mt-number-field/mt-number-field.spec.ts
@@ -127,6 +127,44 @@ describe("mt-number-field", () => {
     expect((screen.getByRole("textbox") as HTMLInputElement).value).toBe("1.63");
   });
 
+  it.each([
+    [10, 10.01],
+    [1333.33, 1333.34],
+  ])("does not reset %s when incrementing with 20 digits", async (modelValue, expectedValue) => {
+    const updateHandler = vi.fn();
+
+    render(MtNumberField, {
+      props: {
+        modelValue,
+        digits: 20,
+        "onUpdate:modelValue": updateHandler,
+      },
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: "Increase" }));
+
+    expect(updateHandler).toHaveBeenLastCalledWith(expectedValue);
+    expect((screen.getByRole("textbox") as HTMLInputElement).value).toBe(expectedValue.toString());
+  });
+
+  it("preserves precision beyond the step when incrementing", async () => {
+    const updateHandler = vi.fn();
+
+    render(MtNumberField, {
+      props: {
+        modelValue: 1.234567,
+        step: 0.01,
+        digits: 20,
+        "onUpdate:modelValue": updateHandler,
+      },
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: "Increase" }));
+
+    expect(updateHandler).toHaveBeenLastCalledWith(1.244567);
+    expect((screen.getByRole("textbox") as HTMLInputElement).value).toBe("1.244567");
+  });
+
   it("is not possible to increment the value by pressing the increment button when inheritance is linked", async () => {
     // ASSERT
     const handler = vi.fn();

--- a/packages/component-library/src/components/mt-number-field/mt-number-field.spec.ts
+++ b/packages/component-library/src/components/mt-number-field/mt-number-field.spec.ts
@@ -128,24 +128,30 @@ describe("mt-number-field", () => {
   });
 
   it.each([
-    [10, 10.01],
-    [1333.33, 1333.34],
-  ])("does not reset %s when incrementing with 20 digits", async (modelValue, expectedValue) => {
-    const updateHandler = vi.fn();
+    [10, 20, 10.01],
+    [1333.33, 20, 1333.34],
+    [0.01, 50, 0.02],
+  ])(
+    "does not reset %s when incrementing with %s digits",
+    async (modelValue, digits, expectedValue) => {
+      const updateHandler = vi.fn();
 
-    render(MtNumberField, {
-      props: {
-        modelValue,
-        digits: 20,
-        "onUpdate:modelValue": updateHandler,
-      },
-    });
+      render(MtNumberField, {
+        props: {
+          modelValue,
+          digits,
+          "onUpdate:modelValue": updateHandler,
+        },
+      });
 
-    await userEvent.click(screen.getByRole("button", { name: "Increase" }));
+      await userEvent.click(screen.getByRole("button", { name: "Increase" }));
 
-    expect(updateHandler).toHaveBeenLastCalledWith(expectedValue);
-    expect((screen.getByRole("textbox") as HTMLInputElement).value).toBe(expectedValue.toString());
-  });
+      expect(updateHandler).toHaveBeenLastCalledWith(expectedValue);
+      expect((screen.getByRole("textbox") as HTMLInputElement).value).toBe(
+        expectedValue.toString(),
+      );
+    },
+  );
 
   it("preserves precision beyond the step when incrementing", async () => {
     const updateHandler = vi.fn();

--- a/packages/component-library/src/components/mt-number-field/mt-number-field.vue
+++ b/packages/component-library/src/components/mt-number-field/mt-number-field.vue
@@ -389,7 +389,14 @@ export default defineComponent({
 
     changeNumberByStep(step: number) {
       const steppedValue = Number(this.currentValue) + step;
-      this.computeValue(this.roundToDigits(steppedValue.toString(), this.digits).toString());
+      const roundingDigits = Math.min(
+        this.digits,
+        Math.max(
+          this.getNumberOfFractionDigits(Number(this.currentValue)),
+          this.getNumberOfFractionDigits(step),
+        ),
+      );
+      this.computeValue(this.roundToDigits(steppedValue.toString(), roundingDigits).toString());
       this.rawUserInput = null;
 
       this.$emit("update:modelValue", this.currentValue);
@@ -460,7 +467,33 @@ export default defineComponent({
       // whose binary float error would otherwise drop e.g. 1.035 to 1.03 instead
       // of 1.04. `Number("1.035e2")` parses straight to 103.5, so Math.round acts
       // on the intended decimal value.
-      return Number(`${Math.round(Number(`${value}e${digits}`))}e-${digits}`);
+      const roundedValue = Math.round(Number(`${value}e${digits}`));
+
+      if (digits === 0) {
+        return roundedValue;
+      }
+
+      // `roundedValue` may use scientific notation, so convert it to a fixed
+      // decimal string before shifting its decimal separator back.
+      const sign = roundedValue < 0 ? "-" : "";
+      const roundedString = Math.abs(roundedValue).toLocaleString("fullwide", {
+        useGrouping: false,
+        maximumFractionDigits: 0,
+      });
+      const decimalIndex = roundedString.length - digits;
+      const decimalValue =
+        decimalIndex > 0
+          ? `${sign}${roundedString.slice(0, decimalIndex)}.${roundedString.slice(decimalIndex)}`
+          : `${sign}0.${roundedString.padStart(digits, "0")}`;
+
+      return Number(decimalValue);
+    },
+
+    getNumberOfFractionDigits(value: number): number {
+      const [coefficient, exponent] = Math.abs(value).toString().split("e-");
+      const fractionDigits = coefficient.split(".")[1]?.length ?? 0;
+
+      return fractionDigits + Number(exponent ?? 0);
     },
 
     checkForInteger(value: number) {


### PR DESCRIPTION
## What?

Correct number field stepping for values with a high fractional precision limit.

## Why?

The previous rounding helper converted shifted values back through a second exponent string. At `digits=20`, values from `10` onward are represented in scientific notation, producing an invalid double-exponent string and resetting the field to `0`.

## How?

Round only to the precision required by the current value and step, capped by `digits`, and use fixed decimal formatting when shifting high-precision values back.

## Testing?

Focused number-field cases pass for keyboard/control rounding, values `10` and `1333.33` with `digits=20`, and a high-precision value.

## Screenshots (optional)

Temporarily used this state in shopware and tested with the price field:
https://www.loom.com/share/1984662d6c254f50a31c9a790dd6d576

note that it uses highest precision of either existing value or step for rounding the steps now, so it behaves as a human would expect.

### For comparison

current trunk behaviour (Meteor 5.2.0, the copy & paste issue was adressed in a separate PR already):
https://www.loom.com/share/f000e6756fb44561a0321e5171f3de0a

## Anything Else?

