### PR TITLE
docs: add B2B Components icon usage

### DIFF
--- a/apps/docs/shared/data/iconCommonUsages.ts
+++ b/apps/docs/shared/data/iconCommonUsages.ts
@@ -19,6 +19,7 @@ export const iconCommonUsages: IconUsage[] = [
   { icon: "plug", label: "Extensions" },
   { icon: "cog", label: "Settings" },
   { icon: "storefront", label: "Sales Channels" },
+  { icon: "briefcase", label: "B2B Components" },
   { icon: "shopping-cart", label: "Shopping cart" },
   { icon: "heart", label: "Wishlist" },
   { icon: "search", label: "Search" },


### PR DESCRIPTION
Adds a "B2B Components" entry (briefcase icon) to the icon common usages list on the Icons page.

<img width="218" height="73" alt="image" src="https://github.com/user-attachments/assets/959cc88c-0725-4ba5-94c2-2cb0501573f8" />
