### PR TITLE
chore: use public repository metadata for all packages

### DIFF
--- a/examples/admin-sdk-app/package.json
+++ b/examples/admin-sdk-app/package.json
@@ -5,7 +5,7 @@
   "description": "",
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com:shopware/meteor.git"
+    "url": "git+https://github.com/shopware/meteor.git"
   },
   "license": "MIT",
   "author": "shopware AG",

--- a/packages/admin-sdk/package.json
+++ b/packages/admin-sdk/package.json
@@ -12,7 +12,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com:shopware/meteor.git"
+    "url": "git+https://github.com/shopware/meteor.git"
   },
   "license": "MIT",
   "exports": {

--- a/packages/component-library/package.json
+++ b/packages/component-library/package.json
@@ -3,7 +3,7 @@
   "version": "5.3.1",
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com:shopware/meteor.git"
+    "url": "git+https://github.com/shopware/meteor.git"
   },
   "license": "MIT",
   "author": "shopware AG",

--- a/packages/icon-kit/package.json
+++ b/packages/icon-kit/package.json
@@ -13,7 +13,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com:shopware/meteor.git"
+    "url": "git+https://github.com/shopware/meteor.git"
   },
   "type": "module",
   "license": "MIT",

--- a/packages/stylelint-plugin-meteor/package.json
+++ b/packages/stylelint-plugin-meteor/package.json
@@ -3,7 +3,7 @@
   "version": "5.0.0",
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com:shopware/meteor.git"
+    "url": "git+https://github.com/shopware/meteor.git"
   },
   "main": "./dist/commonjs/index.js",
   "files": [

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -4,7 +4,7 @@
   "description": "Design Tokens for the Meteor Design System used at shopware",
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com:shopware/meteor.git"
+    "url": "git+https://github.com/shopware/meteor.git"
   },
   "license": "MIT",
   "author": "shopware AG",


### PR DESCRIPTION
## What?

- Switch `repository.url` from the scp-style `git+ssh://git@github.com:shopware/meteor.git` to `git+https://github.com/shopware/meteor.git` in all published packages (component-library, admin-sdk, tokens, icon-kit, stylelint-plugin-meteor) and the admin-sdk-app example.

## Why?

- The scp-style value is invalid as a URL: Node emits `DEP0170` warnings (visible in CI logs) and will throw in future versions. SSH URLs are also unusable as public npm metadata (Repository link on npmjs.com, `npm repo`, provenance/dependency tooling).

## How?

- Metadata-only, no runtime or build impact; no changesets needed — the corrected metadata ships with each package's next regular release. `prettier-config` already had a valid https URL. The `docs:env` shell script in admin-sdk keeps its ssh clone on purpose (real git command, changing it would change clone auth).

## Testing?

- `new URL()` throws on the old value and parses the new one cleanly; all six manifests still parse with the corrected URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)