### PR TITLE
feat(component-library): add iconMode prop to mt-empty-state

### DIFF
--- a/.changeset/mt-empty-state-icon-mode.md
+++ b/.changeset/mt-empty-state-icon-mode.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": minor
+---
+
+Added an `iconMode` prop to `mt-empty-state` that forwards the fill style (`solid` or `regular`) to the icon. This lets you render the empty-state icon in a specific variant when passing a bare icon name (e.g. `icon="products" icon-mode="solid"`), so callers can decide the fill locally instead of encoding it in the icon name. Prefixed names (`solid-*`/`regular-*`) keep overriding the mode, and the prop defaults to `regular`, so existing usages are unchanged.

--- a/packages/component-library/src/components/mt-empty-state/mt-empty-state.spec.ts
+++ b/packages/component-library/src/components/mt-empty-state/mt-empty-state.spec.ts
@@ -51,6 +51,23 @@ describe("mt-empty-state", () => {
     expect(icon.attributes("name")).toBe("solid-chart-line-arrow");
   });
 
+  it("renders the icon in the regular mode by default", async () => {
+    wrapper = await createWrapper(undefined, {
+      icon: "chart-line-arrow",
+    });
+    const icon = wrapper.find("mt-icon-stub");
+    expect(icon.attributes("mode")).toBe("regular");
+  });
+
+  it("forwards the icon mode to the icon", async () => {
+    wrapper = await createWrapper(undefined, {
+      icon: "chart-line-arrow",
+      iconMode: "solid",
+    });
+    const icon = wrapper.find("mt-icon-stub");
+    expect(icon.attributes("mode")).toBe("solid");
+  });
+
   it("should render a link", async () => {
     wrapper = await createWrapper(undefined, {
       linkHref: "https://storybook.js.org",

--- a/packages/component-library/src/components/mt-empty-state/mt-empty-state.stories.ts
+++ b/packages/component-library/src/components/mt-empty-state/mt-empty-state.stories.ts
@@ -17,6 +17,11 @@ export default {
       control: "text",
       description: "The icon to display in the empty state",
     },
+    iconMode: {
+      control: { type: "select", options: ["solid", "regular"] },
+      description:
+        "The fill style of the icon. Only applies when `icon` is a bare name (without a `solid-`/`regular-` prefix).",
+    },
     linkHref: {
       control: "text",
       description: "The URL to link to",

--- a/packages/component-library/src/components/mt-empty-state/mt-empty-state.vue
+++ b/packages/component-library/src/components/mt-empty-state/mt-empty-state.vue
@@ -2,7 +2,12 @@
   <!-- @deprecated tag:v5 remove leftAligned class -->
   <div class="mt-empty-state" :class="{ 'mt-empty-state--left-aligned': !centered }">
     <div class="mt-empty-state__icon">
-      <mt-icon :name="icon" color="var(--color-icon-primary-default)" aria-hidden="true" />
+      <mt-icon
+        :name="icon"
+        :mode="iconMode"
+        color="var(--color-icon-primary-default)"
+        aria-hidden="true"
+      />
     </div>
 
     <mt-text as="h2" size="l" weight="bold" class="mt-empty-state__headline">
@@ -48,6 +53,11 @@ withDefaults(
     headline: string;
     description: string;
     icon: string;
+    /**
+     * The fill style of the icon. Only takes effect when `icon` is a bare icon name
+     * (without a `solid-`/`regular-` prefix); a prefixed name overrides this.
+     */
+    iconMode?: "solid" | "regular";
     linkHref?: string;
     linkText?: string;
     linkType?: "external" | "internal";
@@ -55,6 +65,7 @@ withDefaults(
     centered?: boolean;
   }>(),
   {
+    iconMode: "regular",
     linkType: "internal",
     /** @deprecated tag:v5 remove centered prop and class */
     centered: false,


### PR DESCRIPTION
## What?

Add an `iconMode` prop to `mt-empty-state` that forwards the icon fill style
(`solid` | `regular`) to the internal `mt-icon`. Defaults to `regular`.

```html
<mt-empty-state icon="products" icon-mode="solid" headline="…" description="…" />
```

## Why?

`mt-icon` already supports a bare icon name plus a `mode` prop to choose the
fill style. `mt-empty-state`, however, hardcoded `<mt-icon :name="icon" />`
with no `mode`, so the only way to get a solid empty-state icon was to pass a
`solid-`-prefixed name. Consumers that store an icon as a bare name (and decide
the fill per location — e.g. `regular` in navigation, `solid` in empty states)
had no way to express that on the empty state.

This unblocks the Shopware Administration effort to define module icons by name
only and resolve the fill style locally.

## How?

- Added `iconMode?: "solid" | "regular"` to the props (default `"regular"`,
  mirroring `mt-icon`).
- Bound it through: `<mt-icon :name="icon" :mode="iconMode" … />`.
- A `solid-*`/`regular-*` prefix in `name` still wins over `mode` (unchanged
  `mt-icon` behavior), so existing prefixed usages are unaffected.

## Testing?

- Added specs: renders `regular` by default, and forwards `iconMode="solid"`.
- Full `mt-empty-state` suite passes (12/12).
- ESLint/Prettier clean for the touched files (only pre-existing warnings remain).

## Anything Else?

Backward-compatible and additive — no migration needed. Changeset included
(`minor`). Follow-up (separate, in shopware/shopware): switch module icons to
bare names and pass `icon-mode="solid"` on empty states once this ships.
