### PR TITLE
feat(component-library): make modal initial focus optional

### DIFF
--- a/.changeset/modal-focus-control.md
+++ b/.changeset/modal-focus-control.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": patch
+---
+
+Allow consumers to disable automatic focus when opening a modal.

--- a/packages/component-library/src/components/mt-modal/mt-modal.spec.ts
+++ b/packages/component-library/src/components/mt-modal/mt-modal.spec.ts
@@ -66,6 +66,27 @@ describe("mt-modal", () => {
     expect(onChange).toHaveBeenNthCalledWith(1, true);
   });
 
+  it("keeps focus on the trigger when initial focus is disabled", async () => {
+    render({
+      components: { MtModal, MtModalRoot, MtModalTrigger },
+      template: `
+<mt-modal-root>
+  <mt-modal-trigger as="button">Open modal</mt-modal-trigger>
+  <mt-modal :initialFocus="false" title="title"><a href="#details">Details</a></mt-modal>
+</mt-modal-root>`,
+    });
+
+    const trigger = screen.getByRole("button", { name: "Open modal" });
+    trigger.focus();
+
+    await fireEvent.click(trigger);
+
+    await waitFor(() => {
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+      expect(trigger).toHaveFocus();
+    });
+  });
+
   it("opens the modal when clicking the trigger when 'isOpen' gets changed", async () => {
     // GIVEN
     const onChange = vi.fn();

--- a/packages/component-library/src/components/mt-modal/mt-modal.vue
+++ b/packages/component-library/src/components/mt-modal/mt-modal.vue
@@ -80,7 +80,7 @@ import MtText from "@/components/mt-text/mt-text.vue";
 import { createId } from "@/utils/id";
 import * as focusTrap from "focus-trap";
 
-defineProps({
+const props = defineProps({
   title: {
     type: String,
     required: false,
@@ -105,6 +105,11 @@ defineProps({
     type: Boolean,
     required: false,
     default: false,
+  },
+  initialFocus: {
+    type: Boolean,
+    required: false,
+    default: true,
   },
 });
 
@@ -152,6 +157,7 @@ watch(
       trap = focusTrap.createFocusTrap(modalRef.value as HTMLElement, {
         tabbableOptions: { displayCheck: "none" },
         allowOutsideClick: true,
+        initialFocus: props.initialFocus ? undefined : false,
         onPause: () => {
           // a new modal is being opened, pausing the current trap
           console.warn(


### PR DESCRIPTION
## What?

Adds an `initialFocus` prop to `mt-modal`.

## Why?

Some required-decision modals should keep focus on the triggering element instead of automatically focusing the first interactive element in their content.

## How?

Passes `initialFocus: false` to the underlying focus trap when the prop is disabled. The default behavior remains unchanged.

## Testing?

- `pnpm --filter @shopware-ag/meteor-component-library exec vitest run src/components/mt-modal/mt-modal.spec.ts`
- `pnpm --filter @shopware-ag/meteor-component-library run lint:eslint` (existing warnings only)

## Screenshots (optional)

Not applicable.

## Anything Else?

Required by https://github.com/shopware/shopware/pull/18104.
