### PR TITLE
chore: add root dev command running docs and storybook together

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,21 @@ you can [request a feature](https://github.com/shopware/meteor/issues/new?templa
 
 ## Local development
 
+### Running Storybook and the documentation
+
+To work on the components themselves, start Storybook and the documentation site together from the repository root:
+
+```sh
+pnpm install
+pnpm dev
+```
+
+This runs Storybook on `http://localhost:6006` and the documentation on `http://localhost:3001` in parallel, each opening in your browser. While both run locally, the `Storybook` link on a component's documentation page and the `Documentation` link in Storybook point at these local instances instead of the deployed ones, so you can move between them while developing.
+
+To start just one of them, run `pnpm --filter @shopware-ag/meteor-component-library dev` for Storybook or `pnpm --filter meteor-docs dev` for the documentation.
+
+### Testing your changes in another project with yalc
+
 For local development we use `yalc` to publish packages into a virtual store and consume them from other projects.
 You can find yalc [here](https://github.com/wclr/yalc) on GitHub.
 To use your changes in Shopware and your extensions, you first build and publish the changed package, then add it to your project in a second step.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,17 @@ meteor/
     └── tokens                  # Design Tokens powering the Meteor Design System
 ```
 
+## Local development
+
+Install the dependencies and start Storybook and the documentation site together:
+
+```shell
+pnpm install
+pnpm dev
+```
+
+This serves Storybook on `http://localhost:6006` and the documentation on `http://localhost:3001`. See the [contribution guidelines](./CONTRIBUTING.md#local-development) for more ways to run the packages.
+
 ## Contribute to Meteor
 
 Pull requests are welcome. See the [contribution guidelines](./CONTRIBUTING.md) for more information.

--- a/apps/docs/app/components/DocsPageHeaderLinks.vue
+++ b/apps/docs/app/components/DocsPageHeaderLinks.vue
@@ -49,14 +49,20 @@ const componentSourceUrl = computed(() => {
   return `${github.url}/tree/${github.branch || "main"}/${path}`;
 });
 
+// Base URL of the Storybook to link to. During local development (`nuxt dev`)
+// point at the locally running Storybook (see the root `dev` script) so the
+// docs and Storybook link back and forth; otherwise use the deployed one.
+const storybookBaseUrl = computed(() => {
+  if (import.meta.dev) return "http://localhost:6006";
+  return (appConfig.storybook as { url?: string } | undefined)?.url;
+});
+
 // Link a component page to its Storybook entry. The docs slug matches the
 // Storybook id prefix (e.g. "data-table" -> components-data-table); Storybook
 // resolves that to the component's autodocs (or first story) automatically.
 const componentStorybookUrl = computed(() => {
-  if (!componentSlug.value) return undefined;
-  const storybook = appConfig.storybook as { url?: string } | undefined;
-  if (!storybook?.url) return undefined;
-  return `${storybook.url}/?path=/docs/components-${componentSlug.value}`;
+  if (!componentSlug.value || !storybookBaseUrl.value) return undefined;
+  return `${storybookBaseUrl.value}/?path=/docs/components-${componentSlug.value}`;
 });
 
 const items = computed(() => [

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "sync:changelog": "node scripts/sync-changelogs.mjs",
     "predev": "pnpm sync:changelog",
-    "dev": "nuxt dev --port 3001",
+    "dev": "nuxt dev --port 3001 --open",
     "prebuild": "pnpm sync:changelog",
     "build": "nuxt build",
     "pregenerate": "pnpm sync:changelog",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
   "keywords": [],
   "license": "MIT",
   "scripts": {
-    "validate:changesets": "node scripts/validate-changesets.js"
+    "validate:changesets": "node scripts/validate-changesets.js",
+    "predev": "pnpm --filter=meteor-docs sync:changelog",
+    "dev": "turbo run dev --filter=meteor-docs --filter=@shopware-ag/meteor-component-library"
   },
   "devDependencies": {
     "@changesets/cli": "2.29.8",

--- a/packages/component-library/.storybook/manager.js
+++ b/packages/component-library/.storybook/manager.js
@@ -4,7 +4,13 @@ import { IconButton } from "@storybook/components";
 import { ShareAltIcon } from "@storybook/icons";
 import { shopwareTheme } from "./shopwareTheme";
 
-const DOCS_BASE_URL = "https://meteor.shopware.com";
+// When Storybook is served from localhost (local development) the Documentation
+// button points at the locally running docs app (see the root `dev` script)
+// instead of production, so the two link back and forth while developing.
+const DOCS_BASE_URL =
+  typeof window !== "undefined" && ["localhost", "127.0.0.1"].includes(window.location.hostname)
+    ? "http://localhost:3001"
+    : "https://meteor.shopware.com";
 
 // Map the active Storybook entry to its page on the docs site. Component titles follow
 // "Components/<Name>" and the docs URL uses the kebab-cased name, e.g.

--- a/packages/component-library/README.md
+++ b/packages/component-library/README.md
@@ -66,6 +66,8 @@ pnpm install
 pnpm run storybook
 ```
 
+To run Storybook and the documentation site together, use `pnpm dev` from the repository root instead. See the [contribution guidelines](../../CONTRIBUTING.md#running-storybook-and-the-documentation) for details.
+
 #### Compiles and minifies for production
 
 ```shell

--- a/packages/component-library/package.json
+++ b/packages/component-library/package.json
@@ -54,6 +54,7 @@
     "lint:css:fix": "stylelint \"src/**/*.vue\" --fix",
     "format:check": "prettier . --check",
     "format": "prettier --write .",
+    "dev": "npm run storybook",
     "storybook": "storybook dev -p 6006",
     "build:storybook": "storybook build",
     "test:storybook": "test-storybook",


### PR DESCRIPTION
## What

Adds a single `pnpm dev` at the repo root that runs the docs app and the component-library Storybook together, and makes their cross-links point at the local instances while developing.

## Details

- **`pnpm dev`** runs both dev servers in parallel via Turbo:
  - Docs: `http://localhost:3001`
  - Storybook: `http://localhost:6006`
  - Both auto-open a browser tab; Turbo prefixes their output and tears both down on Ctrl+C. Turbo's `^build` builds the component-library first (cached), and a root `predev` runs the docs changelog sync.
- **Dev-aware cross-links** (production builds unchanged):
  - The docs "Storybook" button targets `localhost:6006` under `nuxt dev` (via `import.meta.dev`).
  - Storybook's "Documentation" button targets `localhost:3001` when served from `localhost`/`127.0.0.1`.

## Notes

- Ports are fixed (docs 3001, Storybook 6006), matching the existing scripts.
- A `dev` script was added to the component-library (aliases `storybook`) so Turbo can target it.
- No changeset: dev-tooling only, no published package behavior change.