### PR TITLE
feat: add theme switching component and expose admin theme to iframe apps

### DIFF
--- a/.changeset/admin-sdk-theme.md
+++ b/.changeset/admin-sdk-theme.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-admin-sdk": minor
+---
+
+Apps now follow the Administration color theme automatically: on startup the SDK mirrors the resolved theme onto the document root's `data-theme` attribute and keeps it in sync, so theme-aware styles (e.g. Meteor tokens) work without any app code changes. Apps that declare `data-theme` themselves are left untouched. For explicit control, the Context API exposes `context.getTheme()`, `context.subscribeTheme()`, and `context.syncTheme()`.

--- a/.changeset/theme-select-color-scheme.md
+++ b/.changeset/theme-select-color-scheme.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": minor
+---
+
+Add the `mt-theme-select` component for choosing the application color theme (light, dark, or system) and the `useTheme` composable that resolves the system preference, applies the resolved theme to `data-theme`, and persists the choice.

--- a/apps/docs/app/components/content/examples/theme-select/ThemeSelectBasicExample.vue
+++ b/apps/docs/app/components/content/examples/theme-select/ThemeSelectBasicExample.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+import { ref } from "vue";
+import MtThemeSelect from "@shopware-ag/meteor-component-library/MtThemeSelect";
+import type { Theme } from "@shopware-ag/meteor-component-library";
+
+const theme = ref<Theme>("system");
+</script>
+
+<template>
+  <mt-theme-select v-model="theme" label="Color theme" />
+</template>

--- a/apps/docs/app/components/content/examples/theme-select/ThemeSelectUseThemeExample.vue
+++ b/apps/docs/app/components/content/examples/theme-select/ThemeSelectUseThemeExample.vue
@@ -1,0 +1,21 @@
+<script setup lang="ts">
+import MtThemeSelect from "@shopware-ag/meteor-component-library/MtThemeSelect";
+import MtText from "@shopware-ag/meteor-component-library/MtText";
+// useTheme has no subpath export, so it is imported from the barrel.
+import { useTheme } from "@shopware-ag/meteor-component-library";
+
+// Persistence and global application are disabled so the docs page itself
+// stays untouched. Omit these options in your app.
+const { theme, resolvedTheme } = useTheme({
+  storageKey: null,
+  applyToTarget: false,
+});
+</script>
+
+<template>
+  <div style="display: flex; flex-direction: column; gap: 16px">
+    <mt-theme-select v-model="theme" label="Color theme" />
+
+    <mt-text>Resolved theme: {{ resolvedTheme }}</mt-text>
+  </div>
+</template>

--- a/apps/docs/content/2.components/theme-select.md
+++ b/apps/docs/content/2.components/theme-select.md
@@ -1,0 +1,62 @@
+---
+title: Theme Select
+description: A select control for choosing the application color theme, either light, dark, or following the system preference.
+---
+
+::component-example{name="theme-select-basic-example" fullWidth}
+::
+
+## Usage
+
+**Theme Select** lets users choose the application color theme: light, dark, or following the operating system preference. Use it in settings screens, profile pages, or anywhere a theme preference belongs. It is a controlled component: it only reports the chosen theme through `v-model` and does not apply or persist the theme itself, which keeps the host application in charge of how the choice takes effect.
+
+```ts
+import { MtThemeSelect } from "@shopware-ag/meteor-component-library";
+```
+
+## Examples
+
+### Pairing with useTheme
+
+The [**useTheme**](/utilities/composables/use-theme) composable resolves the `system` option against `prefers-color-scheme`, applies the resolved value as `data-theme`, and persists the choice. Binding its `theme` ref to the select is all a typical app needs.
+
+::component-example{name="theme-select-use-theme-example" fullWidth}
+::
+
+## API reference
+
+:component-api
+
+## Best practices
+
+::do-dont{vertical}
+#do
+
+- Default to `system` so the application respects the operating system preference.
+- Pair the select with [**useTheme**](/utilities/composables/use-theme) so the choice is applied and persisted consistently.
+- Give the field a label that describes the setting, such as `Color theme` or `Appearance`.
+
+#dont
+
+- Do not use **Theme Select** for unrelated multi-option settings; it is purpose-built for color themes.
+- Do not apply the theme from multiple places at once. Keep one owner for the `data-theme` attribute.
+
+::
+
+## Behavior
+
+- **Theme Select** accepts and emits one of three values through `modelValue`: `"light"`, `"dark"`, or `"system"`, and defaults to `"system"`.
+- The component is purely presentational. Resolving `system`, writing `data-theme`, and persisting the choice is the host's responsibility, which [**useTheme**](/utilities/composables/use-theme) handles out of the box.
+- Option labels are localized (English and German) through the library's i18n setup.
+- Additional [**Select**](/components/select) props such as `small` or `error` fall through to the underlying select.
+
+## Accessibility
+
+- Keyboard and screen reader behavior follow the underlying [**Select**](/components/select) component.
+- Each option is labelled with text, so the choice never relies on color or iconography.
+- Provide a visible `label` so the setting is announced with its purpose.
+
+## Related components
+
+- [**Select**](/components/select): the general-purpose select this component builds on, for arbitrary option sets.
+- [**useTheme**](/utilities/composables/use-theme): the composable that resolves, applies, and persists the theme this component selects.

