### PR TITLE
fix(docs): render literal enum values in the API reference prop table

### DIFF
--- a/.changeset/api-reference-enum-values.md
+++ b/.changeset/api-reference-enum-values.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": patch
+---
+
+Refined several prop types to their literal values so the API reference renders them accurately. The `size` prop of `mt-text-field`, `mt-number-field`, and `mt-unit-field` is now typed as `"small" | "default"`, and the `mt-popover` `width` prop is now typed as `"dynamic" | "large" | "medium" | "small"` to match the value it actually accepts (previously it listed the non-functional `"auto"` and omitted the `"dynamic"` default). These are type-only corrections; the runtime behaviour is unchanged.

--- a/apps/docs/app/components/content/ComponentApi.vue
+++ b/apps/docs/app/components/content/ComponentApi.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { camelCase, kebabCase, upperFirst } from "scule";
-import { formatType } from "#shared/utils/formatType";
+import { formatType, literalUnion } from "#shared/utils/formatType";
+import type { ComponentPropMeta } from "~/types/component-meta";
 
 const props = withDefaults(
   defineProps<{
@@ -33,6 +34,12 @@ interface Cell {
 const visible = <T extends { name: string }>(items: T[] | undefined) =>
   (items ?? []).filter((item) => !props.ignore.includes(item.name));
 
+// Prefer the resolved schema's literal union (e.g. a named enum type alias
+// expanded to its actual values) over the printed type, which can be an opaque
+// alias name or a broad `string`. Falls back to the printed type otherwise.
+const propType = (prop: ComponentPropMeta): string | undefined =>
+  literalUnion(prop.schema) ?? formatType(prop.type);
+
 const sections = computed(() => {
   const m = meta.value?.meta;
 
@@ -47,7 +54,7 @@ const sections = computed(() => {
           required: prop.required,
           description: prop.description,
         },
-        { value: formatType(prop.type), code: true },
+        { value: propType(prop), code: true },
         { value: prop.default, code: true },
       ]),
     },

--- a/apps/docs/app/types/component-meta.ts
+++ b/apps/docs/app/types/component-meta.ts
@@ -1,3 +1,7 @@
+import type { PropSchema } from "#shared/utils/formatType";
+
+export type { PropSchema };
+
 export interface ComponentPropMeta {
   name: string;
   type?: string;
@@ -5,6 +9,7 @@ export interface ComponentPropMeta {
   description?: string;
   required?: boolean;
   tags?: { name: string; text?: string }[];
+  schema?: PropSchema;
 }
 
 export interface ComponentEventMeta {

--- a/apps/docs/shared/utils/formatType.ts
+++ b/apps/docs/shared/utils/formatType.ts
@@ -1,4 +1,57 @@
 /**
+ * The resolved type structure vue-component-meta computes alongside the printed
+ * `type` string. For enums it carries the fully-expanded members (keyed by
+ * index), which is how a named type alias (e.g. `MtColorBadgeVariant`) can be
+ * rendered as its literal values instead of the opaque alias name.
+ */
+export interface PropSchema {
+  kind?: string;
+  type?: string;
+  schema?: Record<string, string | PropSchema> | (string | PropSchema)[];
+}
+
+/**
+ * A TypeScript literal in the type printer's output: a quoted string, a number,
+ * or a boolean/nullish keyword.
+ */
+function isLiteral(member: string): boolean {
+  return (
+    /^(['"`]).*\1$/.test(member) ||
+    /^-?\d+(\.\d+)?$/.test(member) ||
+    ["true", "false", "null", "undefined"].includes(member)
+  );
+}
+
+/**
+ * Expands a prop's resolved `schema` into a literal union string, but only when
+ * every member is a literal (ignoring `undefined`). This is what turns a named
+ * type alias like `MtColorBadgeVariant` — whose printed `type` is just the
+ * opaque alias name — into `"default" | "warning" | ...` for the table.
+ *
+ * Returns undefined when the schema is not a pure-literal enum (e.g. it mixes in
+ * `string`, `number`, or object members), so the caller can fall back to the
+ * printed type. vue-component-meta keys enum members by index in an object, so
+ * the natural ascending-key order of Object.values preserves declaration order.
+ */
+export function literalUnion(
+  schema: PropSchema | undefined,
+): string | undefined {
+  if (!schema || schema.kind !== "enum" || !schema.schema) return undefined;
+
+  const rawMembers = Array.isArray(schema.schema)
+    ? schema.schema
+    : Object.values(schema.schema);
+
+  const members = rawMembers
+    .filter((member): member is string => typeof member === "string")
+    .map((member) => member.trim())
+    .filter((member) => member && member !== "undefined");
+
+  const allLiteral = members.length > 0 && members.every(isLiteral);
+  return allLiteral ? members.join(" | ") : undefined;
+}
+
+/**
  * Removes the `| undefined` that vue-component-meta appends to every optional
  * prop's type. The table already conveys optionality (required props are
  * marked with `*`), so the marker is redundant noise.

--- a/packages/component-library/src/components/_internal/mt-base-field/mt-base-field.vue
+++ b/packages/component-library/src/components/_internal/mt-base-field/mt-base-field.vue
@@ -69,7 +69,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from "vue";
+import { defineComponent, type PropType } from "vue";
 import MtInheritanceSwitch from "../mt-inheritance-switch/mt-inheritance-switch.vue";
 import MtFieldCopyable from "../mt-field-copyable/mt-field-copyable.vue";
 import MtHelpText from "../../mt-help-text/mt-help-text.vue";
@@ -180,7 +180,7 @@ export default defineComponent({
      * @values small, default
      */
     size: {
-      type: String,
+      type: String as PropType<"small" | "default">,
       required: false,
       default: "default",
       validator(value: string) {

--- a/packages/component-library/src/components/_internal/mt-select-base/_internal/mt-select-result.vue
+++ b/packages/component-library/src/components/_internal/mt-select-base/_internal/mt-select-result.vue
@@ -25,7 +25,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from "vue";
+import { defineComponent, type PropType } from "vue";
 import MtIcon from "../../../mt-icon/mt-icon.vue";
 import { inject } from "vue";
 import {
@@ -62,7 +62,7 @@ export default defineComponent({
       default: false,
     },
     descriptionPosition: {
-      type: String,
+      type: String as PropType<"bottom" | "right">,
       required: false,
       default: "right",
       validator(value: string) {

--- a/packages/component-library/src/components/mt-number-field/mt-number-field.vue
+++ b/packages/component-library/src/components/mt-number-field/mt-number-field.vue
@@ -102,6 +102,24 @@ export default defineComponent({
 
   props: {
     /**
+     * The size of the number field.
+     *
+     * Redeclared from MtTextField: vue-component-meta cannot resolve a refined
+     * `PropType` through Vue's `extends`, so without this the docs would show
+     * the inherited `size` as a bare `string` instead of its literal values.
+     *
+     * @values small, default
+     */
+    size: {
+      type: String as PropType<"small" | "default">,
+      required: false,
+      default: "default",
+      validator(value: string) {
+        return ["small", "default"].includes(value);
+      },
+    },
+
+    /**
      * Defines if the number should be a floating point number or integer.
      */
     numberType: {

--- a/packages/component-library/src/components/mt-number-field/mt-number-field.vue
+++ b/packages/component-library/src/components/mt-number-field/mt-number-field.vue
@@ -101,12 +101,11 @@ export default defineComponent({
   extends: MtTextField,
 
   props: {
+    // Redeclared from MtTextField because vue-component-meta cannot resolve a
+    // refined PropType through Vue's `extends`; without this the API reference
+    // would show the inherited `size` as a bare `string` instead of its values.
     /**
      * The size of the number field.
-     *
-     * Redeclared from MtTextField: vue-component-meta cannot resolve a refined
-     * `PropType` through Vue's `extends`, so without this the docs would show
-     * the inherited `size` as a bare `string` instead of its literal values.
      *
      * @values small, default
      */

--- a/packages/component-library/src/components/mt-popover/mt-popover.vue
+++ b/packages/component-library/src/components/mt-popover/mt-popover.vue
@@ -85,7 +85,7 @@ export default defineComponent({
       default: false,
     },
     width: {
-      type: String as PropType<"auto" | "large" | "medium" | "small">,
+      type: String as PropType<"dynamic" | "large" | "medium" | "small">,
       required: false,
       default: "dynamic",
       validator: (value: string) => {

--- a/packages/component-library/src/components/mt-text-field/mt-text-field.vue
+++ b/packages/component-library/src/components/mt-text-field/mt-text-field.vue
@@ -115,7 +115,7 @@ export default defineComponent({
      * @values small, default
      */
     size: {
-      type: String,
+      type: String as PropType<"small" | "default">,
       required: false,
       default: "default",
       validator(value: string) {

--- a/packages/component-library/src/components/mt-unit-field/mt-unit-field.vue
+++ b/packages/component-library/src/components/mt-unit-field/mt-unit-field.vue
@@ -71,7 +71,7 @@ const props = withDefaults(
     disabled?: boolean;
     required?: boolean;
     name?: string;
-    size?: string;
+    size?: "small" | "default";
     helpText?: string;
     isInherited?: boolean;
     isInheritanceField?: boolean;


### PR DESCRIPTION
## Problem

The auto-generated API reference rendered enum-like props (e.g. `mt-number-field` `size`) as a bare `string` instead of their actual allowed values, because those props were declared with a broad runtime type (`type: String`).

## Changes

**Docs (rendering)**
- The prop table now prefers the resolved `schema`'s literal union over the printed `type`. This expands both named type aliases (e.g. `MtPopoverItemType` → `"default" | "critical" | "active"`) and literal enums into their real values, using vue-component-meta's own resolved schema (not fragile JSDoc parsing).
- `formatType.ts` gains a `literalUnion(schema)` helper; `ComponentApi.vue` uses `literalUnion(prop.schema) ?? formatType(prop.type)`; `component-meta.ts` gains the `PropSchema` type.

**Component library (source of truth)**
- Give the affected props real `PropType` unions so vue-component-meta can extract them: `mt-text-field` / `mt-base-field` `size`, `mt-select-result` `descriptionPosition`, `mt-unit-field` `size`.
- `mt-number-field` re-declares the inherited `size` — vue-component-meta cannot resolve a refined `PropType` through Vue's `extends`.
- Fix a drifted `mt-popover` `width` type (`"auto"` was listed but never a valid value; the real values are `dynamic | large | medium | small`).

## Notes
- No runtime behavior change; all edits are type-level plus the docs renderer.
- Verified: component-library + docs typecheck, lint, prettier all clean.