--- a/apps/docs/content/3.utilities/composables/use-theme.md
+++ b/apps/docs/content/3.utilities/composables/use-theme.md
@@ -1,0 +1,58 @@
+---
+title: useTheme
+description: A composable for managing the application color theme, resolving the system preference, and persisting the choice.
+---
+
+::component-example{name="theme-select-use-theme-example" fullWidth}
+::
+
+## Usage
+
+`useTheme` manages the application color theme. It tracks the user's preference (`light`, `dark`, or `system`), resolves `system` against the operating system via `prefers-color-scheme`, writes the resolved value to a target element's `data-theme` attribute (the document root by default), and persists the choice to `localStorage`. Bind the returned `theme` ref to [**Theme Select**](/components/theme-select) with `v-model` to let users control it.
+
+```ts
+import { useTheme } from "@shopware-ag/meteor-component-library";
+
+const { theme, resolvedTheme, setTheme, stop } = useTheme();
+```
+
+The preference is shared: instances using the same `storageKey` stay in sync within the document and across browser tabs.
+
+## API
+
+### Options
+
+`useTheme(options?)` accepts:
+
+| Option | Type | Description |
+| --- | --- | --- |
+| `storageKey` | `string \| null` | The `localStorage` key used to persist the preference. Defaults to `"mt-theme"`. Set it to `null` to disable persistence. |
+| `target` | `HTMLElement` | The element whose `data-theme` attribute is kept in sync with the resolved theme. Defaults to `document.documentElement`. |
+| `defaultTheme` | `"light" \| "dark" \| "system"` | The preference used when nothing has been persisted yet. Defaults to `"system"`. |
+| `applyToTarget` | `boolean` | Whether to write the resolved theme to the target's `data-theme` attribute. Defaults to `true`. Disable it when the host applies the theme itself. |
+
+### Return value
+
+| Member | Type | Description |
+| --- | --- | --- |
+| `theme` | `Ref<Theme>` | The user's preference: `"light"`, `"dark"`, or `"system"`. Writable; bind it to [**Theme Select**](/components/theme-select) with `v-model`. |
+| `resolvedTheme` | `ComputedRef<ResolvedTheme>` | The applied theme after resolving `"system"`: `"light"` or `"dark"`. |
+| `setTheme` | `(theme: Theme) => void` | Sets the preference programmatically. |
+| `stop` | `() => void` | Releases all listeners. Called automatically on scope disposal when used inside a component or `effectScope`; call it manually when using the composable outside of an active scope. |
+
+### Types
+
+```ts
+type Theme = "light" | "dark" | "system";
+type ResolvedTheme = "light" | "dark";
+```
+
+## Behavior
+
+- While the preference is `system`, `resolvedTheme` updates live when the operating system preference changes.
+- Invalid persisted values are ignored and fall back to `defaultTheme`.
+- Meteor tokens are theme-aware through `data-theme`, so applying the resolved theme to the document root themes every Meteor component on the page.
+
+## Related components
+
+- [**Theme Select**](/components/theme-select): the select component built for choosing the theme this composable manages.

--- a/docs/admin-sdk/api-reference/context.md
+++ b/docs/admin-sdk/api-reference/context.md
@@ -7,7 +7,7 @@ sidebar_position: 40
 
 The Context API provides read access to the current state of the Shopware Administration. Extensions can use these methods to retrieve information about the active language, locale, currency, environment, Shopware version, and more.
 
-This is useful for adapting extension behavior based on the current Administration context — for example, loading translations for the active language or checking the Shopware version before using a newer API.
+This is useful for adapting extension behavior based on the current Administration context — for example, loading translations for the active language, matching the active color theme, or checking the Shopware version before using a newer API.
 
 ```ts
 import { context } from "@shopware-ag/meteor-admin-sdk";
@@ -174,6 +174,92 @@ context.subscribeLocale(({ locale, fallbackLocale }) => {
   fallbackLocale: 'en-GB'
 }
 ```
+
+## Automatic theme synchronization
+
+On startup, the SDK mirrors the resolved Administration theme onto the `data-theme` attribute of your document root (`<html data-theme="light|dark">`) and keeps it in sync. Because Meteor tokens are theme-aware through `data-theme`, updating the SDK dependency is all an app needs to follow the Administration theme.
+
+If your document already declares `data-theme` itself, the SDK does not interfere. On Administrations without theme support, the attribute is never set.
+
+## getTheme()
+
+Returns the current resolved color theme of the Administration. A `system` preference is always resolved, so the result is either `"light"` or `"dark"`.
+
+#### Usage
+
+```ts
+const theme = await context.getTheme();
+```
+
+#### Parameters
+
+No parameters needed.
+
+#### Return value
+
+```ts
+Promise<"light" | "dark">
+```
+
+#### Example value
+
+```ts
+"dark";
+```
+
+## subscribeTheme()
+
+Subscribes to theme changes in the Administration. The callback fires whenever the resolved theme changes. Returns a function that stops the subscription.
+
+#### Usage
+
+```ts
+context.subscribeTheme((theme) => {
+  // do something with the callback data
+});
+```
+
+#### Parameters
+
+| Name             | Description                                  |
+| :--------------- | :------------------------------------------- |
+| `callbackMethod` | Called every time the resolved theme changes |
+
+#### Callback value
+
+```ts
+"light" | "dark"
+```
+
+#### Example callback value
+
+```ts
+"dark";
+```
+
+## syncTheme()
+
+Mirrors the Administration theme onto an element's `data-theme` attribute and keeps it in sync. The document root is already handled by the [automatic theme synchronization](#automatic-theme-synchronization); use this when you manage `data-theme` yourself or need the attribute on additional elements.
+
+#### Usage
+
+```ts
+const stopSync = await context.syncTheme({ target: document.getElementById("app") });
+```
+
+#### Parameters
+
+| Name             | Description                                                                             |
+| :--------------- | :-------------------------------------------------------------------------------------- |
+| `options.target` | Element whose `data-theme` attribute is updated. Defaults to `document.documentElement` |
+
+#### Return value
+
+```ts
+Promise<() => void>
+```
+
+The returned function stops the synchronization.
 
 ## getCurrency()
 

--- a/packages/admin-sdk/src/channel.ts
+++ b/packages/admin-sdk/src/channel.ts
@@ -570,7 +570,68 @@ const datasets = new Map<string, unknown>();
   await send('__registerWindow__', {
     sdkVersion: packageVersion,
   });
+
+  // Mirror the Administration theme onto app iframes (the admin owns its own document)
+  if (window.parent !== window) {
+    startAutoThemeSync();
+  }
 })().catch((e) => console.error(e));
+
+function isThemeValue(value: unknown): value is 'light' | 'dark' {
+  return value === 'light' || value === 'dark';
+}
+
+/**
+ * Keeps the `data-theme` attribute of `target` in sync with the resolved
+ * Administration color theme
+ *
+ * @internal - used by the automatic sync below and `context.syncTheme()`
+ */
+export function startThemeSync(target: HTMLElement): { initialFetch: Promise<void>, stop: () => void } {
+  let hasReceivedUpdate = false;
+
+  // Subscribe before fetching so an in-flight change cannot slip through unobserved
+  const stop = subscribe('contextTheme', (theme) => {
+    if (!isThemeValue(theme)) {
+      return;
+    }
+
+    hasReceivedUpdate = true;
+    target.dataset.theme = theme;
+  });
+
+  const initialFetch = send('contextTheme', {}).then((theme) => {
+    // A theme published in the meantime is newer than the fetched value
+    if (!hasReceivedUpdate && isThemeValue(theme)) {
+      target.dataset.theme = theme;
+    }
+  });
+
+  return { initialFetch, stop };
+}
+
+/**
+ * Starts the theme sync on the document root inside app iframes. Skipped
+ * when the document declares `data-theme` itself (the app owns its theme)
+ *
+ * @internal - apps that need explicit control use `context.syncTheme()`
+ */
+export function startAutoThemeSync(): () => void {
+  const target = document.documentElement;
+
+  if (target.dataset.theme) {
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    return () => {};
+  }
+
+  const { initialFetch, stop } = startThemeSync(target);
+
+  // Fails silently: older Administrations have no contextTheme handler
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  initialFetch.catch(() => {});
+
+  return stop;
+}
 
 // New dataset registered
 export async function processDataRegistration(data: Omit<datasetRegistration, 'responseType'>): Promise<void> {

--- a/packages/admin-sdk/src/context/index.ts
+++ b/packages/admin-sdk/src/context/index.ts
@@ -1,4 +1,4 @@
-import { createSender, createSubscriber } from '../channel';
+import { createSender, createSubscriber, startThemeSync } from '../channel';
 import getCompareIsShopwareVersion from './compare-version';
 import createACLHelper from './acl';
 import type { privileges } from '../_internals/privileges';
@@ -17,6 +17,27 @@ export const getAppInformation = createSender('contextAppInformation', {});
 export const can = createACLHelper(getAppInformation);
 export const getModuleInformation = createSender('contextModuleInformation', {});
 export const getShopId = createSender('contextShopId', {});
+export const getTheme = createSender('contextTheme', {});
+export const subscribeTheme = createSubscriber('contextTheme');
+
+/**
+ * Syncs the resolved Administration color theme to the `data-theme` attribute
+ * of an element (the document root by default). Returns a function that stops
+ * the synchronization.
+ */
+export async function syncTheme(options: { target?: HTMLElement } = {}): Promise<() => void> {
+  const { initialFetch, stop } = startThemeSync(options.target ?? document.documentElement);
+
+  try {
+    await initialFetch;
+  } catch (error) {
+    stop();
+
+    throw error;
+  }
+
+  return stop;
+}
 
 /**
  * Get the current content language
@@ -122,4 +143,12 @@ export type contextModuleInformation = {
 
 export type contextShopId = {
   responseType: string|null,
+}
+
+/**
+ * Get the resolved color theme (a `system` preference is always resolved
+ * to `light` or `dark`)
+ */
+export type contextTheme = {
+  responseType: 'light' | 'dark',
 }

--- a/packages/admin-sdk/src/context/theme.spec.ts
+++ b/packages/admin-sdk/src/context/theme.spec.ts
@@ -1,0 +1,237 @@
+import flushPromises from 'flush-promises';
+import type { handle as handleType, publish as publishType, startAutoThemeSync as startAutoThemeSyncType } from '../channel';
+import type { getTheme as getThemeType, subscribeTheme as subscribeThemeType, syncTheme as syncThemeType } from './index';
+
+let handle: typeof handleType;
+let publish: typeof publishType;
+let startAutoThemeSync: typeof startAutoThemeSyncType;
+let getTheme: typeof getThemeType;
+let subscribeTheme: typeof subscribeThemeType;
+let syncTheme: typeof syncThemeType;
+
+// Track handlers so a failing assertion cannot leak listeners into the next test
+const cleanups: Array<() => void> = [];
+function track(remove: () => void): () => void {
+  cleanups.push(remove);
+
+  return remove;
+}
+
+describe('context theme', () => {
+  beforeAll(async () => {
+    window.addEventListener('message', (event: MessageEvent) => {
+      if (event.origin === '') {
+        event.stopImmediatePropagation();
+        const eventWithOrigin: MessageEvent = new MessageEvent('message', {
+          data: event.data,
+          origin: window.location.href,
+        });
+        window.dispatchEvent(eventWithOrigin);
+      }
+    });
+
+    const channel = await import('../channel');
+    handle = channel.handle;
+    publish = channel.publish;
+    startAutoThemeSync = channel.startAutoThemeSync;
+
+    const context = await import('./index');
+    getTheme = context.getTheme;
+    subscribeTheme = context.subscribeTheme;
+    syncTheme = context.syncTheme;
+  });
+
+  afterEach(() => {
+    cleanups.splice(0).forEach((remove) => remove());
+    delete document.documentElement.dataset.theme;
+  });
+
+  it('gets the current resolved theme', async () => {
+    track(handle('contextTheme', () => 'dark' as const));
+
+    await expect(getTheme()).resolves.toBe('dark');
+  });
+
+  it('notifies subscribers about theme changes', async () => {
+    const receivedThemes: Array<'light' | 'dark'> = [];
+    track(subscribeTheme((value) => {
+      receivedThemes.push(value);
+    }));
+
+    publish('contextTheme', 'dark');
+    await flushPromises();
+
+    publish('contextTheme', 'light');
+    await flushPromises();
+
+    expect(receivedThemes).toEqual(['dark', 'light']);
+  });
+
+  it('stops notifying after unsubscribing', async () => {
+    const subscriber = jest.fn();
+    const unsubscribe = track(subscribeTheme(subscriber));
+
+    publish('contextTheme', 'dark');
+    await flushPromises();
+    expect(subscriber).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
+
+    publish('contextTheme', 'light');
+    await flushPromises();
+    expect(subscriber).toHaveBeenCalledTimes(1);
+  });
+
+  it('syncs the resolved theme to the document root and keeps it in sync', async () => {
+    track(handle('contextTheme', () => 'dark' as const));
+
+    track(await syncTheme());
+    expect(document.documentElement.dataset.theme).toBe('dark');
+
+    publish('contextTheme', 'light');
+    await flushPromises();
+    expect(document.documentElement.dataset.theme).toBe('light');
+  });
+
+  it('syncs the theme to a custom target element', async () => {
+    track(handle('contextTheme', () => 'light' as const));
+    const target = document.createElement('div');
+
+    track(await syncTheme({ target }));
+
+    expect(target.dataset.theme).toBe('light');
+    expect(document.documentElement.dataset.theme).toBeUndefined();
+  });
+
+  it('stops updating the target after the sync is stopped', async () => {
+    track(handle('contextTheme', () => 'dark' as const));
+
+    const stopSync = track(await syncTheme());
+    expect(document.documentElement.dataset.theme).toBe('dark');
+
+    stopSync();
+
+    publish('contextTheme', 'light');
+    await flushPromises();
+    expect(document.documentElement.dataset.theme).toBe('dark');
+  });
+
+  it('does not overwrite a newer published theme with a stale initial value', async () => {
+    // Delay the response so a change can be published while the fetch is in flight
+    let resolveInitialFetch: (value: 'light') => void = () => {};
+    track(handle('contextTheme', () => new Promise<'light'>((resolve) => {
+      resolveInitialFetch = resolve;
+    })));
+
+    const syncPromise = syncTheme();
+    await flushPromises();
+
+    publish('contextTheme', 'dark');
+    await flushPromises();
+    expect(document.documentElement.dataset.theme).toBe('dark');
+
+    resolveInitialFetch('light');
+    track(await syncPromise);
+
+    expect(document.documentElement.dataset.theme).toBe('dark');
+  });
+
+  it('ignores published values that are not a valid theme', async () => {
+    track(handle('contextTheme', () => 'dark' as const));
+
+    track(await syncTheme());
+    expect(document.documentElement.dataset.theme).toBe('dark');
+
+    publish('contextTheme', 'not-a-theme' as unknown as 'light');
+    await flushPromises();
+
+    expect(document.documentElement.dataset.theme).toBe('dark');
+  });
+
+  it('rejects and unsubscribes when no Administration answers the initial fetch', async () => {
+    jest.useFakeTimers();
+
+    try {
+      const syncPromise = syncTheme();
+      const rejection = expect(syncPromise).rejects.toMatch('Send timeout expired');
+
+      // No contextTheme handler is registered, so the request runs into the channel timeout
+      jest.advanceTimersByTime(8000);
+      await rejection;
+    } finally {
+      jest.useRealTimers();
+    }
+
+    // The failed sync must not leave a subscription behind
+    publish('contextTheme', 'dark');
+    await flushPromises();
+    expect(document.documentElement.dataset.theme).toBeUndefined();
+  });
+
+  describe('automatic theme sync (zero-config in app iframes)', () => {
+    it('applies the current theme to the document root without any app code', async () => {
+      track(handle('contextTheme', () => 'dark' as const));
+
+      track(startAutoThemeSync());
+      // Two flushes: the request and the response are separate message tasks
+      await flushPromises();
+      await flushPromises();
+
+      expect(document.documentElement.dataset.theme).toBe('dark');
+    });
+
+    it('follows theme changes published by the Administration', async () => {
+      track(handle('contextTheme', () => 'dark' as const));
+      track(startAutoThemeSync());
+      await flushPromises();
+
+      publish('contextTheme', 'light');
+      await flushPromises();
+
+      expect(document.documentElement.dataset.theme).toBe('light');
+    });
+
+    it('does not overwrite a newer published theme with a stale initial value', async () => {
+      let resolveInitialFetch: (value: 'light') => void = () => {};
+      track(handle('contextTheme', () => new Promise<'light'>((resolve) => {
+        resolveInitialFetch = resolve;
+      })));
+
+      track(startAutoThemeSync());
+      await flushPromises();
+
+      publish('contextTheme', 'dark');
+      await flushPromises();
+      expect(document.documentElement.dataset.theme).toBe('dark');
+
+      resolveInitialFetch('light');
+      await flushPromises();
+
+      expect(document.documentElement.dataset.theme).toBe('dark');
+    });
+
+    it('does not interfere when the app manages its own data-theme attribute', async () => {
+      document.documentElement.dataset.theme = 'light';
+      track(handle('contextTheme', () => 'dark' as const));
+
+      track(startAutoThemeSync());
+      await flushPromises();
+
+      publish('contextTheme', 'dark');
+      await flushPromises();
+
+      expect(document.documentElement.dataset.theme).toBe('light');
+    });
+
+    it('ignores published values that are not a valid theme', async () => {
+      track(handle('contextTheme', () => 'dark' as const));
+      track(startAutoThemeSync());
+      await flushPromises();
+
+      publish('contextTheme', 'not-a-theme' as unknown as 'light');
+      await flushPromises();
+
+      expect(document.documentElement.dataset.theme).toBe('dark');
+    });
+  });
+});

--- a/packages/admin-sdk/src/message-types.ts
+++ b/packages/admin-sdk/src/message-types.ts
@@ -12,6 +12,7 @@ import type {
   contextUserInformation,
   contextUserTimezone,
   contextShopId,
+  contextTheme,
 } from './context';
 import type { uiComponentSectionRenderer } from './ui/component-section/index';
 import type { uiTabsAddTabItem } from './ui/tabs';
@@ -71,6 +72,7 @@ export interface ShopwareMessageTypes {
   contextAppInformation: contextAppInformation,
   contextModuleInformation: contextModuleInformation,
   contextShopId: contextShopId,
+  contextTheme: contextTheme,
   getPageTitle: getPageTitle,
   uiComponentSectionRenderer: uiComponentSectionRenderer,
   uiTabsAddTabItem: uiTabsAddTabItem,

--- a/packages/component-library/src/components/mt-theme-select/mt-theme-select.interactive.stories.ts
+++ b/packages/component-library/src/components/mt-theme-select/mt-theme-select.interactive.stories.ts
@@ -1,0 +1,40 @@
+import { within, userEvent, expect } from "@storybook/test";
+
+import meta, { type MtThemeSelectMeta, type MtThemeSelectStory } from "./mt-theme-select.stories";
+
+export default {
+  ...meta,
+  title: "Components/Theme Select/Interaction tests",
+  tags: ["!autodocs"],
+} as MtThemeSelectMeta;
+
+export const TestSelectTheme: MtThemeSelectStory = {
+  name: "Should select a color theme",
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(canvas.getByRole("textbox"));
+
+    const popover = within(
+      document.querySelector(".mt-popover-deprecated__wrapper") as HTMLElement,
+    );
+    await userEvent.click(popover.getByTestId("mt-select-option--dark"));
+
+    expect(args["onUpdate:modelValue"]).toHaveBeenCalledWith("dark");
+    expect(canvas.getByRole("textbox")).toHaveValue("Dark");
+  },
+};
+
+export const TestDisabledSelect: MtThemeSelectStory = {
+  name: "Should not open the result list when disabled",
+  args: {
+    disabled: true,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(canvas.getByRole("textbox"));
+
+    expect(document.querySelector(".mt-select-result-list__content")).toBeNull();
+  },
+};

--- a/packages/component-library/src/components/mt-theme-select/mt-theme-select.spec.ts
+++ b/packages/component-library/src/components/mt-theme-select/mt-theme-select.spec.ts
@@ -1,0 +1,82 @@
+import { render, screen } from "@testing-library/vue";
+import { userEvent } from "@testing-library/user-event";
+import MtThemeSelect from "./mt-theme-select.vue";
+
+describe("mt-theme-select", () => {
+  it("shows the label of the selected color theme", async () => {
+    // ARRANGE
+    render(MtThemeSelect, {
+      props: {
+        modelValue: "dark",
+      },
+    });
+
+    // ASSERT
+    expect(screen.getByRole("textbox")).toHaveValue("Dark");
+  });
+
+  it("defaults to the system color theme", async () => {
+    // ARRANGE
+    render(MtThemeSelect);
+
+    // ASSERT
+    expect(screen.getByRole("textbox")).toHaveValue("System");
+  });
+
+  it("offers light, dark and system as options", async () => {
+    // ARRANGE
+    render(MtThemeSelect);
+
+    // ACT
+    await userEvent.click(screen.getByRole("textbox"));
+
+    // ASSERT
+    expect(screen.getByTestId("mt-select-option--light")).toBeVisible();
+    expect(screen.getByTestId("mt-select-option--dark")).toBeVisible();
+    expect(screen.getByTestId("mt-select-option--system")).toBeVisible();
+  });
+
+  it("emits the selected color theme", async () => {
+    // ARRANGE
+    const handler = vi.fn();
+
+    render(MtThemeSelect, {
+      props: {
+        modelValue: "system",
+        "onUpdate:modelValue": handler,
+      },
+    });
+
+    // ACT
+    await userEvent.click(screen.getByRole("textbox"));
+    await userEvent.click(screen.getByTestId("mt-select-option--dark"));
+
+    // ASSERT
+    expect(handler).toHaveBeenCalledOnce();
+    expect(handler).toHaveBeenCalledWith("dark");
+  });
+
+  it("renders the field label", async () => {
+    // ARRANGE
+    render(MtThemeSelect, {
+      props: {
+        label: "Color theme",
+      },
+    });
+
+    // ASSERT
+    expect(screen.getByText("Color theme")).toBeInTheDocument();
+  });
+
+  it("disables the select field", async () => {
+    // ARRANGE
+    render(MtThemeSelect, {
+      props: {
+        disabled: true,
+      },
+    });
+
+    // ASSERT
+    expect(screen.getByRole("textbox")).toBeDisabled();
+  });
+});

--- a/packages/component-library/src/components/mt-theme-select/mt-theme-select.stories.ts
+++ b/packages/component-library/src/components/mt-theme-select/mt-theme-select.stories.ts
@@ -1,0 +1,123 @@
+import MtThemeSelect from "./mt-theme-select.vue";
+import type { Meta, StoryObj } from "@storybook/vue3";
+import { fn } from "@storybook/test";
+import { ref, watch } from "vue";
+import { useTheme } from "@/composables/useTheme";
+
+export type MtThemeSelectMeta = Meta<typeof MtThemeSelect>;
+
+export default {
+  title: "Components/Theme Select",
+  component: MtThemeSelect,
+  args: {
+    label: "Color theme",
+    modelValue: "system",
+    "onUpdate:modelValue": fn(),
+  },
+  argTypes: {
+    modelValue: {
+      control: "select",
+      options: ["light", "dark", "system"],
+    },
+  },
+  render: (args) => ({
+    components: { MtThemeSelect },
+    setup() {
+      const model = ref(args.modelValue);
+      watch(
+        () => args.modelValue,
+        (value) => {
+          model.value = value;
+        },
+      );
+
+      return { args, model };
+    },
+    template: `<mt-theme-select
+      v-model="model"
+      :label="args.label"
+      :disabled="args.disabled"
+      @update:model-value="args['onUpdate:modelValue']"
+    />`,
+  }),
+} as MtThemeSelectMeta;
+
+export type MtThemeSelectStory = StoryObj<MtThemeSelectMeta>;
+
+export const Default: MtThemeSelectStory = {
+  parameters: {
+    docs: {
+      source: {
+        language: "html",
+        code: `<mt-theme-select v-model="theme" label="Color theme" />`,
+      },
+    },
+  },
+};
+
+export const Disabled: MtThemeSelectStory = {
+  args: {
+    disabled: true,
+  },
+  parameters: {
+    docs: {
+      source: {
+        language: "html",
+        code: `<mt-theme-select v-model="theme" label="Color theme" disabled />`,
+      },
+    },
+  },
+};
+
+/**
+ * Pair the select with the `useTheme` composable to resolve the
+ * `system` option against the operating system preference, apply the
+ * resolved value as `data-theme`, and persist the choice. In this story the
+ * resolved theme is scoped to the preview box instead of the whole document.
+ */
+export const WithUseTheme: MtThemeSelectStory = {
+  render: (args) => ({
+    components: { MtThemeSelect },
+    setup() {
+      const { theme, resolvedTheme } = useTheme({
+        storageKey: null,
+        applyToTarget: false,
+      });
+
+      return { args, theme, resolvedTheme };
+    },
+    template: `<div style="display: flex; flex-direction: column; gap: 24px;">
+      <mt-theme-select v-model="theme" :label="args.label" />
+
+      <div
+        :data-theme="resolvedTheme"
+        style="
+          padding: 24px;
+          border-radius: var(--border-radius-overlay);
+          border: 1px solid var(--color-border-primary-default);
+          background: var(--color-elevation-surface-default);
+          color: var(--color-text-primary-default);
+        "
+      >
+        Resolved theme: {{ resolvedTheme }}
+      </div>
+    </div>`,
+  }),
+  parameters: {
+    docs: {
+      source: {
+        language: "html",
+        code: `<script setup>
+import { MtThemeSelect, useTheme } from "@shopware-ag/meteor-component-library";
+
+// Resolves "system", applies data-theme to the document root, and persists.
+const { theme } = useTheme();
+</script>
+
+<template>
+  <mt-theme-select v-model="theme" label="Color theme" />
+</template>`,
+      },
+    },
+  },
+};

--- a/packages/component-library/src/components/mt-theme-select/mt-theme-select.vue
+++ b/packages/component-library/src/components/mt-theme-select/mt-theme-select.vue
@@ -1,0 +1,60 @@
+<template>
+  <mt-select
+    class="mt-theme-select"
+    :model-value="model"
+    :options="options"
+    :label="label"
+    :disabled="disabled"
+    hide-clearable-button
+    @update:model-value="onSelect"
+  />
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+import { useI18n } from "vue-i18n";
+import MtSelect from "../mt-select/mt-select.vue";
+import type { Theme } from "@/composables/useTheme";
+
+const model = defineModel<Theme>({ default: "system" });
+
+defineProps<{
+  /**
+   * The label for the select field itself.
+   */
+  label?: string;
+  /**
+   * Disables the select field.
+   */
+  disabled?: boolean;
+}>();
+
+const { t } = useI18n({
+  messages: {
+    en: {
+      light: "Light",
+      dark: "Dark",
+      system: "System",
+    },
+    de: {
+      light: "Hell",
+      dark: "Dunkel",
+      system: "System",
+    },
+  },
+});
+
+const options = computed<{ value: Theme; label: string }[]>(() => [
+  { value: "light", label: t("light") },
+  { value: "dark", label: t("dark") },
+  { value: "system", label: t("system") },
+]);
+
+function isTheme(value: unknown): value is Theme {
+  return value === "light" || value === "dark" || value === "system";
+}
+
+function onSelect(value: unknown): void {
+  if (isTheme(value)) model.value = value;
+}
+</script>

--- a/packages/component-library/src/composables/useTheme.spec.ts
+++ b/packages/component-library/src/composables/useTheme.spec.ts
@@ -1,0 +1,248 @@
+import { effectScope, nextTick } from "vue";
+import { useTheme } from "./useTheme";
+
+type MediaListener = (event: MediaQueryListEvent) => void;
+
+function mockMatchMedia(initialDark: boolean) {
+  const listeners = new Set<MediaListener>();
+  const mediaQueryList = {
+    matches: initialDark,
+    media: "(prefers-color-scheme: dark)",
+    onchange: null,
+    addEventListener: (_type: string, listener: MediaListener) => listeners.add(listener),
+    removeEventListener: (_type: string, listener: MediaListener) => listeners.delete(listener),
+    dispatchEvent: () => true,
+  };
+
+  vi.stubGlobal("matchMedia", vi.fn().mockReturnValue(mediaQueryList));
+
+  return {
+    listeners,
+    emit(matches: boolean) {
+      mediaQueryList.matches = matches;
+      listeners.forEach((listener) => listener({ matches } as MediaQueryListEvent));
+    },
+  };
+}
+
+/** Runs the composable inside an effect scope so auto-cleanup can be tested. */
+function withScope<T>(setup: () => T): { result: T; dispose: () => void } {
+  const scope = effectScope();
+  const result = scope.run(setup) as T;
+
+  return { result, dispose: () => scope.stop() };
+}
+
+function createLocalStorageMock(): Storage {
+  const store = new Map<string, string>();
+
+  return {
+    getItem: (key) => store.get(key) ?? null,
+    setItem: (key, value) => void store.set(key, String(value)),
+    removeItem: (key) => void store.delete(key),
+    clear: () => store.clear(),
+    key: (index) => [...store.keys()][index] ?? null,
+    get length() {
+      return store.size;
+    },
+  };
+}
+
+describe("useTheme", () => {
+  // The test environment does not provide a working localStorage implementation.
+  beforeEach(() => {
+    vi.stubGlobal("localStorage", createLocalStorageMock());
+    delete document.documentElement.dataset.theme;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("defaults to the system theme and resolves it against a light OS preference", () => {
+    // ARRANGE
+    mockMatchMedia(false);
+
+    // ACT
+    const { result } = withScope(() => useTheme());
+
+    // ASSERT
+    expect(result.theme.value).toBe("system");
+    expect(result.resolvedTheme.value).toBe("light");
+    expect(document.documentElement.dataset.theme).toBe("light");
+  });
+
+  it("resolves the system theme to dark when the OS prefers dark", () => {
+    // ARRANGE
+    mockMatchMedia(true);
+
+    // ACT
+    const { result } = withScope(() => useTheme());
+
+    // ASSERT
+    expect(result.resolvedTheme.value).toBe("dark");
+    expect(document.documentElement.dataset.theme).toBe("dark");
+  });
+
+  it("prioritizes an explicit preference over the OS preference", async () => {
+    // ARRANGE
+    mockMatchMedia(true);
+    const { result } = withScope(() => useTheme());
+
+    // ACT
+    result.setTheme("light");
+    await nextTick();
+
+    // ASSERT
+    expect(result.resolvedTheme.value).toBe("light");
+    expect(document.documentElement.dataset.theme).toBe("light");
+  });
+
+  it("persists the preference to localStorage", async () => {
+    // ARRANGE
+    mockMatchMedia(false);
+    const { result } = withScope(() => useTheme());
+
+    // ACT
+    result.setTheme("dark");
+    await nextTick();
+
+    // ASSERT
+    expect(localStorage.getItem("mt-theme")).toBe("dark");
+  });
+
+  it("restores a persisted preference on initialization", () => {
+    // ARRANGE
+    mockMatchMedia(false);
+    localStorage.setItem("mt-theme", "dark");
+
+    // ACT
+    const { result } = withScope(() => useTheme());
+
+    // ASSERT
+    expect(result.theme.value).toBe("dark");
+    expect(result.resolvedTheme.value).toBe("dark");
+  });
+
+  it("falls back to the default theme when the persisted value is invalid", () => {
+    // ARRANGE
+    mockMatchMedia(false);
+    localStorage.setItem("mt-theme", "not-a-theme");
+
+    // ACT
+    const { result } = withScope(() => useTheme());
+
+    // ASSERT
+    expect(result.theme.value).toBe("system");
+  });
+
+  it("reacts to OS preference changes while following the system", async () => {
+    // ARRANGE
+    const media = mockMatchMedia(false);
+    const { result } = withScope(() => useTheme());
+    expect(result.resolvedTheme.value).toBe("light");
+
+    // ACT
+    media.emit(true);
+    await nextTick();
+
+    // ASSERT
+    expect(result.resolvedTheme.value).toBe("dark");
+    expect(document.documentElement.dataset.theme).toBe("dark");
+  });
+
+  it("ignores OS preference changes once an explicit theme is chosen", async () => {
+    // ARRANGE
+    const media = mockMatchMedia(false);
+    const { result } = withScope(() => useTheme());
+    result.setTheme("light");
+    await nextTick();
+
+    // ACT
+    media.emit(true);
+    await nextTick();
+
+    // ASSERT
+    expect(result.resolvedTheme.value).toBe("light");
+    expect(document.documentElement.dataset.theme).toBe("light");
+  });
+
+  it("applies the resolved theme to a custom target element", () => {
+    // ARRANGE
+    mockMatchMedia(true);
+    const target = document.createElement("div");
+
+    // ACT
+    withScope(() => useTheme({ target }));
+
+    // ASSERT
+    expect(target.dataset.theme).toBe("dark");
+    expect(document.documentElement.dataset.theme).toBeUndefined();
+  });
+
+  it("does not touch the target when applyToTarget is disabled", () => {
+    // ARRANGE
+    mockMatchMedia(true);
+
+    // ACT
+    withScope(() => useTheme({ applyToTarget: false }));
+
+    // ASSERT
+    expect(document.documentElement.dataset.theme).toBeUndefined();
+  });
+
+  it("does not persist the preference when storageKey is null", async () => {
+    // ARRANGE
+    mockMatchMedia(false);
+    const { result } = withScope(() => useTheme({ storageKey: null }));
+
+    // ACT
+    result.setTheme("dark");
+    await nextTick();
+
+    // ASSERT
+    expect(result.resolvedTheme.value).toBe("dark");
+    expect(localStorage.getItem("mt-theme")).toBeNull();
+  });
+
+  it("stops listening to OS preference changes when the scope is disposed", () => {
+    // ARRANGE
+    const media = mockMatchMedia(false);
+    const { dispose } = withScope(() => useTheme());
+    expect(media.listeners.size).toBeGreaterThan(0);
+
+    // ACT
+    dispose();
+
+    // ASSERT
+    expect(media.listeners.size).toBe(0);
+  });
+
+  it("stops listening to OS preference changes when stop is called manually", () => {
+    // ARRANGE
+    const media = mockMatchMedia(false);
+    const { result } = withScope(() => useTheme());
+    expect(media.listeners.size).toBeGreaterThan(0);
+
+    // ACT
+    result.stop();
+
+    // ASSERT
+    expect(media.listeners.size).toBe(0);
+  });
+
+  it("no longer reacts to OS preference changes after stopping", async () => {
+    // ARRANGE
+    const media = mockMatchMedia(false);
+    const { result } = withScope(() => useTheme());
+    expect(document.documentElement.dataset.theme).toBe("light");
+
+    // ACT
+    result.stop();
+    media.emit(true);
+    await nextTick();
+
+    // ASSERT
+    expect(document.documentElement.dataset.theme).toBe("light");
+  });
+});

--- a/packages/component-library/src/composables/useTheme.ts
+++ b/packages/component-library/src/composables/useTheme.ts
@@ -1,0 +1,138 @@
+import { computed, effectScope, getCurrentScope, onScopeDispose, ref, watch } from "vue";
+import type { ComputedRef, Ref } from "vue";
+import { useLocalStorage, usePreferredDark } from "@vueuse/core";
+
+/**
+ * The theme a user can choose. `"system"` follows the operating system
+ * preference via `prefers-color-scheme`.
+ */
+export type Theme = "light" | "dark" | "system";
+
+/**
+ * The theme that is actually applied once `"system"` has been resolved.
+ */
+export type ResolvedTheme = "light" | "dark";
+
+export interface UseThemeOptions {
+  /**
+   * `localStorage` key used to persist the preference across reloads.
+   * Set to `null` to disable persistence.
+   *
+   * @default "mt-theme"
+   */
+  storageKey?: string | null;
+  /**
+   * Element whose `data-theme` attribute is kept in sync with the resolved
+   * theme. Defaults to the document root element.
+   */
+  target?: HTMLElement;
+  /**
+   * Preference used when nothing has been persisted yet.
+   *
+   * @default "system"
+   */
+  defaultTheme?: Theme;
+  /**
+   * Whether to write the resolved theme to the target's `data-theme`
+   * attribute. Disable this when the host applies the theme itself.
+   *
+   * @default true
+   */
+  applyToTarget?: boolean;
+}
+
+export interface UseThemeReturn {
+  /** The user's preference: `"light"`, `"dark"`, or `"system"`. */
+  theme: Ref<Theme>;
+  /** The applied theme after resolving `"system"`: `"light"` or `"dark"`. */
+  resolvedTheme: ComputedRef<ResolvedTheme>;
+  /** Sets the preference. Convenient for use outside of `v-model` bindings. */
+  setTheme: (theme: Theme) => void;
+  /**
+   * Releases all listeners held by the composable. Called automatically on
+   * scope disposal when used inside a component or `effectScope`; call it
+   * manually when using the composable outside of an active scope.
+   */
+  stop: () => void;
+}
+
+const DEFAULT_STORAGE_KEY = "mt-theme";
+
+function isTheme(value: unknown): value is Theme {
+  return value === "light" || value === "dark" || value === "system";
+}
+
+/**
+ * Manages the application theme: tracks the user's preference, resolves
+ * `"system"` against the operating system setting, applies the result to a
+ * target element's `data-theme` attribute, and persists the choice to
+ * `localStorage`.
+ *
+ * The returned `theme` ref is meant to be bound to `mt-theme-select` via
+ * `v-model`, while `resolvedTheme` reflects the value actually rendered.
+ */
+export function useTheme(options: UseThemeOptions = {}): UseThemeReturn {
+  const {
+    storageKey = DEFAULT_STORAGE_KEY,
+    target,
+    defaultTheme = "system",
+    applyToTarget = true,
+  } = options;
+
+  /*
+   * All reactive effects run in a detached scope so the composable works both
+   * inside components (auto-cleanup via onScopeDispose) and outside of any
+   * scope (manual cleanup via the returned stop function).
+   */
+  const scope = effectScope(true);
+
+  const state = scope.run(() => {
+    const prefersDark = usePreferredDark();
+
+    const theme: Ref<Theme> =
+      storageKey === null
+        ? ref(defaultTheme)
+        : useLocalStorage<Theme>(storageKey, defaultTheme, {
+            writeDefaults: false,
+            serializer: {
+              read: (raw) => (isTheme(raw) ? raw : defaultTheme),
+              write: (value) => value,
+            },
+          });
+
+    const resolvedTheme = computed<ResolvedTheme>(() => {
+      if (theme.value === "system") return prefersDark.value ? "dark" : "light";
+
+      return theme.value;
+    });
+
+    watch(
+      resolvedTheme,
+      (value) => {
+        if (!applyToTarget) return;
+
+        const element =
+          target ?? (typeof document !== "undefined" ? document.documentElement : undefined);
+        if (element) element.dataset.theme = value;
+      },
+      { immediate: true },
+    );
+
+    return { theme, resolvedTheme };
+  })!;
+
+  const stop = (): void => scope.stop();
+
+  if (getCurrentScope()) onScopeDispose(stop);
+
+  const setTheme = (value: Theme): void => {
+    state.theme.value = value;
+  };
+
+  return {
+    theme: state.theme,
+    resolvedTheme: state.resolvedTheme,
+    setTheme,
+    stop,
+  };
+}

--- a/packages/component-library/src/index.ts
+++ b/packages/component-library/src/index.ts
@@ -47,6 +47,14 @@ import MtModalAction from "./components/mt-modal/sub-components/mt-modal-action.
 import MtText from "./components/mt-text/mt-text.vue";
 import MtInset from "./components/mt-inset/mt-inset.vue";
 import MtThemeProvider from "./components/mt-theme-provider/mt-theme-provider.vue";
+import MtThemeSelect from "./components/mt-theme-select/mt-theme-select.vue";
+import {
+  useTheme,
+  type Theme,
+  type ResolvedTheme,
+  type UseThemeOptions,
+  type UseThemeReturn,
+} from "./composables/useTheme";
 import TooltipDirective from "./directives/tooltip.directive";
 import DeviceHelperPlugin from "./plugin/device-helper.plugin";
 import MtTooltip from "./components/mt-tooltip/mt-tooltip.vue";
@@ -128,6 +136,7 @@ export {
   MtSearch,
   MtUrlField,
   MtThemeProvider,
+  MtThemeSelect,
   MtUnitField,
   MtEntityDataTable,
   MtEntitySelect,
@@ -145,6 +154,7 @@ export {
   DropdownMenuSub as MtDropdownMenuSub,
   DeviceHelperPlugin,
   useSnackbar,
+  useTheme,
   // @deprecated
   MtBanner as SwBanner,
   // @deprecated
@@ -189,5 +199,6 @@ export {
 
 // Exporting types
 export type { Filter, Option, Toast, Snackbar, ChartOptions };
+export type { Theme, ResolvedTheme, UseThemeOptions, UseThemeReturn };
 export type { Editor } from "@tiptap/vue-3";
 export type { default as Link } from "@tiptap/extension-link";


### PR DESCRIPTION
## Description

Adds theme switching for Meteor apps and exposes the Administration's resolved theme to iframe apps through the Admin SDK.

🎥 Example usage in the Administration: https://www.loom.com/share/25b434e8ca85432eb303e6d30e0e9992

Closes #1174
Closes #1129

## Component library (#1174)

- `mt-theme-select` — select for choosing `light`, `dark`, or `system` (localized labels, en/de).
- `useTheme` composable — resolves the `system` preference, applies the resolved theme via `data-theme`, persists to `localStorage` (key `mt-theme`). Built on `@vueuse/core`.

## Admin SDK (#1129)

- `context.getTheme()`, `context.subscribeTheme()`, `context.syncTheme()` — following the `contextLocale` pattern (message key `contextTheme`).
- **Zero-config for apps:** on SDK startup inside an iframe, the resolved admin theme is mirrored onto `<html data-theme="…">` and kept in sync. Updating the SDK dependency is the only change an app needs. Apps that set `data-theme` themselves are left untouched; older admins without theme support are a silent no-op.
- The admin side implements `handle('contextTheme', …)` + `publish('contextTheme', …)`, same wiring as `contextLocale`.

## Known limitation

Iframes can briefly flash unthemed (white) on load: the theme arrives via an async postMessage round trip, so the first paint can happen before it. This could potentially be solved by one of my previous proposed fixes of adjusting the default bg color to transparent if inside of a embedded iframe context (passed through via admin-sdk).

## Tests

Unit tests for the composable, the component, and the SDK theme API (incl. stale-response race, invalid values, rejected initial fetch, and the zero-config auto-sync). Changesets: minor for both packages.