### PR TITLE
fix: replace svgo-autocrop dep icon-kit

### DIFF
--- a/.github/workflows/update-icons.yml
+++ b/.github/workflows/update-icons.yml
@@ -25,9 +25,6 @@ jobs:
       - name: Install dependencies
         run: pnpm i --frozen-lockfile --prefer-offline
 
-      - name: Install puppeteer
-        run: npx @puppeteer/browsers install chrome
-
       - name: Update icons
         run: pnpm --filter @shopware-ag/meteor-icon-kit run start
 

--- a/.github/workflows/update-icons.yml
+++ b/.github/workflows/update-icons.yml
@@ -29,7 +29,7 @@ jobs:
         run: pnpm --filter @shopware-ag/meteor-icon-kit run start
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@v8
         with:
           commit-message: Update icons
           committer: Dennis Mader <${{ secrets.ICON_KIT__COMMITTER }}>

--- a/packages/icon-kit/eslint.config.mjs
+++ b/packages/icon-kit/eslint.config.mjs
@@ -5,7 +5,8 @@ import tseslint from "typescript-eslint";
 
 export default tseslint.config([
   {
-    ignores: ["node_modules/", "dist/"],
+    // src/autocrop is vendored third-party CommonJS (see src/autocrop/README.md)
+    ignores: ["node_modules/", "dist/", "src/autocrop/"],
   },
   eslint.configs.recommended,
   tseslint.configs.recommendedTypeChecked,

--- a/packages/icon-kit/package.json
+++ b/packages/icon-kit/package.json
@@ -44,6 +44,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.20.0",
+    "@resvg/resvg-js": "^2.6.2",
     "@shopware-ag/meteor-prettier-config": "workspace:*",
     "@supercharge/promise-pool": "^2.4.0",
     "@types/axios": "^0.14.0",
@@ -52,8 +53,8 @@
     "axios": "^0.26.1",
     "eslint": "^9.21.0",
     "prettier": "^3.5.3",
+    "svg-pathdata": "^6.0.3",
     "svgo": "^2.8.0",
-    "svgo-autocrop": "1.1.1",
     "ts-node": "^10.8.1",
     "tsx": "^4.19.3",
     "typescript": "^5.7.0",

--- a/packages/icon-kit/src/autocrop/README.md
+++ b/packages/icon-kit/src/autocrop/README.md
@@ -1,0 +1,41 @@
+# autocrop (vendored)
+
+This directory is a vendored, lightly-modified copy of the SVGO plugin
+[`svgo-autocrop`](https://www.npmjs.com/package/svgo-autocrop) (v1.1.1, MIT licensed,
+© Glennos). It reduces an icon's `viewBox` to the smallest box that still contains all
+visible pixels and translates the geometry back to the origin.
+
+## Why it is vendored
+
+The upstream package renders every SVG in **headless Chrome via `puppeteer`** purely to
+compute a pixel-accurate bounding box. `puppeteer` is a hard dependency, so a Chromium
+binary was downloaded on nearly every `pnpm install`, which was slow and flaky in CI. The
+package is also no longer actively maintained.
+
+Vendoring lets us keep the exact cropping/translating behaviour (so generated icons do not
+change) while replacing **only** the renderer.
+
+## What was changed vs. upstream
+
+- Removed `lib/Browser.js`, `lib/ImageUtils.js`, `lib/WorkerThead.js`,
+  `lib/WorkerTheadParent.js` and `lib/WorkerTheadUtils.js` — the puppeteer + jimp +
+  worker-thread rendering pipeline.
+- Added [`lib/ImageBounds.cjs`](lib/ImageBounds.cjs): rasterises the SVG with
+  [`@resvg/resvg-js`](https://www.npmjs.com/package/@resvg/resvg-js) (a Rust rasterizer
+  shipped as a prebuilt binary — no browser) and scans for the `alpha > 0` bounds. The scan
+  is a straight port of the original `ImageUtils.getBounds`, and because `resvg` renders
+  synchronously the async worker-thread machinery is no longer needed.
+- [`lib/AutocropUtils.cjs`](lib/AutocropUtils.cjs): `getViewboxWithoutPadding` now calls
+  `ImageBounds.getBounds` instead of `WorkerTheadParent.getBounds`. Nothing else changed.
+
+`lib/SvgTranslate.cjs`, `lib/SvgTranslateError.cjs`, `lib/SvgUtils.cjs` and `lib/Ensure.cjs`
+are verbatim copies.
+
+The files use the `.cjs` extension because this package is ESM (`"type": "module"`) but the
+vendored code is CommonJS; `.cjs` forces CommonJS per-file, so no extra config is needed.
+
+## Equivalence
+
+The change was validated against 891 raw-input → committed-output pairs captured in
+`run.log` (the last full generation run): the resvg-based pipeline produces **byte-for-byte
+identical** output for every icon, including the hairline antialiasing cases.

--- a/packages/icon-kit/src/autocrop/index.cjs
+++ b/packages/icon-kit/src/autocrop/index.cjs
@@ -1,0 +1,30 @@
+'use strict';
+
+// Vendored from svgo-autocrop@1.1.1 (MIT, © Glennos). Only the renderer was swapped from
+// puppeteer to @resvg/resvg-js — see ./README.md for details.
+
+const AutocropUtils = require('./lib/AutocropUtils.cjs');
+
+exports.type = 'visitor';
+exports.name = 'autocrop';
+exports.active = true;
+exports.description = 'reduce viewBox to minimum possible size so no wasted transparent space around svg';
+
+/**
+ * Reduce viewBox to minimum possible size so no wasted transparent space around svg.
+ *
+ * @example
+ * <svg viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+ *   <rect x="5" y="5" width="10" height="10" fill="#000"/>
+ * </svg>
+ *             ⬇
+ * <svg viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg">
+ *   <rect x="0" y="0" width="10" height="10" fill="#000"/>
+ * </svg>
+ *
+ * @author Glennos
+ */
+exports.fn = (ast, params, info) => {
+	AutocropUtils.plugin(ast, params, info);
+	return null;
+};

--- a/packages/icon-kit/src/autocrop/lib/AutocropUtils.cjs
+++ b/packages/icon-kit/src/autocrop/lib/AutocropUtils.cjs
@@ -1,0 +1,242 @@
+
+const Ensure = require('./Ensure.cjs');
+
+const ImageBounds = Ensure.clazz(require('./ImageBounds.cjs'));
+const SvgTranslate = Ensure.clazz(require('./SvgTranslate.cjs'));
+const SvgTranslateError = Ensure.clazz(require('./SvgTranslateError.cjs'));
+const SvgUtils = Ensure.clazz(require('./SvgUtils.cjs'));
+
+module.exports = class AutocropUtils {
+
+	/**
+	 * See 'README.md#Parameters' for documentation on supported parameters.
+	 */
+	static plugin(ast, params, info) {
+		try {
+			// Get <svg> attributes
+			let attribs = AutocropUtils.getSvgAttribs(ast);
+			let includeWidthAndHeightAttributes = AutocropUtils.isIncludeWidthAndHeightAttributes(params, attribs);
+	
+			// Get viewbox as specified by <svg viewbox> or implied by <svg width/height>
+			let viewbox = AutocropUtils.getViewbox(attribs);
+
+			// Ensure width/height set (need svg to be fixed size rather than scaling to screen)
+			attribs.width = '' + viewbox.width;
+			attribs.height = '' + viewbox.height;
+			let svg = SvgUtils.js2svg(ast);
+
+			// Only render svg on first first call. We still do everything else - like translate - because after <svg> is optimised, translate may be able to succeed if it was previously failing.
+			let viewboxNew;
+			let multipassCount = info.multipassCount;
+			if ( multipassCount!==0 || params.autocrop===false ) {
+				viewboxNew = viewbox;
+			} else {
+				// Get viewbox without padding
+				viewboxNew = AutocropUtils.getViewboxWithoutPadding(svg, viewbox, params, info);
+
+				// Add padding if any
+				AutocropUtils.addPadding(viewboxNew, viewbox,
+						ast, params, info);
+			}
+
+			// Attempt to translate back to (0,0) if not already (0,0)
+			if (! AutocropUtils.translate(ast, params, viewboxNew, multipassCount) ) {
+				// Rollback the ast by recreating the js representation. This has to be done because the ast may currently be in an inconsistent/only partially modified state.
+				ast.children = SvgUtils.svg2js(svg).children;
+				attribs = AutocropUtils.getSvgAttribs(ast);
+			}
+
+			// Set new viewbox
+			AutocropUtils.setViewbox(attribs, viewboxNew, includeWidthAndHeightAttributes);
+			if ( params.debug ) {
+				console.log('Old viewbox: ' + JSON.stringify(viewbox) + '. New viewbox: ' + JSON.stringify(viewboxNew));
+			}
+		} catch ( e ) {
+			console.error('Failed to process: ' + info.path);
+			throw e;
+		}
+	}
+
+	static getViewboxWithoutPadding(svg, viewbox, params, info) {
+		// Rasterise the svg (resvg, no headless browser) and calculate/return non-transparent bounds.
+		let bounds = ImageBounds.getBounds(svg, viewbox.width, viewbox.height);
+		if ( bounds.width!=viewbox.width || bounds.height!=viewbox.height ) {
+			throw new Error('Loaded png had unexpected width/height\n<svg viewbox>=' + JSON.stringify(viewbox) + ', png bounds=' + JSON.stringify(bounds));
+		}
+		return {
+			x: viewbox.x + bounds.xMin,
+			y: viewbox.y + bounds.yMin,
+			width: bounds.xMax - bounds.xMin + 1,
+			height: bounds.yMax - bounds.yMin + 1
+		};
+	}
+
+	static addPadding(viewboxNew, viewbox,
+		ast, params, info) {
+		let padding = params.padding;
+		if ( !padding ) {
+			return;
+		}
+		let type = typeof padding;
+		if ( type=='number' ) {
+			viewboxNew.x -= padding;
+			viewboxNew.y -= padding;
+			viewboxNew.width += padding * 2;
+			viewboxNew.height += padding * 2;
+		} else if ( type=='object' ) {
+			let top = Ensure.integer(padding.top, "padding.top");
+			let bottom = Ensure.integer(padding.bottom, "padding.bottom");
+			let left = Ensure.integer(padding.left, "padding.left");
+			let right = Ensure.integer(padding.right, "padding.right");
+
+			viewboxNew.x -= left;
+			viewboxNew.y -= top;
+			viewboxNew.width += left + right;
+			viewboxNew.height += top + bottom;
+		} else if ( type=='function' ) {
+			padding(viewboxNew, viewbox,
+				ast, params, info);
+		} else {
+			throw Ensure.unexpectedObject('Unsupported padding specified', padding);
+		}
+	}
+
+	/**
+	 * @return Returns true if successful or did nothing. Returns false if failure - and will need to roll back ast
+     */
+	static translate(ast, params, viewboxNew, multipassCount) {
+		if ( params.disableTranslate ) {
+			return true; // Nothing to do.
+		}
+		let x = viewboxNew.x;
+		let y = viewboxNew.y;
+		let removeClass = params.removeClass;
+		let removeStyle = params.removeStyle;
+		let removeDeprecated = params.removeDeprecated;
+		let setColor = params.setColor;
+		if ( x==0 && y==0 && !removeClass && !removeStyle && !removeDeprecated && !setColor ) {
+			return true; // Nothing to do.
+		}
+
+		// Attempt to translate back to (0, 0)
+		try {
+			new SvgTranslate(-x, -y, multipassCount,
+				removeClass, removeStyle, removeDeprecated, setColor, params.setColorIssue).translate(ast);
+		} catch ( e ) {
+			if ( e instanceof SvgTranslateError ) {
+				let type = e.type;
+				if ( type=='silentRollback' ) {
+					return false; // Rollback!
+				} else {
+					throw e; // Fail outright when this error is thrown.
+				}
+			} else if (! params.disableTranslateWarning ) {
+				console.warn("Failed to translate <svg> by (" + x + ", " + y + ") - this warning can be safely ignored and can be hidden by setting 'disableTranslateWarning=true'.\n"
+					+ "Ideally you should update the code to fix this issue so translation can properly occur.\n"
+					+ "The only impact of this warning is the top/left of the viewbox won't be (0, 0)\n", e);
+			}
+			return false; // Rollback!
+		}
+
+		// Return successfully translated ast
+		viewboxNew.x = 0;
+		viewboxNew.y = 0;
+		return true;
+	}
+
+	static getSvgAttribs(ast) {
+		let nodes = ast.children;
+		let nodeCount;
+		if ( !nodes || (nodeCount=nodes.length)<=0 ) {
+			throw new Error('AST contains no nodes');
+		}
+		let index = 0;
+		let svg;
+		do {
+			let node = nodes[index];
+			if ( node.type=='element' && node.name=='svg' ) {
+				if ( svg ) {
+					throw new Error('AST contains multiple root <svg> elements');
+				}
+				svg = node;
+			}
+		} while ( ++index<nodeCount );
+		if ( !svg ) {
+			throw new Error("AST didn't contain root <svg> element");
+		}
+		return Ensure.notNull(svg.attributes, "<svg> attributes");
+	}
+
+	static getDebugWriteFilePrefix(params, info) {
+		let value = params.debugWriteFiles;
+		if (! value ) {
+			return null;
+		}
+		let type = typeof value;
+		if ( type=='boolean' ) {
+			let path = info.path;
+			if ( !path ) {
+				throw new Error("Param 'debugWriteFiles' enabled - but couldn't determine path of SVG - set 'debugWriteFiles' to path instead so can write debug files");
+			}
+			return path;
+		} else if ( type=='string' ) {
+			return value;
+		} else {
+			throw new Ensure.unexpectedObject("Unknown 'debugWriteFiles' params value specified", value);
+		}
+	}
+
+	static isIncludeWidthAndHeightAttributes(params, attribs) {
+		let flag = params.includeWidthAndHeightAttributes;
+		let type = typeof(flag);
+		if ( type=='undefined' ) { // Default to including only if already included in svg.
+			flag = attribs.width || attribs.height;
+		} else if ( type!='boolean' ) {
+			throw Ensure.unexpectedObject("Invalid 'includeWidthAndHeightAttributes' param - expected either 'boolean' or 'undefined' (which defaults to true/false depending on whether svg already includes a width/height", flag);
+		}
+		return flag;
+	}
+	
+	/**
+	 * @return Returns object taking the form {x, y, width, height}.
+	 */
+	static getViewbox(attribs) {
+		let viewbox = attribs.viewBox;
+		let x, y, width, height;
+		if ( !viewbox ) {
+			x = 0;
+			y = 0;
+			height = Ensure.integer(attribs.height, '<svg height>');
+			width = Ensure.integer(attribs.width, '<svg width>');
+		} else {
+			Ensure.string(viewbox, '<svg viewbox>');
+			let array = viewbox.split(/[ ,]+/);
+			if ( array instanceof Array && array.length!=4 ) {
+				throw new Error("Invalid <svg viewbox='" + viewbox + "'> attribute - expected viewbox to specify 4 parts.");
+			}
+			x = Ensure.integer(array[0], '<svg viewbox[0]>');
+			y = Ensure.integer(array[1], '<svg viewbox[1]>');
+			width = Ensure.integer(array[2], '<svg viewbox[2]>');
+			height = Ensure.integer(array[3], '<svg viewbox[3]>');
+		}
+		return {x, y, width, height};
+	}
+
+	static setViewbox(attribs, viewbox, includeWidthAndHeightAttributes) {
+		let width = viewbox.width;
+		let height = viewbox.height;
+
+		// Either update or set width/height
+		if ( includeWidthAndHeightAttributes ) {
+			attribs.width = '' + width;
+			attribs.height = '' + height;
+		} else {
+			delete attribs.width;
+			delete attribs.height;
+		}
+
+		// Set viewbox
+		attribs.viewBox = viewbox.x + ' ' + viewbox.y + ' ' + width + ' ' + height;
+	}
+
+}

--- a/packages/icon-kit/src/autocrop/lib/Ensure.cjs
+++ b/packages/icon-kit/src/autocrop/lib/Ensure.cjs
@@ -1,0 +1,99 @@
+
+const util = require('util');
+
+module.exports = class Ensure {
+
+	static unexpectedObject(message, obj) {
+		return new Error(message + ": " + util.inspect(obj, {showHidden: false, depth: 2}));
+	}
+
+	static notNull(obj, objDescription = 'object') {
+		if ( !obj ) {
+			throw Ensure.unexpectedObject("Expected non-null " + objDescription, obj);
+		}
+		return obj;
+	}
+	
+	static type(expectedType, obj, objDescription = 'object') {
+		Ensure.notNull(obj, objDescription);
+		let actualType = typeof obj;
+		if (actualType !== expectedType) {
+			throw Ensure.unexpectedObject("Expected type '" + expectedType + "' for " + objDescription + ", instead '" + actualType + "'", obj);
+		}
+		return obj;
+	}
+
+	static boolean(obj, objDescription = 'boolean') {
+		return Ensure.type('boolean', obj, objDescription);
+	}
+	
+	static string(obj, objDescription = 'string') {
+		return Ensure.type('string', obj, objDescription);
+	}
+	
+	static object(obj, objDescription = 'object') {
+		return Ensure.type('object', obj, objDescription);
+	}
+	
+	static func(obj, objDescription = 'function') {
+		return Ensure.type('function', obj, objDescription);
+		// TODO presently no easy way to detect difference between function vs class.
+	}
+
+	static clazz(obj, objDescription = 'class') {
+		Ensure.type('function', obj, objDescription);
+		if (typeof obj.constructor !== 'function' ) {
+			throw Ensure.unexpectedObject("[" + objDescription + "] Expected class, but function doesn't have constructor", obj);
+		}
+		return obj;
+	}
+
+	static array(obj, objDescription = 'array') {
+		if (!( obj instanceof Array )) { // Note: typeof for arrays is 'object'.
+			throw Ensure.unexpectedObject("Expected array for " + objDescription + ", instead '" + (typeof obj) + "'", obj);
+		}
+		return obj;
+	}
+	
+	static arrayWithLength(obj, expectedLength, objDescription = 'array') {
+		Ensure.array(obj, objDescription);
+		if (obj.length != 1) {
+			throw Ensure.unexpectedObject("[" + objDescription + "] Expected array with length " + expectedLength + ", but has length " + obj.length, obj);
+		}
+		return obj;
+	}
+
+	static integer(value, valueDescription = "integer") {
+		Ensure.notNull(value, valueDescription);
+
+		// Ensure number - or if string, then convert to number
+		let type = typeof value;
+		if (type !== 'number') {
+			if (type === 'string') {
+				let _value = parseInt(value, 10);
+				if ( !isFinite(_value) ) {
+					throw new Error("[" + valueDescription + "] Couldn't convert string to integer: " + value);
+				}
+				value = _value;
+			} else {
+				throw Ensure.unexpectedObject("Expected type 'number' (or 'string' that can be converted to 'number') for " + objDescription + ", instead '" + type + "'", obj);
+			}
+		}
+
+		// Ensure integer
+		if ( isFinite(value) && value!=Math.trunc(value) ) {
+			throw new Error("[" + valueDescription + "] Number is not integer: " + value);
+		}
+		return value;
+	}
+
+	/**
+	 * Faster/less flexible version of above method.
+	 */
+	static integerStrict(value, valueDescription = "integer") {
+		if ( isFinite(value) && value!=Math.trunc(value) ) {
+			throw new Error("[" + valueDescription + "] Not valid integer: " + value);
+		}
+		return value;
+	}
+}

--- a/packages/icon-kit/src/autocrop/lib/ImageBounds.cjs
+++ b/packages/icon-kit/src/autocrop/lib/ImageBounds.cjs
@@ -22,7 +22,15 @@ module.exports = class ImageBounds {
 		// Rasterise at the SVG's intrinsic size (== viewBox size, since <svg width/height> are set
 		// to the viewBox dimensions before this is called). Background is left transparent, matching
 		// the old puppeteer 'omitBackground: true' screenshot.
-		const rendered = new Resvg(svg, { fitTo: { mode: 'original' } }).render();
+		//
+		// loadSystemFonts is disabled because it makes resvg parse the entire OS font database on
+		// every construction (~0.5s/icon, i.e. minutes across the full set). Icons contain no text,
+		// so this changes nothing about the output (verified: identical visible-pixel bounds) but
+		// removes essentially all of the optimize phase's runtime.
+		const rendered = new Resvg(svg, {
+			fitTo: { mode: 'original' },
+			font: { loadSystemFonts: false },
+		}).render();
 		const w = rendered.width;
 		const h = rendered.height;
 		const data = rendered.pixels; // RGBA, row-major, same layout jimp exposed.

--- a/packages/icon-kit/src/autocrop/lib/ImageBounds.cjs
+++ b/packages/icon-kit/src/autocrop/lib/ImageBounds.cjs
@@ -1,0 +1,76 @@
+
+const Ensure = require('./Ensure.cjs');
+const { Resvg } = require('@resvg/resvg-js');
+
+/**
+ * Browser-free replacement for the old puppeteer + jimp + worker-thread rendering pipeline.
+ *
+ * Renders the SVG to a transparent RGBA bitmap using resvg (a Rust rasterizer shipped as a
+ * prebuilt binary - no headless browser download) and returns the bounds of the visible
+ * (alpha > 0) pixels. The scan logic is a straight port of the original ImageUtils.getBounds
+ * so the resulting crop is identical to the previous puppeteer implementation.
+ *
+ * @return Returns {width, height, xMin, yMin, xMax, yMax}
+ */
+module.exports = class ImageBounds {
+
+	static getBounds(svg, width, height) {
+		Ensure.string(svg);
+		Ensure.integerStrict(width);
+		Ensure.integerStrict(height);
+
+		// Rasterise at the SVG's intrinsic size (== viewBox size, since <svg width/height> are set
+		// to the viewBox dimensions before this is called). Background is left transparent, matching
+		// the old puppeteer 'omitBackground: true' screenshot.
+		const rendered = new Resvg(svg, { fitTo: { mode: 'original' } }).render();
+		const w = rendered.width;
+		const h = rendered.height;
+		const data = rendered.pixels; // RGBA, row-major, same layout jimp exposed.
+		if ( w < 0 || h < 0 ) {
+			throw new Error('Invalid image dimensions; width=' + w + ', height=' + h);
+		}
+
+		// Scan image determining bounds of visible pixels (port of ImageUtils.getBounds).
+		let xMin, xMax, yMin, yMax;
+		for ( let y = 0; y < h; y++ ) {
+			for ( let x = 0; x < w; x++ ) {
+				const idx = (y * w + x) * 4;
+				const alpha = data[idx + 3];
+				if ( alpha > 0 ) {
+					// Avoid truthy issues (i.e. (!!0)===false) by incrementing x/y by 1.
+					const px = x + 1;
+					const py = y + 1;
+					if ( !xMin ) { // Set all coordinates for first visible pixel
+						xMin = xMax = px;
+						yMin = yMax = py;
+					} else {
+						if ( px < xMin ) {
+							xMin = px;
+						} else if ( px > xMax ) {
+							xMax = px;
+						}
+						if ( py < yMin ) {
+							yMin = py;
+						} else if ( py > yMax ) {
+							yMax = py;
+						}
+					}
+				}
+			}
+		}
+		if ( !xMin ) {
+			throw new Error('Image has no visible pixels');
+		}
+		xMin--;
+		yMin--;
+		xMax--;
+		yMax--;
+
+		const result = { width: w, height: h, xMin: xMin, yMin: yMin, xMax: xMax, yMax: yMax };
+		if (!( 0 <= xMin && xMin <= xMax && xMax < w && 0 <= yMin && yMin <= yMax && yMax < h )) {
+			throw new Error('Unexpected - invalid bounds calculated: ' + JSON.stringify(result));
+		}
+		return result;
+	}
+
+}

--- a/packages/icon-kit/src/autocrop/lib/SvgTranslate.cjs
+++ b/packages/icon-kit/src/autocrop/lib/SvgTranslate.cjs
@@ -1,0 +1,389 @@
+
+const Ensure = require('./Ensure.cjs');
+
+const SVGPathData = Ensure.clazz(require('svg-pathdata').SVGPathData);
+const SvgTranslateError = Ensure.clazz(require('./SvgTranslateError.cjs'));
+
+module.exports = class SvgTranslate {
+
+	/**
+	 * @removeClass If true, then delete 'class' attribute.
+	 * @removeStyle If true, then delete 'style' and other styling attributes.
+	 * @removeDeprecated If true, then delete <svg version/baseProfile> attributes. Also deletes other non-standard/not useful attributes like 'sketch:type'/'data-name'/etc.
+     * @setColor If provided, then replace all colors with color specified. Usually set to 'currentColor'.
+     * @setColorIssue Either undefined/'warn', 'fail', 'rollback' or 'ignore'. See "README.md#Parameters" for a full description of these values.
+	 */
+	constructor(x, y, multipassCount,
+			removeClass = false, removeStyle = false, removeDeprecated = false, setColor = undefined, setColorIssue = undefined) {
+		this.x = x;
+		this.y = y;
+		this.multipassCount = multipassCount;
+
+		this.removeClass = removeClass;
+		this.removeStyle = removeStyle;
+		this.removeDeprecated = removeDeprecated;
+
+		this.setColor = setColor;
+		this.previousColor = null; // Used to store lowercase color previously encountered. If 'setColor' is defined and we encounter more than one color, then we fail.
+		if ( !setColorIssue || setColorIssue=='warn' ) {
+			this.setColorIssue = null;
+		} else if ( setColorIssue=='fail' || setColorIssue=='rollback' || setColorIssue=='ignore' ) {
+			this.setColorIssue = setColorIssue;
+		} else {
+			throw Ensure.unexpectedObject('Invalid "params.setColorIssue" value specified', setColorIssue);
+		}
+	}
+
+	/**
+	 * Translate the ast by (x, y).
+     *
+     * Implementation works off a whitelist of known svg elements/attributes - if anything unknown is encountered, an exception is thrown.
+     * If an exception is thrown, the caller has to rollback the ast themselves to the original unmodified version.
+	 */
+	translate(ast) {
+		if ( ast.type!='root' ) {
+			throw Ensure.unexpectedObject('Expected root', ast);
+		}
+		let hasSvg;
+		for ( const child of ast.children ) {
+			const type = child.type;
+			if ( type=='element' && child.name=='svg' ) {
+				if ( hasSvg ) {
+					throw Ensure.unexpectedObject('Multiple <svg> elements found', ast);
+				}
+				hasSvg = true;
+				this.#rootSvg(child);
+			} else if ( type=='comment' || type=='instruction' || type=='doctype' ) {
+				// Can ignore comments and instructions like <?xml ... ?>
+			} else {
+				throw Ensure.unexpectedObject('Unhandled node', child);
+			}
+		}
+		if (! hasSvg ) {
+			throw Ensure.unexpectedObject('No <svg> element found', ast);
+		}
+	}
+
+	#rootSvg(svg) {
+		this.#svg(svg);
+
+		// Ensure color set to root <svg> if not set to any other part of the <svg>
+		let setColor = this.setColor;
+		if ( setColor && !this.previousColor ) {
+			svg.attributes['fill'] = setColor;
+		}
+	}
+
+	#svg(svg) {
+		const attribs = svg.attributes;
+		for ( const attribName in attribs ) {
+			if ( attribName=='viewBox' ) {
+				// TODO maybe do something?
+			} else if ( attribName=='width' || attribName=='height' || attribName=='xmlns' || attribName=='enable-background' ) {
+				// Ignore
+			} else if ( attribName=='version' || attribName=='baseProfile' ) {
+				if ( this.removeDeprecated ) { // Remove deprecated if requested
+					delete attribs[attribName];
+				}
+			} else if ( attribName=='x' || attribName=='y' ) {
+				let str = attribs[attribName];
+				if ( !str || str=='0' || str=='0px' ) {
+					delete attribs[attribName]; // Can just remove this - completely redundant.
+				} else {
+					this.#unhandledAttribute(svg, attribs, attribName);
+				}
+			} else {
+				this.#unhandledAttribute(svg, attribs, attribName);
+			}
+		}
+		this.#handleChildren(svg);
+	}
+
+	#handleChildren(node) {
+		for ( const child of node.children ) {
+			const type = child.type;
+			if ( type=='element' ) {
+				const name = child.name.toLowerCase();
+				if ( name=='g' ) {
+					this.#g(child);
+				} else if ( name=='path' ) {
+					this.#path(child);
+				} else if ( name=='rect' ) {
+					this.#rect(child);
+				} else if ( name=='line' ) {
+					this.#line(child);
+				} else if ( name=='polyline' ) {
+					this.#polyline(child);
+				} else if ( name=='polygon' ) {
+					this.#polygon(child);
+				} else if ( name=='circle' ) {
+					this.#circle(child);
+				} else if ( name=='ellipse' ) {
+					this.#ellipse(child);
+				} else if ( name=='defs' ) {
+					this.#defs(child);
+				} else if ( name=='title' || name=='desc' ) {
+					// Can just ignore title/description
+				} else {
+					throw Ensure.unexpectedObject('Unhandled element', child);				
+				}
+			} else if ( type=='comment' ) {
+				// Can ignore comments
+			} else {
+				throw Ensure.unexpectedObject('Unhandled node type "' + type + '"', child);
+			}
+		}
+	}
+
+	#ensureNoChildren(node) {
+		let children = node.children;
+		if ( children && children.length>0 ) {
+			throw Ensure.unexpectedObject('Unexpected/unhandled children', node);
+		}
+	}
+
+	#unhandledAttribute(node, attribs, attribName) {
+		if ( attribName ) { // For full list, see: https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute
+			if (attribName=='fill' || attribName=='stroke' || attribName=='color'
+					|| attribName=='stop-color' || attribName=='flood-color' || attribName=='lighting-color' ) {
+				this.#translateColor(node, attribs, attribName);
+				return;
+			} else if ( attribName=='class' ) {
+				if ( this.removeClass ) {
+					delete attribs[attribName];
+				}
+				return;
+			} else if ( attribName=='style' || attribName=='font-family' ) {
+				if ( this.removeStyle ) {
+					delete attribs[attribName];
+				}
+				return;
+			} else if ( attribName=='overflow' ) { // https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/overflow
+				if ( this.removeStyle ) {
+					let value = attribs[attribName];
+					if ( !value || value=='visible' ) { // 'overflow=visible' is the default - so just remove this.
+						delete attribs[attribName];
+					}
+				}
+				return;
+			} else if ( attribName=='enable-background' || attribName=='data-name' || attribName=='xml:space'
+					|| attribName=='xmlns:sketch' || attribName.startsWith('sketch:')) { // Note: most common 'sketch:' attribute is 'sketch:type'.
+				if ( this.removeDeprecated ) { // Remove deprecated/redundant if requested
+					delete attribs[attribName];
+				}
+				return;
+			} else if ( attribName=='transform' ) {
+				let multipassCount = this.multipassCount;
+				if ( multipassCount===0 ) {
+					throw SvgTranslateError.silentRollback("Svgo's 'convertTransform' plugin will often remove transforms. During the next run potentially no transform attribute will be present.");
+				} else {
+					throw Ensure.unexpectedObject("Svgo's 'convertTransform' is either not enabled or failed to remove <" + node.name + " transform='" + attribs[attribName] + "'> on the first pass.\n"
+						+ "If this was a simple transform, consider confirming the svgo default plugins or at least the 'convertTransform' plugin are in your svgo configuration file.", node);
+				}
+			} else if (attribName=='id'
+					|| attribName=='opacity' || attribName=='display'
+				    || attribName.startsWith('fill-') || attribName.startsWith('stroke-') || attribName.startsWith('clip-')
+					|| attribName.startsWith('xmlns:') || attribName.startsWith('xml:')) {
+				return; // Can somewhat safely ignore these.
+			}
+		}
+		throw Ensure.unexpectedObject('Unhandled <' + node.name + ' ' + attribName + '> attribute', node);
+	}
+
+	#translateX(node, attribs, attribName) {
+		let x = this.x;
+		if ( x!==0 ) {
+			let num = this.#getAttribNumber(node, attribs, attribName);
+			attribs[attribName] = '' + (num + x);
+		}
+	}
+
+	#translateY(node, attribs, attribName) {
+		let y = this.y;
+		if ( y!==0 ) {
+			let num = this.#getAttribNumber(node, attribs, attribName);
+			attribs[attribName] = '' + (num + y);
+		}
+	}
+
+	#translateColor(node, attribs, attribName) {
+		let setColor = this.setColor;
+		if (!setColor) {
+			return;
+		}
+
+		// Get value		
+		let value = attribs[attribName];
+		if ( !value || (value = value.trim()).length<=0 ) {
+			delete attribs[attribName];
+			return;
+		}
+		value = value.toLowerCase();
+
+		// Set color
+		if ( value!='none' ) {
+			// 'color="currentColor"' is always redundant - setting color to the 'currentColor' has no effect given the previous color was already 'currentColor'.
+			if ( attribName=='color' && setColor=='currentColor' ) {
+				delete attribs[attribName];
+				return;
+			}
+
+			// Compare to previous color
+			let previousColor = this.previousColor;
+			if ( !previousColor ) {
+				this.previousColor = value;
+			} else if ( previousColor!=value ) { // Note: case insensitive comparison.
+			    let setColorIssue = this.setColorIssue;
+				if ( setColorIssue!='ignore' ) {
+					let message = 'Expected single color/monotone <svg>, however multiple colors encountered in <svg> - previous color "'
+						+ previousColor + '", but just encountered <' + node.name + ' ' + attribName + '="' + attribs[attribName] + '"> attribute with different color';
+					if ( !setColorIssue || setColorIssue=='warn' ) {
+						console.warn(message);
+					} else if ( setColorIssue=='rollback' ) {
+						throw Ensure.unexpectedObject(message, node);
+					} else {
+						throw SvgTranslateError.fail(message);
+					}
+				}
+			}
+			
+			// Set color
+			attribs[attribName] = setColor;
+		}
+	}
+
+	#getAttribString(node, attribs, attribName) {
+		let str = attribs[attribName];
+		if ( typeof str != 'string' ) {
+			throw Ensure.unexpectedObject('Invalid <' + node.name + ' ' + attribName + '> attribute - expected string', node);
+		} else if ( str.length<=0 ) {
+			throw Ensure.unexpectedObject('Invalid <' + node.name + ' ' + attribName + '> attribute - empty string specified for attribute', node);
+		}
+		return str;
+	}
+
+	#getAttribNumber(node, attribs, attribName) {
+		let str = this.#getAttribString(node, attribs, attribName);
+		let num = Number(str);
+		if (! isFinite(num) ) {
+			throw Ensure.unexpectedObject('Invalid <' + node.name + ' ' + attribName + '="' + str + '"> attribute - invalid number', node);
+		}
+		return num;
+	}
+
+	#defs(node) { // https://developer.mozilla.org/en-US/docs/Web/SVG/Element/defs
+		const attribs = node.attributes;
+		for ( const attribName in attribs ) {
+			this.#unhandledAttribute(node, attribs, attribName);
+		}
+		this.#ensureNoChildren(node);
+	}
+
+	#g(node) { // https://developer.mozilla.org/en-US/docs/Web/SVG/Element/g
+		const attribs = node.attributes;
+		for ( const attribName in attribs ) {
+			this.#unhandledAttribute(node, attribs, attribName);
+		}
+		this.#handleChildren(node);
+	}
+
+	#path(node) { // https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorial/Basic_Shapes#path
+		const attribs = node.attributes;
+		for ( const attribName in attribs ) {
+			if ( attribName=='d' ) {
+				let x = this.x;
+				let y = this.y;
+				if ( x!==0 || y!==0 ) {
+					let data = attribs.d;
+					let dataNew = new SVGPathData(data).toAbs().translate(x, y).round(1e14).encode();
+					attribs.d = dataNew;
+				}
+			} else {
+				this.#unhandledAttribute(node, attribs, attribName);
+			}
+		}
+		this.#ensureNoChildren(node);
+	}
+
+	#rect(node) { // https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorial/Basic_Shapes#rectangle
+		const attribs = node.attributes;
+		for ( const attribName in attribs ) {
+			if ( attribName=='x' ) {
+				this.#translateX(node, attribs, attribName);
+			} else if ( attribName=='y' ) {
+				this.#translateY(node, attribs, attribName);
+			} else if ( attribName=='width' || attribName=='height' || attribName=='rx' || attribName=='ry' ) {
+				// Can safely ignore these
+			} else {
+				this.#unhandledAttribute(node, attribs, attribName);
+			}
+		}
+		this.#ensureNoChildren(node);
+	}
+
+	#line(node) { // https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorial/Basic_Shapes#line
+		const attribs = node.attributes;
+		for ( const attribName in attribs ) {
+			if ( attribName=='x1' || attribName=='x2' ) {
+				this.#translateX(node, attribs, attribName);
+			} else if ( attribName=='y1' || attribName=='y2' ) {
+				this.#translateY(node, attribs, attribName);
+			} else {
+				this.#unhandledAttribute(node, attribs, attribName);
+			}
+		}
+		this.#ensureNoChildren(node);
+	}
+
+	#polyline(node) { // https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorial/Basic_Shapes#polyline
+		this.#_silentRollbackIfFirstPass(node);
+	}
+
+	#polygon(node) { // https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorial/Basic_Shapes#polygon
+		this.#_silentRollbackIfFirstPass(node);
+	}
+
+	#_silentRollbackIfFirstPass(node) {
+		let multipassCount = this.multipassCount;
+		if ( multipassCount===0 ) {
+			throw SvgTranslateError.silentRollback("Svgo's 'convertShapeToPath' plugin will convert this to <path d> - which we can translate on next call");
+		} else {
+			throw Ensure.unexpectedObject("Svgo's 'convertShapeToPath' was meant to convert <" + node.name + "> to <path d> on the first pass,"
+				+ " however it's multipassCount=" + multipassCount + " and this <" + node.name + "> element hasn't been replaced.\n"
+				+ "Please confirm svgo default plugins or at least the 'convertShapeToPath' plugin are in your svgo configuration file.", node);
+		}
+	}
+
+	#circle(node) { // https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorial/Basic_Shapes#circle
+		const attribs = node.attributes;
+		for ( const attribName in attribs ) {
+			if ( attribName=='cx' ) {
+				this.#translateX(node, attribs, attribName);
+			} else if ( attribName=='cy' ) {
+				this.#translateY(node, attribs, attribName);
+			} else if ( attribName=='r' ) {
+				// Can safely ignore these
+			} else {
+				this.#unhandledAttribute(node, attribs, attribName);
+			}
+		}
+		this.#ensureNoChildren(node);
+	}
+
+	#ellipse(node) { // https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorial/Basic_Shapes#ellipse
+		const attribs = node.attributes;
+		for ( const attribName in attribs ) {
+			if ( attribName=='cx' ) {
+				this.#translateX(node, attribs, attribName);
+			} else if ( attribName=='cy' ) {
+				this.#translateY(node, attribs, attribName);
+			} else if ( attribName=='rx' || attribName=='ry' ) {
+				// Can safely ignore these
+			} else {
+				this.#unhandledAttribute(node, attribs, attribName);
+			}
+		}
+		this.#ensureNoChildren(node);
+	}
+
+}

--- a/packages/icon-kit/src/autocrop/lib/SvgTranslateError.cjs
+++ b/packages/icon-kit/src/autocrop/lib/SvgTranslateError.cjs
@@ -1,0 +1,25 @@
+
+/**
+ * Allows customisation of error handling;
+ *  (*) If type=='fail' - throw the error back to svgo/the user.
+ *  (*) If type=='silent-rollback' - silently rollback <svg> and continue.
+ *
+ * If any other exception is thrown when 'SvgTranslate.translate()' is being called, the change is just rolled back. 
+ */
+module.exports = class SvgTranslateError extends Error {
+
+	// Don't use this constructor - use static creator methods below.
+	constructor(message, type) {
+		super(message);
+		this.type = type;
+	}
+
+	static fail(message) {
+		return new SvgTranslateError(message, 'fail');
+	}
+
+	static silentRollback(message) {
+		return new SvgTranslateError(message, 'silentRollback');
+	}
+
+}

--- a/packages/icon-kit/src/autocrop/lib/SvgUtils.cjs
+++ b/packages/icon-kit/src/autocrop/lib/SvgUtils.cjs
@@ -1,0 +1,28 @@
+
+const Ensure = require('./Ensure.cjs');
+const path = Ensure.object(require('path'));
+
+const svgDirName = path.dirname(require.resolve('svgo'));
+const _stringifySvg = Ensure.func(require(path.join(svgDirName, '/stringifier.js')).stringifySvg); // Ugly way of loading "{repo}/node_modules/svgo/lib/stringifier.js".
+const _parseSvg = Ensure.func(require(path.join(svgDirName + '/parser.js')).parseSvg); // Ugly way of loading "{repo}/node_modules/svgo/lib/parser.js".
+
+module.exports = class SvgUtils {
+
+	/**
+	 * Parse the SVG/XML string provided - and return the javascript in-memory representation.
+     *
+	 * @param str SVG/XML string.
+	 * @param path Optional SVG path - only used if reporting error.
+     */
+	static svg2js(str, path) {
+		return _parseSvg(str, path);
+	}
+
+	/**
+	 * Format the AST/Javascript in-memory representation back to the SVG/XML string.
+	 */
+	static js2svg(ast) {
+		return _stringifySvg(ast).data;
+	}
+
+}

--- a/packages/icon-kit/src/figma/index.ts
+++ b/packages/icon-kit/src/figma/index.ts
@@ -83,14 +83,26 @@ export default class FigmaApiClient {
     );
   }
 
-  public downloadImage(url: string): AxiosPromise {
-    // @ts-expect-error -- TODO: add types for axios
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-    return Axios({
-      url,
-      method: "GET",
-      responseType: "blob",
-    });
+  public async downloadImage(url: string, retries = 3): Promise<AxiosResponse> {
+    // Figma serves rendered SVGs from S3, where the occasional connection stalls
+    // or is reset. Without a timeout (axios defaults to none) a stalled socket
+    // hangs the whole run forever, so we bound each attempt and retry on failure.
+    let lastError: unknown;
+    for (let attempt = 0; attempt <= retries; attempt++) {
+      try {
+        // @ts-expect-error -- TODO: add types for axios
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+        return await Axios({
+          url,
+          method: "GET",
+          responseType: "blob",
+          timeout: 30_000,
+        });
+      } catch (error) {
+        lastError = error;
+      }
+    }
+    throw lastError;
   }
 
   public getNodeInfo(ids: string[]): Promise<AxiosPromise<FigmaNodeResponse>> {

--- a/packages/icon-kit/src/index.ts
+++ b/packages/icon-kit/src/index.ts
@@ -51,16 +51,20 @@ client
     const meta = util.buildMeta(iconMap);
 
     spinner.succeed("Gathered icons");
-    spinner.start("Optimizing icons");
+    // Phase 1 — download every icon's raw SVG. This is network-bound and finishes
+    // in a few seconds. It must NOT be interleaved with the optimize step below:
+    // the autocrop plugin rasterises each SVG synchronously via resvg (~0.5s/icon),
+    // which blocks the event loop long enough that concurrent in-flight S3 sockets
+    // stall and AWS resets them ("socket hang up" / ECONNRESET).
+    spinner.start("Downloading icons");
+    spinner.text = `Downloaded ${0} out of ${iconMap.size} icons`;
 
-    spinner.text = `Optimized ${0} out of ${iconMap.size} icons`;
-
-    const styling = [] as { name: string; width: string; height: string }[];
+    const rawSvgs = new Map<string, string>();
 
     await PromisePool.for(Array.from(iconMap.keys()))
       .withConcurrency(25)
       .onTaskFinished((iconName, pool) => {
-        spinner.text = `Optimized ${pool.processedCount()} out of ${iconMap.size} icons`;
+        spinner.text = `Downloaded ${pool.processedCount()} out of ${iconMap.size} icons`;
       })
       .handleError((error) => {
         console.log(error);
@@ -69,84 +73,99 @@ client
         const icon = iconMap.get(iconName);
         if (!icon) {
           throw new Error(
-            `Failed to optimize icon: ${iconName}; Icon does not exist`
+            `Failed to download icon: ${iconName}; Icon does not exist`
           );
         }
 
         const result = await client.downloadImage(icon.image);
-        const svg = result.data as string;
+        rawSvgs.set(iconName, result.data as string);
         logger.info("Received icon data", {
           icon: icon.image,
-          svg,
-        });
-
-        // Remove width/height from SVGs
-        logger.info(`Optimizing icon: ${icon.image}`);
-        const optimizedSvgResult = optimize(svg, {
-          plugins: [
-            { name: "removeDimensions" },
-            {
-              ...(svgoAutocrop as unknown as CustomPlugin<{
-                disableTranslateWarning: boolean;
-              }>),
-              params: {
-                disableTranslateWarning: true,
-              },
-            },
-          ],
-          // svgo's `optimize()` always returns an object with a string `data`
-          // field. Asserting just that keeps this resilient across svgo majors
-          // (the old `OptimizedSvg` type was removed in svgo 3+).
-        }) as { data: string };
-
-        let optimizedSvg = optimizedSvgResult.data;
-        logger.info("Received optimized icon", {
-          icon: icon.image,
-          svg: optimizedSvg,
-        });
-
-        const viewBox = optimizedSvg.match(/viewBox="(\d*) (\d*) (\d*) (\d*)"/);
-        if (viewBox) {
-          const width = viewBox[3];
-          const height = viewBox[4];
-          if (!width || !height) {
-            throw new Error(
-              `Failed to optimize icon: ${iconName}; Could not extract width and height from viewBox`
-            );
-          }
-          const className = iconName.replace(/icons\//, "").replace(/\//g, "-");
-
-          // Add class name to SVG
-          optimizedSvg = optimizedSvg.replace(
-            /<svg/,
-            `<svg id="meteor-icon-kit__${className}"`
-          );
-
-          styling.push({
-            name: className,
-            width,
-            height,
-          });
-
-          logger.info(`Added className "${className}" to style map`);
-        } else {
-          console.error(`Could not find viewBox for ${iconName}`);
-          logger.info(`Failed to further optimize icon: "${iconName}"`, {
-            icon: icon.image,
-          });
-        }
-
-        const pathToIcon = path.resolve(
-          iconDirectory,
-          `${iconName.replace("icons/", "")}.svg`
-        );
-
-        fileSystem.createFile(pathToIcon, optimizedSvg);
-        logger.info(`Created icon: "${iconName}"`, {
-          path: pathToIcon,
-          svg: optimizedSvg,
+          svg: result.data,
         });
       });
+
+    // Phase 2 — optimize + write. Pure CPU work with no open sockets, so blocking
+    // the event loop here is harmless.
+    spinner.start("Optimizing icons");
+    spinner.text = `Optimized ${0} out of ${iconMap.size} icons`;
+
+    const styling = [] as { name: string; width: string; height: string }[];
+
+    let optimizedCount = 0;
+    for (const [iconName, svg] of rawSvgs) {
+      const icon = iconMap.get(iconName)!;
+
+      // Remove width/height from SVGs
+      logger.info(`Optimizing icon: ${icon.image}`);
+      const optimizedSvgResult = optimize(svg, {
+        plugins: [
+          { name: "removeDimensions" },
+          {
+            ...(svgoAutocrop as unknown as CustomPlugin<{
+              disableTranslateWarning: boolean;
+            }>),
+            params: {
+              disableTranslateWarning: true,
+            },
+          },
+        ],
+        // svgo's `optimize()` always returns an object with a string `data`
+        // field. Asserting just that keeps this resilient across svgo majors
+        // (the old `OptimizedSvg` type was removed in svgo 3+).
+      }) as { data: string };
+
+      let optimizedSvg = optimizedSvgResult.data;
+      logger.info("Received optimized icon", {
+        icon: icon.image,
+        svg: optimizedSvg,
+      });
+
+      const viewBox = optimizedSvg.match(/viewBox="(\d*) (\d*) (\d*) (\d*)"/);
+      if (viewBox) {
+        const width = viewBox[3];
+        const height = viewBox[4];
+        if (!width || !height) {
+          throw new Error(
+            `Failed to optimize icon: ${iconName}; Could not extract width and height from viewBox`
+          );
+        }
+        const className = iconName.replace(/icons\//, "").replace(/\//g, "-");
+
+        // Add class name to SVG
+        optimizedSvg = optimizedSvg.replace(
+          /<svg/,
+          `<svg id="meteor-icon-kit__${className}"`
+        );
+
+        styling.push({
+          name: className,
+          width,
+          height,
+        });
+
+        logger.info(`Added className "${className}" to style map`);
+      } else {
+        console.error(`Could not find viewBox for ${iconName}`);
+        logger.info(`Failed to further optimize icon: "${iconName}"`, {
+          icon: icon.image,
+        });
+      }
+
+      const pathToIcon = path.resolve(
+        iconDirectory,
+        `${iconName.replace("icons/", "")}.svg`
+      );
+
+      fileSystem.createFile(pathToIcon, optimizedSvg);
+      logger.info(`Created icon: "${iconName}"`, {
+        path: pathToIcon,
+        svg: optimizedSvg,
+      });
+
+      optimizedCount++;
+      spinner.text = `Optimized ${optimizedCount} out of ${iconMap.size} icons`;
+    }
 
     spinner.text = "Finished writing icons to filesystem";
     spinner.text = "Creating stylesheet";

--- a/packages/icon-kit/src/index.ts
+++ b/packages/icon-kit/src/index.ts
@@ -1,9 +1,10 @@
 import FigmaApiClient from "./figma/index.js";
 import FigmaUtil from "./figma/util/index.js";
 import { optimize } from "svgo";
+import type { CustomPlugin } from "svgo";
 import { PromisePool } from "@supercharge/promise-pool";
-// @ts-expect-error - this dependency has no type definitions
-import * as svgoAutocrop from "svgo-autocrop";
+// Vendored SVGO plugin (CommonJS, untyped); see ./autocrop/README.md
+import svgoAutocrop from "./autocrop/index.cjs";
 import path from "node:path";
 import { WinstonLogger } from "./logger/winston-logger.js";
 import ora from "ora";
@@ -85,7 +86,9 @@ client
           plugins: [
             { name: "removeDimensions" },
             {
-              ...svgoAutocrop,
+              ...(svgoAutocrop as unknown as CustomPlugin<{
+                disableTranslateWarning: boolean;
+              }>),
               params: {
                 disableTranslateWarning: true,
               },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,7 +47,7 @@ importers:
         version: 12.10.0
       docus:
         specifier: ^5.12.1
-        version: 5.12.1(d9b85ea07a2d7e296a55ed08e0dd5a55)
+        version: 5.12.1(c643f0c1e05997ad3a11d68c44b0dcde)
       nuxt:
         specifier: ^4.3.1
         version: 4.4.8(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@types/node@25.2.0)(@vue/compiler-sfc@3.5.13)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(encoding@0.1.13)(eslint@9.39.2(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.61.1))(rollup@4.61.1)(sass@1.77.6)(stylelint@16.26.1(typescript@5.7.3))(terser@5.31.1)(tsx@4.19.3)(typescript@5.7.3)(vite@7.3.5(@types/node@25.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.77.6)(terser@5.31.1)(tsx@4.19.3)(yaml@2.9.0))(vue-tsc@2.2.4(typescript@5.7.3))(yaml@2.9.0)
@@ -708,6 +708,9 @@ importers:
       '@eslint/js':
         specifier: ^9.20.0
         version: 9.21.0
+      '@resvg/resvg-js':
+        specifier: ^2.6.2
+        version: 2.6.2
       '@shopware-ag/meteor-prettier-config':
         specifier: workspace:*
         version: link:../prettier-config
@@ -732,12 +735,12 @@ importers:
       prettier:
         specifier: ^3.5.3
         version: 3.5.3
+      svg-pathdata:
+        specifier: ^6.0.3
+        version: 6.0.3
       svgo:
         specifier: ^2.8.0
         version: 2.8.0
-      svgo-autocrop:
-        specifier: 1.1.1
-        version: 1.1.1
       ts-node:
         specifier: ^10.8.1
         version: 10.9.2(@swc/core@1.6.1(@swc/helpers@0.5.17))(@types/node@20.17.19)(typescript@5.7.3)
@@ -3030,171 +3033,6 @@ packages:
     resolution: {integrity: sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
-  '@jimp/bmp@0.16.13':
-    resolution: {integrity: sha512-9edAxu7N2FX7vzkdl5Jo1BbACfycUtBQX+XBMcHA2bk62P8R0otgkHg798frgAk/WxQIzwxqOH6wMiCwrlAzdQ==}
-    peerDependencies:
-      '@jimp/custom': '>=0.3.5'
-
-  '@jimp/core@0.16.13':
-    resolution: {integrity: sha512-qXpA1tzTnlkTku9yqtuRtS/wVntvE6f3m3GNxdTdtmc+O+Wcg9Xo2ABPMh7Nc0AHbMKzwvwgB2JnjZmlmJEObg==}
-
-  '@jimp/custom@0.16.13':
-    resolution: {integrity: sha512-LTATglVUPGkPf15zX1wTMlZ0+AU7cGEGF6ekVF1crA8eHUWsGjrYTB+Ht4E3HTrCok8weQG+K01rJndCp/l4XA==}
-
-  '@jimp/gif@0.16.13':
-    resolution: {integrity: sha512-yFAMZGv3o+YcjXilMWWwS/bv1iSqykFahFMSO169uVMtfQVfa90kt4/kDwrXNR6Q9i6VHpFiGZMlF2UnHClBvg==}
-    peerDependencies:
-      '@jimp/custom': '>=0.3.5'
-
-  '@jimp/jpeg@0.16.13':
-    resolution: {integrity: sha512-BJHlDxzTlCqP2ThqP8J0eDrbBfod7npWCbJAcfkKqdQuFk0zBPaZ6KKaQKyKxmWJ87Z6ohANZoMKEbtvrwz1AA==}
-    peerDependencies:
-      '@jimp/custom': '>=0.3.5'
-
-  '@jimp/plugin-blit@0.16.13':
-    resolution: {integrity: sha512-8Z1k96ZFxlhK2bgrY1JNWNwvaBeI/bciLM0yDOni2+aZwfIIiC7Y6PeWHTAvjHNjphz+XCt01WQmOYWCn0ML6g==}
-    peerDependencies:
-      '@jimp/custom': '>=0.3.5'
-
-  '@jimp/plugin-blur@0.16.13':
-    resolution: {integrity: sha512-PvLrfa8vkej3qinlebyhLpksJgCF5aiysDMSVhOZqwH5nQLLtDE9WYbnsofGw4r0VVpyw3H/ANCIzYTyCtP9Cg==}
-    peerDependencies:
-      '@jimp/custom': '>=0.3.5'
-
-  '@jimp/plugin-circle@0.16.13':
-    resolution: {integrity: sha512-RNave7EFgZrb5V5EpdvJGAEHMnDAJuwv05hKscNfIYxf0kR3KhViBTDy+MoTnMlIvaKFULfwIgaZWzyhuINMzA==}
-    peerDependencies:
-      '@jimp/custom': '>=0.3.5'
-
-  '@jimp/plugin-color@0.16.13':
-    resolution: {integrity: sha512-xW+9BtEvoIkkH/Wde9ql4nAFbYLkVINhpgAE7VcBUsuuB34WUbcBl/taOuUYQrPEFQJ4jfXiAJZ2H/rvKjCVnQ==}
-    peerDependencies:
-      '@jimp/custom': '>=0.3.5'
-
-  '@jimp/plugin-contain@0.16.13':
-    resolution: {integrity: sha512-QayTXw4tXMwU6q6acNTQrTTFTXpNRBe+MgTGMDU0lk+23PjlFCO/9sacflelG8lsp7vNHhAxFeHptDMAksEYzg==}
-    peerDependencies:
-      '@jimp/custom': '>=0.3.5'
-      '@jimp/plugin-blit': '>=0.3.5'
-      '@jimp/plugin-resize': '>=0.3.5'
-      '@jimp/plugin-scale': '>=0.3.5'
-
-  '@jimp/plugin-cover@0.16.13':
-    resolution: {integrity: sha512-BSsP71GTNaqWRcvkbWuIVH+zK7b3TSNebbhDkFK0fVaUTzHuKMS/mgY4hDZIEVt7Rf5FjadAYtsujHN9w0iSYA==}
-    peerDependencies:
-      '@jimp/custom': '>=0.3.5'
-      '@jimp/plugin-crop': '>=0.3.5'
-      '@jimp/plugin-resize': '>=0.3.5'
-      '@jimp/plugin-scale': '>=0.3.5'
-
-  '@jimp/plugin-crop@0.16.13':
-    resolution: {integrity: sha512-WEl2tPVYwzYL8OKme6Go2xqiWgKsgxlMwyHabdAU4tXaRwOCnOI7v4021gCcBb9zn/oWwguHuKHmK30Fw2Z/PA==}
-    peerDependencies:
-      '@jimp/custom': '>=0.3.5'
-
-  '@jimp/plugin-displace@0.16.13':
-    resolution: {integrity: sha512-qt9WKq8vWrcjySa9DyQ0x/RBMHQeiVjdVSY1SJsMjssPUf0pS74qorcuAkGi89biN3YoGUgPkpqECnAWnYwgGA==}
-    peerDependencies:
-      '@jimp/custom': '>=0.3.5'
-
-  '@jimp/plugin-dither@0.16.13':
-    resolution: {integrity: sha512-5/N3yJggbWQTlGZHQYJPmQXEwR52qaXjEzkp1yRBbtdaekXE3BG/suo0fqeoV/csf8ooI78sJzYmIrxNoWVtgQ==}
-    peerDependencies:
-      '@jimp/custom': '>=0.3.5'
-
-  '@jimp/plugin-fisheye@0.16.13':
-    resolution: {integrity: sha512-2rZmTdFbT/cF9lEZIkXCYO0TsT114Q27AX5IAo0Sju6jVQbvIk1dFUTnwLDadTo8wkJlFzGqMQ24Cs8cHWOliA==}
-    peerDependencies:
-      '@jimp/custom': '>=0.3.5'
-
-  '@jimp/plugin-flip@0.16.13':
-    resolution: {integrity: sha512-EmcgAA74FTc5u7Z+hUO/sRjWwfPPLuOQP5O64x5g4j0T12Bd29IgsYZxoutZo/rb3579+JNa/3wsSEmyVv1EpA==}
-    peerDependencies:
-      '@jimp/custom': '>=0.3.5'
-      '@jimp/plugin-rotate': '>=0.3.5'
-
-  '@jimp/plugin-gaussian@0.16.13':
-    resolution: {integrity: sha512-A1XKfGQD0iDdIiKqFYi8nZMv4dDVYdxbrmgR7y/CzUHhSYdcmoljLIIsZZM3Iks/Wa353W3vtvkWLuDbQbch1w==}
-    peerDependencies:
-      '@jimp/custom': '>=0.3.5'
-
-  '@jimp/plugin-invert@0.16.13':
-    resolution: {integrity: sha512-xFMrIn7czEZbdbMzZWuaZFnlLGJDVJ82y5vlsKsXRTG2kcxRsMPXvZRWHV57nSs1YFsNqXSbrC8B98n0E32njQ==}
-    peerDependencies:
-      '@jimp/custom': '>=0.3.5'
-
-  '@jimp/plugin-mask@0.16.13':
-    resolution: {integrity: sha512-wLRYKVBXql2GAYgt6FkTnCfE+q5NomM7Dlh0oIPGAoMBWDyTx0eYutRK6PlUrRK2yMHuroAJCglICTbxqGzowQ==}
-    peerDependencies:
-      '@jimp/custom': '>=0.3.5'
-
-  '@jimp/plugin-normalize@0.16.13':
-    resolution: {integrity: sha512-3tfad0n9soRna4IfW9NzQdQ2Z3ijkmo21DREHbE6CGcMIxOSvfRdSvf1qQPApxjTSo8LTU4MCi/fidx/NZ0GqQ==}
-    peerDependencies:
-      '@jimp/custom': '>=0.3.5'
-
-  '@jimp/plugin-print@0.16.13':
-    resolution: {integrity: sha512-0m6i3p01PGRkGAK9r53hDYrkyMq+tlhLOIbsSTmZyh6HLshUKlTB7eXskF5OpVd5ZUHoltlNc6R+ggvKIzxRFw==}
-    peerDependencies:
-      '@jimp/custom': '>=0.3.5'
-      '@jimp/plugin-blit': '>=0.3.5'
-
-  '@jimp/plugin-resize@0.16.13':
-    resolution: {integrity: sha512-qoqtN8LDknm3fJm9nuPygJv30O3vGhSBD2TxrsCnhtOsxKAqVPJtFVdGd/qVuZ8nqQANQmTlfqTiK9mVWQ7MiQ==}
-    peerDependencies:
-      '@jimp/custom': '>=0.3.5'
-
-  '@jimp/plugin-rotate@0.16.13':
-    resolution: {integrity: sha512-Ev+Jjmj1nHYw897z9C3R9dYsPv7S2/nxdgfFb/h8hOwK0Ovd1k/+yYS46A0uj/JCKK0pQk8wOslYBkPwdnLorw==}
-    peerDependencies:
-      '@jimp/custom': '>=0.3.5'
-      '@jimp/plugin-blit': '>=0.3.5'
-      '@jimp/plugin-crop': '>=0.3.5'
-      '@jimp/plugin-resize': '>=0.3.5'
-
-  '@jimp/plugin-scale@0.16.13':
-    resolution: {integrity: sha512-05POQaEJVucjTiSGMoH68ZiELc7QqpIpuQlZ2JBbhCV+WCbPFUBcGSmE7w4Jd0E2GvCho/NoMODLwgcVGQA97A==}
-    peerDependencies:
-      '@jimp/custom': '>=0.3.5'
-      '@jimp/plugin-resize': '>=0.3.5'
-
-  '@jimp/plugin-shadow@0.16.13':
-    resolution: {integrity: sha512-nmu5VSZ9hsB1JchTKhnnCY+paRBnwzSyK5fhkhtQHHoFD5ArBQ/5wU8y6tCr7k/GQhhGq1OrixsECeMjPoc8Zw==}
-    peerDependencies:
-      '@jimp/custom': '>=0.3.5'
-      '@jimp/plugin-blur': '>=0.3.5'
-      '@jimp/plugin-resize': '>=0.3.5'
-
-  '@jimp/plugin-threshold@0.16.13':
-    resolution: {integrity: sha512-+3zArBH0OE3Rhjm4HyAokMsZlIq5gpQec33CncyoSwxtRBM2WAhUVmCUKuBo+Lr/2/4ISoY4BWpHKhMLDix6cA==}
-    peerDependencies:
-      '@jimp/custom': '>=0.3.5'
-      '@jimp/plugin-color': '>=0.8.0'
-      '@jimp/plugin-resize': '>=0.8.0'
-
-  '@jimp/plugins@0.16.13':
-    resolution: {integrity: sha512-CJLdqODEhEVs4MgWCxpWL5l95sCBlkuSLz65cxEm56X5akIsn4LOlwnKoSEZioYcZUBvHhCheH67AyPTudfnQQ==}
-    peerDependencies:
-      '@jimp/custom': '>=0.3.5'
-
-  '@jimp/png@0.16.13':
-    resolution: {integrity: sha512-8cGqINvbWJf1G0Her9zbq9I80roEX0A+U45xFby3tDWfzn+Zz8XKDF1Nv9VUwVx0N3zpcG1RPs9hfheG4Cq2kg==}
-    peerDependencies:
-      '@jimp/custom': '>=0.3.5'
-
-  '@jimp/tiff@0.16.13':
-    resolution: {integrity: sha512-oJY8d9u95SwW00VPHuCNxPap6Q1+E/xM5QThb9Hu+P6EGuu6lIeLaNBMmFZyblwFbwrH+WBOZlvIzDhi4Dm/6Q==}
-    peerDependencies:
-      '@jimp/custom': '>=0.3.5'
-
-  '@jimp/types@0.16.13':
-    resolution: {integrity: sha512-mC0yVNUobFDjoYLg4hoUwzMKgNlxynzwt3cDXzumGvRJ7Kb8qQGOWJQjQFo5OxmGExqzPphkirdbBF88RVLBCg==}
-    peerDependencies:
-      '@jimp/custom': '>=0.3.5'
-
-  '@jimp/utils@0.16.13':
-    resolution: {integrity: sha512-VyCpkZzFTHXtKgVO35iKN0sYR10psGpV6SkcSeV4oF7eSYlR8Bl6aQLCzVeFjvESF7mxTmIiI3/XrMobVrtxDA==}
-
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -4824,6 +4662,82 @@ packages:
   '@remirror/core-constants@3.0.0':
     resolution: {integrity: sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg==}
 
+  '@resvg/resvg-js-android-arm-eabi@2.6.2':
+    resolution: {integrity: sha512-FrJibrAk6v29eabIPgcTUMPXiEz8ssrAk7TXxsiZzww9UTQ1Z5KAbFJs+Z0Ez+VZTYgnE5IQJqBcoSiMebtPHA==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [android]
+
+  '@resvg/resvg-js-android-arm64@2.6.2':
+    resolution: {integrity: sha512-VcOKezEhm2VqzXpcIJoITuvUS/fcjIw5NA/w3tjzWyzmvoCdd+QXIqy3FBGulWdClvp4g+IfUemigrkLThSjAQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@resvg/resvg-js-darwin-arm64@2.6.2':
+    resolution: {integrity: sha512-nmok2LnAd6nLUKI16aEB9ydMC6Lidiiq2m1nEBDR1LaaP7FGs4AJ90qDraxX+CWlVuRlvNjyYJTNv8qFjtL9+A==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@resvg/resvg-js-darwin-x64@2.6.2':
+    resolution: {integrity: sha512-GInyZLjgWDfsVT6+SHxQVRwNzV0AuA1uqGsOAW+0th56J7Nh6bHHKXHBWzUrihxMetcFDmQMAX1tZ1fZDYSRsw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@resvg/resvg-js-linux-arm-gnueabihf@2.6.2':
+    resolution: {integrity: sha512-YIV3u/R9zJbpqTTNwTZM5/ocWetDKGsro0SWp70eGEM9eV2MerWyBRZnQIgzU3YBnSBQ1RcxRZvY/UxwESfZIw==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@resvg/resvg-js-linux-arm64-gnu@2.6.2':
+    resolution: {integrity: sha512-zc2BlJSim7YR4FZDQ8OUoJg5holYzdiYMeobb9pJuGDidGL9KZUv7SbiD4E8oZogtYY42UZEap7dqkkYuA91pg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@resvg/resvg-js-linux-arm64-musl@2.6.2':
+    resolution: {integrity: sha512-3h3dLPWNgSsD4lQBJPb4f+kvdOSJHa5PjTYVsWHxLUzH4IFTJUAnmuWpw4KqyQ3NA5QCyhw4TWgxk3jRkQxEKg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@resvg/resvg-js-linux-x64-gnu@2.6.2':
+    resolution: {integrity: sha512-IVUe+ckIerA7xMZ50duAZzwf1U7khQe2E0QpUxu5MBJNao5RqC0zwV/Zm965vw6D3gGFUl7j4m+oJjubBVoftw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@resvg/resvg-js-linux-x64-musl@2.6.2':
+    resolution: {integrity: sha512-UOf83vqTzoYQO9SZ0fPl2ZIFtNIz/Rr/y+7X8XRX1ZnBYsQ/tTb+cj9TE+KHOdmlTFBxhYzVkP2lRByCzqi4jQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@resvg/resvg-js-win32-arm64-msvc@2.6.2':
+    resolution: {integrity: sha512-7C/RSgCa+7vqZ7qAbItfiaAWhyRSoD4l4BQAbVDqRRsRgY+S+hgS3in0Rxr7IorKUpGE69X48q6/nOAuTJQxeQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@resvg/resvg-js-win32-ia32-msvc@2.6.2':
+    resolution: {integrity: sha512-har4aPAlvjnLcil40AC77YDIk6loMawuJwFINEM7n0pZviwMkMvjb2W5ZirsNOZY4aDbo5tLx0wNMREp5Brk+w==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@resvg/resvg-js-win32-x64-msvc@2.6.2':
+    resolution: {integrity: sha512-ZXtYhtUr5SSaBrUDq7DiyjOFJqBVL/dOBN7N/qmi/pO0IgiWW/f/ue3nbvu9joWE5aAKDoIzy/CxsY0suwGosQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@resvg/resvg-js@2.6.2':
+    resolution: {integrity: sha512-xBaJish5OeGmniDj9cW5PRa/PtmuVU3ziqrbr5xJj901ZDN4TosrVaNZpEiLZAxdfnhAe7uQ7QFWfjPe9d9K2Q==}
+    engines: {node: '>= 10'}
+
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
@@ -6322,9 +6236,6 @@ packages:
       y-protocols: ^1.0.1
       yjs: ^13.5.38
 
-  '@tokenizer/token@0.3.0':
-    resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
-
   '@tootallnate/once@1.1.2':
     resolution: {integrity: sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==}
     engines: {node: '>= 6'}
@@ -6481,9 +6392,6 @@ packages:
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
-  '@types/node@16.9.1':
-    resolution: {integrity: sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==}
-
   '@types/node@18.19.36':
     resolution: {integrity: sha512-tX1BNmYSWEvViftB26VLNxT6mEr37M7+ldUtq7rlKnv4/2fKYsJIOmqJAjT6h1DNuwQjIKgw3VJ/Dtw3yiTIQw==}
 
@@ -6579,9 +6487,6 @@ packages:
 
   '@types/yargs@17.0.32':
     resolution: {integrity: sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==}
-
-  '@types/yauzl@2.10.3':
-    resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
 
   '@typescript-eslint/eslint-plugin@5.62.0':
     resolution: {integrity: sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==}
@@ -7469,9 +7374,6 @@ packages:
     resolution: {integrity: sha512-BJ8/l4R5LRE7hW9WdSuGYrLSHi2ynxeFpDFbH0K/CgNeY/tyhk+vO6TYxXC5r5CpUhNVX310xzPsN/H9lCdfOA==}
     engines: {node: '>=14'}
 
-  any-base@1.1.0:
-    resolution: {integrity: sha512-uMgjozySS8adZZYePpaWs8cxB9/kdzmpX6SgJZ+wbz1K5eYk5QMYDVJaZKhxyIHUdnnJkfR7SVgStgH7LkGUyg==}
-
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
 
@@ -7748,9 +7650,6 @@ packages:
   blob-util@2.0.2:
     resolution: {integrity: sha512-T7JQa+zsXXEa6/8ZhHcQEW1UFfVM49Ts65uBkFL6fz2QmrElqmbajIDJvuA0tEhRe5eIjpV9ZF+0RfZR9voJFQ==}
 
-  bmp-js@0.1.0:
-    resolution: {integrity: sha512-vHdS19CnY3hwiNdkaqk93DvjVLfbEcI8mys4UjuWrlX1haDmroo8o4xCzh4wD6DGV6HxRCyauwhHRqMTfERtjw==}
-
   body-parser@1.20.2:
     resolution: {integrity: sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
@@ -7806,16 +7705,9 @@ packages:
   bser@2.1.1:
     resolution: {integrity: sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==}
 
-  buffer-crc32@0.2.13:
-    resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
-
   buffer-crc32@1.0.0:
     resolution: {integrity: sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==}
     engines: {node: '>=8.0.0'}
-
-  buffer-equal@0.0.1:
-    resolution: {integrity: sha512-RgSV6InVQ9ODPdLWJ5UAqBqJBOg370Nz6ZQtRzpt6nUjc8v0St97uJ4PYC6NztqIScrAXafKM3mZPMygSe1ggA==}
-    engines: {node: '>=0.4.0'}
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
@@ -8491,15 +8383,6 @@ packages:
       supports-color:
         optional: true
 
-  debug@4.3.2:
-    resolution: {integrity: sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==}
-    engines: {node: '>=6.0'}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-
   debug@4.3.5:
     resolution: {integrity: sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==}
     engines: {node: '>=6.0'}
@@ -8714,9 +8597,6 @@ packages:
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
-  devtools-protocol@0.0.937139:
-    resolution: {integrity: sha512-daj+rzR3QSxsPRy5vjjthn58axO8c11j58uY0lG5vvlJk/EiOdCWOptGdkXDjtuRHr78emKq0udHCXM4trhoDQ==}
-
   diff-sequences@27.5.1:
     resolution: {integrity: sha512-k1gCAXAsNgLwEL+Y8Wvl+M6oEFj5bgazfZULpS5CneoPPXRaCCW7dm+q21Ky2VEE5X+VeRDBVg1Pcvvsr4TtNQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
@@ -8782,9 +8662,6 @@ packages:
   dom-serializer@3.1.1:
     resolution: {integrity: sha512-4MEa38/QexBob6gFNwu+EGdWvhJ1OKuNwdYY3Y3NyeWDQfnGeDYQUDfIRzWu5B5gsv03so2Uxd28YC6zrsx3Lw==}
     engines: {node: '>=20.19.0'}
-
-  dom-walk@0.1.2:
-    resolution: {integrity: sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w==}
 
   domelementtype@1.3.1:
     resolution: {integrity: sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==}
@@ -9523,9 +9400,6 @@ packages:
     resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
     engines: {node: '>=16.17'}
 
-  exif-parser@0.1.12:
-    resolution: {integrity: sha512-c2bQfLNbMzLPmzQuOr8fy0csy84WmwnER81W88DzTp9CYNPJ6yzOj2EZAh9pywYpqHnshVLHQJ8WzldAyfY+Iw==}
-
   exit@0.1.2:
     resolution: {integrity: sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==}
     engines: {node: '>= 0.8.0'}
@@ -9583,11 +9457,6 @@ packages:
 
   externality@1.0.2:
     resolution: {integrity: sha512-LyExtJWKxtgVzmgtEHyQtLFpw1KFhQphF9nTG8TpAIVkiI/xQ3FJh75tRFLYl4hkn7BNIIdLJInuDAavX35pMw==}
-
-  extract-zip@2.0.1:
-    resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
-    engines: {node: '>= 10.17.0'}
-    hasBin: true
 
   fake-indexeddb@6.2.5:
     resolution: {integrity: sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==}
@@ -9654,9 +9523,6 @@ packages:
   fb-watchman@2.0.2:
     resolution: {integrity: sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==}
 
-  fd-slicer@1.1.0:
-    resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
-
   fdir@6.4.3:
     resolution: {integrity: sha512-PMXmW2y1hDDfTSRc9gaXIuCCRpuoz3Kaz8cUelp3smouvfT632ozg2vrT6lJsHKKOF59YLbOGfAWGUcKEfRMQw==}
     peerDependencies:
@@ -9697,10 +9563,6 @@ packages:
   file-type@10.11.0:
     resolution: {integrity: sha512-uzk64HRpUZyTGZtVuvrjP0FYxzQrBf4rojot6J65YMEbwBLB0CWm0CLojVpwpmFmxcE/lkvYICgfcGozbBq6rw==}
     engines: {node: '>=6'}
-
-  file-type@16.5.4:
-    resolution: {integrity: sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==}
-    engines: {node: '>=10'}
 
   file-uri-to-path@1.0.0:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
@@ -9990,10 +9852,6 @@ packages:
     resolution: {integrity: sha512-jZV7n6jGE3Gt7fgSTJoz91Ak5MuTLwMwkoYdjxuJ/AmjIsE1UC03y/IWkZCQGEvVNS9qoRNwy5BCqxImv0FVeA==}
     engines: {node: '>=0.12.0'}
 
-  get-stream@5.2.0:
-    resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
-    engines: {node: '>=8'}
-
   get-stream@6.0.1:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
     engines: {node: '>=10'}
@@ -10008,9 +9866,6 @@ packages:
 
   get-tsconfig@4.7.5:
     resolution: {integrity: sha512-ZCuZCnlqNzjb4QprAzXKdpp/gh6KTxSJuw3IBsPnV/7fV4NxC9ckB+vPTt8w7fJA0TaSD7c55BR47JD6MEDyDw==}
-
-  gifwrap@0.9.4:
-    resolution: {integrity: sha512-MDMwbhASQuVeD4JKd1fKgNgCRL3fGqMM4WaqpNhWO0JiMOAjbQdumbs4BbBZEy9/M00EHEjKN3HieVhCUlwjeQ==}
 
   giget@3.2.0:
     resolution: {integrity: sha512-GvHTWcykIR/fP8cj8dMpuMMkvaeJfPvYnhq0oW+chSeIr+ldX21ifU2Ms6KBoyKZQZmVaUAAhQ2EZ68KJF8a7A==}
@@ -10077,9 +9932,6 @@ packages:
   global-prefix@3.0.0:
     resolution: {integrity: sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==}
     engines: {node: '>=6'}
-
-  global@4.4.0:
-    resolution: {integrity: sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==}
 
   globals@11.12.0:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
@@ -10368,10 +10220,6 @@ packages:
     resolution: {integrity: sha512-S9wWkJ/VSY9/k4qcjG318bqJNruzE4HySUhFYknwmu6LBP97KLLfwNf+n4V1BHurvFNkSKLFnK/RsuUnRTf9Vw==}
     engines: {iojs: '>= 1.0.0', node: '>= 0.12.0'}
 
-  https-proxy-agent@5.0.0:
-    resolution: {integrity: sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==}
-    engines: {node: '>= 6'}
-
   https-proxy-agent@5.0.1:
     resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
     engines: {node: '>= 6'}
@@ -10436,9 +10284,6 @@ packages:
 
   image-meta@0.2.2:
     resolution: {integrity: sha512-3MOLanc3sb3LNGWQl1RlQlNWURE5g32aUphrDyFeCsxBTk08iE3VNe4CwsUZ0Qs1X+EfX0+r29Sxdpza4B+yRA==}
-
-  image-q@4.0.0:
-    resolution: {integrity: sha512-PfJGVgIfKQJuq3s0tTDOKtztksibuUEbJQIYT3by6wctQo+Rdlh7ef4evJ5NCdxY4CfMbvFkocEwbl4BF8RlJw==}
 
   image-type@4.1.0:
     resolution: {integrity: sha512-CFJMJ8QK8lJvRlTCEgarL4ro6hfDQKif2HjSvYCdQZESaIPV4v9imrf7BQHK+sQeTeNeMpWciR9hyC/g8ybXEg==}
@@ -10621,9 +10466,6 @@ packages:
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
-
-  is-function@1.0.2:
-    resolution: {integrity: sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ==}
 
   is-generator-fn@2.1.0:
     resolution: {integrity: sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==}
@@ -11186,9 +11028,6 @@ packages:
       node-notifier:
         optional: true
 
-  jimp@0.16.13:
-    resolution: {integrity: sha512-Bxz8q7V4rnCky9A0ktTNGA9SkNFVWRHodddI/DaAWZJzF7sVUlFYKQ60y9JGqrKpi48ECA/TnfMzzc5C70VByA==}
-
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
@@ -11489,9 +11328,6 @@ packages:
   listhen@1.10.0:
     resolution: {integrity: sha512-kfz4C0OrC6IpaVMtYDJtf6PFjurxe9NBBoDAh/o2p587INryFOO4DQ9OetbCdDrWFt1m1CJKvYrzkGsuPHw8nQ==}
     hasBin: true
-
-  load-bmfont@1.4.1:
-    resolution: {integrity: sha512-8UyQoYmdRDy81Brz6aLAUhfZLwr5zV0L3taTQ4hju7m6biuwiWiJXjPhBJxbUQJA8PrkvJ/7Enqmwk2sM14soA==}
 
   local-pkg@0.5.1:
     resolution: {integrity: sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==}
@@ -11959,9 +11795,6 @@ packages:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
 
-  min-document@2.19.0:
-    resolution: {integrity: sha512-9Wy1B3m3f66bPPmU5hdA4DR4PB2OfDU/+GS3yAB7IQozE3tqXaVv2zOjgla7MEGSRv95+ILmOuvhLkOK6wJtCQ==}
-
   min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
@@ -12282,10 +12115,6 @@ packages:
   node-fetch-native@1.6.7:
     resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
 
-  node-fetch@2.6.5:
-    resolution: {integrity: sha512-mmlIVHJEu5rnIxgEgez6b9GgWXbkZj5YZ7fx+2r94a2E+Uirsp6HsPTPlomfdHtpt/B0cdKviwkoaM6pyvUOpQ==}
-    engines: {node: 4.x || >=6.0.0}
-
   node-fetch@2.7.0:
     resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
     engines: {node: 4.x || >=6.0.0}
@@ -12538,9 +12367,6 @@ packages:
   ohash@2.0.11:
     resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
 
-  omggif@1.0.10:
-    resolution: {integrity: sha512-LMJTtvgc/nugXj0Vcrrs68Mn2D1r0zf630VNtqtpI1FEO7e+O9FP4gqs9AcnBaSEeoHIPm28u6qgPR0oyEpGSw==}
-
   on-change@6.0.2:
     resolution: {integrity: sha512-08+12qcOVEA0fS9g/VxKS27HaT94nRutUT77J2dr8zv/unzXopvhBuF8tNLWsoLQ5IgrQ6eptGeGqUYat82U1w==}
     engines: {node: '>=20'}
@@ -12733,20 +12559,8 @@ packages:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
 
-  parse-bmfont-ascii@1.0.6:
-    resolution: {integrity: sha512-U4RrVsUFCleIOBsIGYOMKjn9PavsGOXxbvYGtMOEfnId0SVNsgehXh1DxUdVPLoxd5mvcEtvmKs2Mmf0Mpa1ZA==}
-
-  parse-bmfont-binary@1.0.6:
-    resolution: {integrity: sha512-GxmsRea0wdGdYthjuUeWTMWPqm2+FAd4GI8vCvhgJsFnoGhTrLhXDDupwTo7rXVAgaLIGoVHDZS9p/5XbSqeWA==}
-
-  parse-bmfont-xml@1.1.6:
-    resolution: {integrity: sha512-0cEliVMZEhrFDwMh4SxIyVJpqYoOWDJ9P895tFuS+XuNzI5UBmBk5U5O4KuJdTnZpSBI4LFA2+ZiJaiwfSwlMA==}
-
   parse-entities@4.0.2:
     resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
-
-  parse-headers@2.0.5:
-    resolution: {integrity: sha512-ft3iAoLOB/MlwbNXgzy43SWGP6sQki2jQvAyBg/zDFAgr9bfNWZIUj42Kw2eJIl8kEi4PbgE6U1Zau/HwI75HA==}
 
   parse-json@5.2.0:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
@@ -12851,22 +12665,11 @@ packages:
     resolution: {integrity: sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==}
     engines: {node: '>= 14.16'}
 
-  peek-readable@4.1.0:
-    resolution: {integrity: sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg==}
-    engines: {node: '>=8'}
-
-  pend@1.2.0:
-    resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
-
   perfect-debounce@1.0.0:
     resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
 
   perfect-debounce@2.1.0:
     resolution: {integrity: sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==}
-
-  phin@2.9.3:
-    resolution: {integrity: sha512-CzFr90qM24ju5f88quFC/6qohjC144rehe5n6DH900lgXmUe86+xCKc10ev56gRKC4/BkHUoG4uSiQgBiIXwDA==}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   picocolors@1.0.1:
     resolution: {integrity: sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==}
@@ -12898,10 +12701,6 @@ packages:
   pirates@4.0.6:
     resolution: {integrity: sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==}
     engines: {node: '>= 6'}
-
-  pixelmatch@4.0.2:
-    resolution: {integrity: sha512-J8B6xqiO37sU/gkcMglv6h5Jbd9xNER7aHzpfRdNmV4IbQBzBpe4l9XmbG+xPF/znacgu2jfEw+wHffaq/YkXA==}
-    hasBin: true
 
   pixelmatch@5.3.0:
     resolution: {integrity: sha512-o8mkY4E/+LNUf6LzX96ht6k6CEDi65k9G2rjMtBe9Oo+VPKSvl+0GKHuH/AlG+GA5LPG/i5hrekkxUc3s2HU+Q==}
@@ -13433,10 +13232,6 @@ packages:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
     engines: {node: '>= 0.6.0'}
 
-  progress@2.0.3:
-    resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
-    engines: {node: '>=0.4.0'}
-
   promise@7.3.1:
     resolution: {integrity: sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==}
 
@@ -13589,11 +13384,6 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
-  puppeteer@12.0.1:
-    resolution: {integrity: sha512-YQ3GRiyZW0ddxTW+iiQcv2/8TT5c3+FcRUCg7F8q2gHqxd5akZN400VRXr9cHQKLWGukmJLDiE72MrcLK9tFHQ==}
-    engines: {node: '>=10.18.1'}
-    deprecated: < 24.15.0 is no longer supported
-
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
 
@@ -13690,10 +13480,6 @@ packages:
     resolution: {integrity: sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
-  readable-web-to-node-stream@3.0.2:
-    resolution: {integrity: sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==}
-    engines: {node: '>=8'}
-
   readdir-glob@1.1.3:
     resolution: {integrity: sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==}
 
@@ -13727,9 +13513,6 @@ packages:
   redis-parser@3.0.0:
     resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
     engines: {node: '>=4'}
-
-  regenerator-runtime@0.13.11:
-    resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==}
 
   regenerator-runtime@0.14.1:
     resolution: {integrity: sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==}
@@ -14007,9 +13790,6 @@ packages:
     resolution: {integrity: sha512-ByXE1oLD79GVq9Ht1PeHWCPMPB8XHpBuz1r85oByKHjZY6qV6rWnQovQzXJXuQ/XyE1Oj3iPk3lo28uzaRA2/Q==}
     engines: {node: '>=14.0.0'}
     hasBin: true
-
-  sax@1.4.1:
-    resolution: {integrity: sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==}
 
   sax@1.6.0:
     resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
@@ -14457,10 +14237,6 @@ packages:
   strip-literal@3.1.0:
     resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
 
-  strtok3@6.3.0:
-    resolution: {integrity: sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==}
-    engines: {node: '>=10'}
-
   structured-clone-es@2.0.0:
     resolution: {integrity: sha512-5UuAHmBLXYPCl22xWJrFuGmIhBKQzxISPVz6E7nmTmTcAOpUzlbjKJsRrCE4vADmMQ0dzeCnlWn9XufnAGf76Q==}
 
@@ -14578,10 +14354,6 @@ packages:
 
   svg-tags@1.0.0:
     resolution: {integrity: sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==}
-
-  svgo-autocrop@1.1.1:
-    resolution: {integrity: sha512-pvrbr1Fz8SZtqWjxNWnjn+sInj/7QuIY4Iz5eIjdX4DZpJ9oTSInjgv/9i5UrizcrqQPryDw0lcr1QlrnUkcNA==}
-    hasBin: true
 
   svgo@2.8.0:
     resolution: {integrity: sha512-+N/Q9kV1+F+UeWYoSiULYo4xYSDQlTgb+ayMobAXPwMnLvop7oxKMo9OzIrX5x3eS4L4f2UHhc9axXwY8DpChg==}
@@ -14702,17 +14474,11 @@ packages:
   through2@2.0.5:
     resolution: {integrity: sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==}
 
-  through@2.3.8:
-    resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
-
   tiff@2.1.0:
     resolution: {integrity: sha512-Q4zLT4+Csn/ZhFVacYCAl+w/1J51NW/m2y2yx7Qxp/bsHYOEsK7+5JOID2kfk+EvsaF0LbA6ccAkqiuXOmAbYw==}
 
   tiff@5.0.3:
     resolution: {integrity: sha512-R0WckwRGhawWDNdha8iPQCjHyOiaEEmfFjhmalUVCIEELsON7Y/XO3eeGmBkoCXQp0Gg2nmTozN92Z4hlwbsow==}
-
-  timm@1.7.1:
-    resolution: {integrity: sha512-IjZc9KIotudix8bMaBW6QvMuq64BrJWFs1+4V0lXwWGQZwH+LnX87doAYhem4caOEusRP9/g6jVDQmZ8XOk1nw==}
 
   tiny-inflate@1.0.3:
     resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
@@ -14726,9 +14492,6 @@ packages:
   tinyclip@0.1.14:
     resolution: {integrity: sha512-F1oWdz8tjT17qe1d5JgDK6z03WGOhYYAN0lK3/D/fzNiy93xswLLEw7pk+3g05onhAy6Bsc6PLNUGhdgVjemMQ==}
     engines: {node: ^16.14.0 || >= 17.3.0}
-
-  tinycolor2@1.6.0:
-    resolution: {integrity: sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==}
 
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
@@ -14811,10 +14574,6 @@ packages:
 
   token-stream@1.0.0:
     resolution: {integrity: sha512-VSsyNPPW74RpHwR8Fc21uubwHY7wMDeJLys2IX5zJNih+OnAnaifKHo+1LHT7DAdloQ7apeaaWg8l7qnf/TnEg==}
-
-  token-types@4.2.1:
-    resolution: {integrity: sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==}
-    engines: {node: '>=10'}
 
   tosource@2.0.0-alpha.3:
     resolution: {integrity: sha512-KAB2lrSS48y91MzFPFuDg4hLbvDiyTjOVgaK7Erw+5AmZXNq4sFRVn8r6yxSLuNs15PaokrDRpS61ERY9uZOug==}
@@ -15182,9 +14941,6 @@ packages:
   unbox-primitive@1.0.2:
     resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==}
 
-  unbzip2-stream@1.4.3:
-    resolution: {integrity: sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==}
-
   unconfig-core@7.5.0:
     resolution: {integrity: sha512-Su3FauozOGP44ZmKdHy2oE6LPjk51M/TRRjHv2HNCWiDvfvCoxC2lno6jevMA91MYAdCdwP05QnWdWpSbncX/w==}
 
@@ -15450,9 +15206,6 @@ packages:
 
   url-parse@1.5.10:
     resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
-
-  utif@2.0.1:
-    resolution: {integrity: sha512-Z/S1fNKCicQTf375lIP9G8Sa1H/phcysstNrrSdZKj1f9g58J4NMgb5IgiEZN9/nLMPDwF0W7hdOe9Qq2IYoLg==}
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -15977,6 +15730,9 @@ packages:
   vue-component-type-helpers@3.3.6:
     resolution: {integrity: sha512-FkljacAwJ9BUoSUdpFe3VDy0sGigNlTH9+2zcXUWmZOjN8swiCkl3t48wOJun0OsUd2cEIda1l04tsxMiKIIrQ==}
 
+  vue-component-type-helpers@3.3.8:
+    resolution: {integrity: sha512-troqCMmQodQDqUqn63NQaFi+CDSclSe7sc8VEBFqf5GFLqmGR2Ph3P2WEC7qwpRVyEWsTi/aAr4vyOe/B1hU3g==}
+
   vue-demi@0.14.10:
     resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
     engines: {node: '>=12'}
@@ -16306,18 +16062,6 @@ packages:
       utf-8-validate:
         optional: true
 
-  ws@8.2.3:
-    resolution: {integrity: sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: ^5.0.2
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
   ws@8.20.1:
     resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
     engines: {node: '>=10.0.0'}
@@ -16350,9 +16094,6 @@ packages:
     resolution: {integrity: sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==}
     engines: {node: '>=20'}
 
-  xhr@2.6.0:
-    resolution: {integrity: sha512-/eCGLb5rxjx5e3mF1A7s+pLlR6CGyqWN91fv1JgER5mVWg1MZmlhBvy9kjcsOdRk8RrIujotWyJamfyrp+WIcA==}
-
   xml-name-validator@3.0.0:
     resolution: {integrity: sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==}
 
@@ -16364,19 +16105,8 @@ packages:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
 
-  xml-parse-from-string@1.0.1:
-    resolution: {integrity: sha512-ErcKwJTF54uRzzNMXq2X5sMIy88zJvfN2DmdoQvy7PAFJ+tPRU6ydWuOKNMyfmOjdyBQTFREi60s0Y0SyI0G0g==}
-
-  xml2js@0.5.0:
-    resolution: {integrity: sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==}
-    engines: {node: '>=4.0.0'}
-
   xml@1.0.1:
     resolution: {integrity: sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==}
-
-  xmlbuilder@11.0.1:
-    resolution: {integrity: sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==}
-    engines: {node: '>=4.0'}
 
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
@@ -16467,9 +16197,6 @@ packages:
   yargs@18.0.0:
     resolution: {integrity: sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=23}
-
-  yauzl@2.10.0:
-    resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
 
   yjs@13.6.31:
     resolution: {integrity: sha512-Eq+5BRfbeGyqGVrTJL3bEcr8gKkxPuyuoHmAwpk52fDb8kOVMrfVSTRPd6yiGgX5Fskb96qCRjzjbRjrL4YEnw==}
@@ -18799,247 +18526,6 @@ snapshots:
       '@types/yargs': 17.0.32
       chalk: 4.1.2
 
-  '@jimp/bmp@0.16.13(@jimp/custom@0.16.13)':
-    dependencies:
-      '@babel/runtime': 7.24.7
-      '@jimp/custom': 0.16.13
-      '@jimp/utils': 0.16.13
-      bmp-js: 0.1.0
-
-  '@jimp/core@0.16.13':
-    dependencies:
-      '@babel/runtime': 7.24.7
-      '@jimp/utils': 0.16.13
-      any-base: 1.1.0
-      buffer: 5.7.1
-      exif-parser: 0.1.12
-      file-type: 16.5.4
-      load-bmfont: 1.4.1
-      mkdirp: 0.5.6
-      phin: 2.9.3
-      pixelmatch: 4.0.2
-      tinycolor2: 1.6.0
-
-  '@jimp/custom@0.16.13':
-    dependencies:
-      '@babel/runtime': 7.24.7
-      '@jimp/core': 0.16.13
-
-  '@jimp/gif@0.16.13(@jimp/custom@0.16.13)':
-    dependencies:
-      '@babel/runtime': 7.24.7
-      '@jimp/custom': 0.16.13
-      '@jimp/utils': 0.16.13
-      gifwrap: 0.9.4
-      omggif: 1.0.10
-
-  '@jimp/jpeg@0.16.13(@jimp/custom@0.16.13)':
-    dependencies:
-      '@babel/runtime': 7.24.7
-      '@jimp/custom': 0.16.13
-      '@jimp/utils': 0.16.13
-      jpeg-js: 0.4.4
-
-  '@jimp/plugin-blit@0.16.13(@jimp/custom@0.16.13)':
-    dependencies:
-      '@babel/runtime': 7.24.7
-      '@jimp/custom': 0.16.13
-      '@jimp/utils': 0.16.13
-
-  '@jimp/plugin-blur@0.16.13(@jimp/custom@0.16.13)':
-    dependencies:
-      '@babel/runtime': 7.24.7
-      '@jimp/custom': 0.16.13
-      '@jimp/utils': 0.16.13
-
-  '@jimp/plugin-circle@0.16.13(@jimp/custom@0.16.13)':
-    dependencies:
-      '@babel/runtime': 7.24.7
-      '@jimp/custom': 0.16.13
-      '@jimp/utils': 0.16.13
-
-  '@jimp/plugin-color@0.16.13(@jimp/custom@0.16.13)':
-    dependencies:
-      '@babel/runtime': 7.24.7
-      '@jimp/custom': 0.16.13
-      '@jimp/utils': 0.16.13
-      tinycolor2: 1.6.0
-
-  '@jimp/plugin-contain@0.16.13(@jimp/custom@0.16.13)(@jimp/plugin-blit@0.16.13(@jimp/custom@0.16.13))(@jimp/plugin-resize@0.16.13(@jimp/custom@0.16.13))(@jimp/plugin-scale@0.16.13(@jimp/custom@0.16.13)(@jimp/plugin-resize@0.16.13(@jimp/custom@0.16.13)))':
-    dependencies:
-      '@babel/runtime': 7.24.7
-      '@jimp/custom': 0.16.13
-      '@jimp/plugin-blit': 0.16.13(@jimp/custom@0.16.13)
-      '@jimp/plugin-resize': 0.16.13(@jimp/custom@0.16.13)
-      '@jimp/plugin-scale': 0.16.13(@jimp/custom@0.16.13)(@jimp/plugin-resize@0.16.13(@jimp/custom@0.16.13))
-      '@jimp/utils': 0.16.13
-
-  '@jimp/plugin-cover@0.16.13(@jimp/custom@0.16.13)(@jimp/plugin-crop@0.16.13(@jimp/custom@0.16.13))(@jimp/plugin-resize@0.16.13(@jimp/custom@0.16.13))(@jimp/plugin-scale@0.16.13(@jimp/custom@0.16.13)(@jimp/plugin-resize@0.16.13(@jimp/custom@0.16.13)))':
-    dependencies:
-      '@babel/runtime': 7.24.7
-      '@jimp/custom': 0.16.13
-      '@jimp/plugin-crop': 0.16.13(@jimp/custom@0.16.13)
-      '@jimp/plugin-resize': 0.16.13(@jimp/custom@0.16.13)
-      '@jimp/plugin-scale': 0.16.13(@jimp/custom@0.16.13)(@jimp/plugin-resize@0.16.13(@jimp/custom@0.16.13))
-      '@jimp/utils': 0.16.13
-
-  '@jimp/plugin-crop@0.16.13(@jimp/custom@0.16.13)':
-    dependencies:
-      '@babel/runtime': 7.24.7
-      '@jimp/custom': 0.16.13
-      '@jimp/utils': 0.16.13
-
-  '@jimp/plugin-displace@0.16.13(@jimp/custom@0.16.13)':
-    dependencies:
-      '@babel/runtime': 7.24.7
-      '@jimp/custom': 0.16.13
-      '@jimp/utils': 0.16.13
-
-  '@jimp/plugin-dither@0.16.13(@jimp/custom@0.16.13)':
-    dependencies:
-      '@babel/runtime': 7.24.7
-      '@jimp/custom': 0.16.13
-      '@jimp/utils': 0.16.13
-
-  '@jimp/plugin-fisheye@0.16.13(@jimp/custom@0.16.13)':
-    dependencies:
-      '@babel/runtime': 7.24.7
-      '@jimp/custom': 0.16.13
-      '@jimp/utils': 0.16.13
-
-  '@jimp/plugin-flip@0.16.13(@jimp/custom@0.16.13)(@jimp/plugin-rotate@0.16.13(@jimp/custom@0.16.13)(@jimp/plugin-blit@0.16.13(@jimp/custom@0.16.13))(@jimp/plugin-crop@0.16.13(@jimp/custom@0.16.13))(@jimp/plugin-resize@0.16.13(@jimp/custom@0.16.13)))':
-    dependencies:
-      '@babel/runtime': 7.24.7
-      '@jimp/custom': 0.16.13
-      '@jimp/plugin-rotate': 0.16.13(@jimp/custom@0.16.13)(@jimp/plugin-blit@0.16.13(@jimp/custom@0.16.13))(@jimp/plugin-crop@0.16.13(@jimp/custom@0.16.13))(@jimp/plugin-resize@0.16.13(@jimp/custom@0.16.13))
-      '@jimp/utils': 0.16.13
-
-  '@jimp/plugin-gaussian@0.16.13(@jimp/custom@0.16.13)':
-    dependencies:
-      '@babel/runtime': 7.24.7
-      '@jimp/custom': 0.16.13
-      '@jimp/utils': 0.16.13
-
-  '@jimp/plugin-invert@0.16.13(@jimp/custom@0.16.13)':
-    dependencies:
-      '@babel/runtime': 7.24.7
-      '@jimp/custom': 0.16.13
-      '@jimp/utils': 0.16.13
-
-  '@jimp/plugin-mask@0.16.13(@jimp/custom@0.16.13)':
-    dependencies:
-      '@babel/runtime': 7.24.7
-      '@jimp/custom': 0.16.13
-      '@jimp/utils': 0.16.13
-
-  '@jimp/plugin-normalize@0.16.13(@jimp/custom@0.16.13)':
-    dependencies:
-      '@babel/runtime': 7.24.7
-      '@jimp/custom': 0.16.13
-      '@jimp/utils': 0.16.13
-
-  '@jimp/plugin-print@0.16.13(@jimp/custom@0.16.13)(@jimp/plugin-blit@0.16.13(@jimp/custom@0.16.13))':
-    dependencies:
-      '@babel/runtime': 7.24.7
-      '@jimp/custom': 0.16.13
-      '@jimp/plugin-blit': 0.16.13(@jimp/custom@0.16.13)
-      '@jimp/utils': 0.16.13
-      load-bmfont: 1.4.1
-
-  '@jimp/plugin-resize@0.16.13(@jimp/custom@0.16.13)':
-    dependencies:
-      '@babel/runtime': 7.24.7
-      '@jimp/custom': 0.16.13
-      '@jimp/utils': 0.16.13
-
-  '@jimp/plugin-rotate@0.16.13(@jimp/custom@0.16.13)(@jimp/plugin-blit@0.16.13(@jimp/custom@0.16.13))(@jimp/plugin-crop@0.16.13(@jimp/custom@0.16.13))(@jimp/plugin-resize@0.16.13(@jimp/custom@0.16.13))':
-    dependencies:
-      '@babel/runtime': 7.24.7
-      '@jimp/custom': 0.16.13
-      '@jimp/plugin-blit': 0.16.13(@jimp/custom@0.16.13)
-      '@jimp/plugin-crop': 0.16.13(@jimp/custom@0.16.13)
-      '@jimp/plugin-resize': 0.16.13(@jimp/custom@0.16.13)
-      '@jimp/utils': 0.16.13
-
-  '@jimp/plugin-scale@0.16.13(@jimp/custom@0.16.13)(@jimp/plugin-resize@0.16.13(@jimp/custom@0.16.13))':
-    dependencies:
-      '@babel/runtime': 7.24.7
-      '@jimp/custom': 0.16.13
-      '@jimp/plugin-resize': 0.16.13(@jimp/custom@0.16.13)
-      '@jimp/utils': 0.16.13
-
-  '@jimp/plugin-shadow@0.16.13(@jimp/custom@0.16.13)(@jimp/plugin-blur@0.16.13(@jimp/custom@0.16.13))(@jimp/plugin-resize@0.16.13(@jimp/custom@0.16.13))':
-    dependencies:
-      '@babel/runtime': 7.24.7
-      '@jimp/custom': 0.16.13
-      '@jimp/plugin-blur': 0.16.13(@jimp/custom@0.16.13)
-      '@jimp/plugin-resize': 0.16.13(@jimp/custom@0.16.13)
-      '@jimp/utils': 0.16.13
-
-  '@jimp/plugin-threshold@0.16.13(@jimp/custom@0.16.13)(@jimp/plugin-color@0.16.13(@jimp/custom@0.16.13))(@jimp/plugin-resize@0.16.13(@jimp/custom@0.16.13))':
-    dependencies:
-      '@babel/runtime': 7.24.7
-      '@jimp/custom': 0.16.13
-      '@jimp/plugin-color': 0.16.13(@jimp/custom@0.16.13)
-      '@jimp/plugin-resize': 0.16.13(@jimp/custom@0.16.13)
-      '@jimp/utils': 0.16.13
-
-  '@jimp/plugins@0.16.13(@jimp/custom@0.16.13)':
-    dependencies:
-      '@babel/runtime': 7.24.7
-      '@jimp/custom': 0.16.13
-      '@jimp/plugin-blit': 0.16.13(@jimp/custom@0.16.13)
-      '@jimp/plugin-blur': 0.16.13(@jimp/custom@0.16.13)
-      '@jimp/plugin-circle': 0.16.13(@jimp/custom@0.16.13)
-      '@jimp/plugin-color': 0.16.13(@jimp/custom@0.16.13)
-      '@jimp/plugin-contain': 0.16.13(@jimp/custom@0.16.13)(@jimp/plugin-blit@0.16.13(@jimp/custom@0.16.13))(@jimp/plugin-resize@0.16.13(@jimp/custom@0.16.13))(@jimp/plugin-scale@0.16.13(@jimp/custom@0.16.13)(@jimp/plugin-resize@0.16.13(@jimp/custom@0.16.13)))
-      '@jimp/plugin-cover': 0.16.13(@jimp/custom@0.16.13)(@jimp/plugin-crop@0.16.13(@jimp/custom@0.16.13))(@jimp/plugin-resize@0.16.13(@jimp/custom@0.16.13))(@jimp/plugin-scale@0.16.13(@jimp/custom@0.16.13)(@jimp/plugin-resize@0.16.13(@jimp/custom@0.16.13)))
-      '@jimp/plugin-crop': 0.16.13(@jimp/custom@0.16.13)
-      '@jimp/plugin-displace': 0.16.13(@jimp/custom@0.16.13)
-      '@jimp/plugin-dither': 0.16.13(@jimp/custom@0.16.13)
-      '@jimp/plugin-fisheye': 0.16.13(@jimp/custom@0.16.13)
-      '@jimp/plugin-flip': 0.16.13(@jimp/custom@0.16.13)(@jimp/plugin-rotate@0.16.13(@jimp/custom@0.16.13)(@jimp/plugin-blit@0.16.13(@jimp/custom@0.16.13))(@jimp/plugin-crop@0.16.13(@jimp/custom@0.16.13))(@jimp/plugin-resize@0.16.13(@jimp/custom@0.16.13)))
-      '@jimp/plugin-gaussian': 0.16.13(@jimp/custom@0.16.13)
-      '@jimp/plugin-invert': 0.16.13(@jimp/custom@0.16.13)
-      '@jimp/plugin-mask': 0.16.13(@jimp/custom@0.16.13)
-      '@jimp/plugin-normalize': 0.16.13(@jimp/custom@0.16.13)
-      '@jimp/plugin-print': 0.16.13(@jimp/custom@0.16.13)(@jimp/plugin-blit@0.16.13(@jimp/custom@0.16.13))
-      '@jimp/plugin-resize': 0.16.13(@jimp/custom@0.16.13)
-      '@jimp/plugin-rotate': 0.16.13(@jimp/custom@0.16.13)(@jimp/plugin-blit@0.16.13(@jimp/custom@0.16.13))(@jimp/plugin-crop@0.16.13(@jimp/custom@0.16.13))(@jimp/plugin-resize@0.16.13(@jimp/custom@0.16.13))
-      '@jimp/plugin-scale': 0.16.13(@jimp/custom@0.16.13)(@jimp/plugin-resize@0.16.13(@jimp/custom@0.16.13))
-      '@jimp/plugin-shadow': 0.16.13(@jimp/custom@0.16.13)(@jimp/plugin-blur@0.16.13(@jimp/custom@0.16.13))(@jimp/plugin-resize@0.16.13(@jimp/custom@0.16.13))
-      '@jimp/plugin-threshold': 0.16.13(@jimp/custom@0.16.13)(@jimp/plugin-color@0.16.13(@jimp/custom@0.16.13))(@jimp/plugin-resize@0.16.13(@jimp/custom@0.16.13))
-      timm: 1.7.1
-
-  '@jimp/png@0.16.13(@jimp/custom@0.16.13)':
-    dependencies:
-      '@babel/runtime': 7.24.7
-      '@jimp/custom': 0.16.13
-      '@jimp/utils': 0.16.13
-      pngjs: 3.4.0
-
-  '@jimp/tiff@0.16.13(@jimp/custom@0.16.13)':
-    dependencies:
-      '@babel/runtime': 7.24.7
-      '@jimp/custom': 0.16.13
-      utif: 2.0.1
-
-  '@jimp/types@0.16.13(@jimp/custom@0.16.13)':
-    dependencies:
-      '@babel/runtime': 7.24.7
-      '@jimp/bmp': 0.16.13(@jimp/custom@0.16.13)
-      '@jimp/custom': 0.16.13
-      '@jimp/gif': 0.16.13(@jimp/custom@0.16.13)
-      '@jimp/jpeg': 0.16.13(@jimp/custom@0.16.13)
-      '@jimp/png': 0.16.13(@jimp/custom@0.16.13)
-      '@jimp/tiff': 0.16.13(@jimp/custom@0.16.13)
-      timm: 1.7.1
-
-  '@jimp/utils@0.16.13':
-    dependencies:
-      '@babel/runtime': 7.24.7
-      regenerator-runtime: 0.13.11
-
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -21003,6 +20489,57 @@ snapshots:
 
   '@remirror/core-constants@3.0.0': {}
 
+  '@resvg/resvg-js-android-arm-eabi@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-android-arm64@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-darwin-arm64@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-darwin-x64@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-linux-arm-gnueabihf@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-linux-arm64-gnu@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-linux-arm64-musl@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-linux-x64-gnu@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-linux-x64-musl@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-win32-arm64-msvc@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-win32-ia32-msvc@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-win32-x64-msvc@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js@2.6.2':
+    optionalDependencies:
+      '@resvg/resvg-js-android-arm-eabi': 2.6.2
+      '@resvg/resvg-js-android-arm64': 2.6.2
+      '@resvg/resvg-js-darwin-arm64': 2.6.2
+      '@resvg/resvg-js-darwin-x64': 2.6.2
+      '@resvg/resvg-js-linux-arm-gnueabihf': 2.6.2
+      '@resvg/resvg-js-linux-arm64-gnu': 2.6.2
+      '@resvg/resvg-js-linux-arm64-musl': 2.6.2
+      '@resvg/resvg-js-linux-x64-gnu': 2.6.2
+      '@resvg/resvg-js-linux-x64-musl': 2.6.2
+      '@resvg/resvg-js-win32-arm64-msvc': 2.6.2
+      '@resvg/resvg-js-win32-ia32-msvc': 2.6.2
+      '@resvg/resvg-js-win32-x64-msvc': 2.6.2
+
   '@rolldown/pluginutils@1.0.1': {}
 
   '@rollup/plugin-alias@6.0.0(rollup@4.61.1)':
@@ -21688,7 +21225,7 @@ snapshots:
       ts-dedent: 2.2.0
       type-fest: 2.19.0
       vue: 3.5.37(typescript@5.7.3)
-      vue-component-type-helpers: 3.3.6
+      vue-component-type-helpers: 3.3.8
 
   '@supercharge/promise-pool@2.4.0': {}
 
@@ -22429,8 +21966,6 @@ snapshots:
       y-protocols: 1.0.7(yjs@13.6.31)
       yjs: 13.6.31
 
-  '@tokenizer/token@0.3.0': {}
-
   '@tootallnate/once@1.1.2': {}
 
   '@trysound/sax@0.2.0': {}
@@ -22608,8 +22143,6 @@ snapshots:
 
   '@types/node@12.20.55': {}
 
-  '@types/node@16.9.1': {}
-
   '@types/node@18.19.36':
     dependencies:
       undici-types: 5.26.5
@@ -22703,11 +22236,6 @@ snapshots:
   '@types/yargs@17.0.32':
     dependencies:
       '@types/yargs-parser': 21.0.3
-
-  '@types/yauzl@2.10.3':
-    dependencies:
-      '@types/node': 18.19.36
-    optional: true
 
   '@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@8.36.0(eslint@8.57.0)(typescript@4.9.5))(eslint@8.57.0)(typescript@4.9.5)':
     dependencies:
@@ -24137,8 +23665,6 @@ snapshots:
 
   ansis@4.3.1: {}
 
-  any-base@1.1.0: {}
-
   any-promise@1.3.0: {}
 
   anymatch@3.1.3:
@@ -24491,8 +24017,6 @@ snapshots:
 
   blob-util@2.0.2: {}
 
-  bmp-js@0.1.0: {}
-
   body-parser@1.20.2:
     dependencies:
       bytes: 3.1.2
@@ -24578,11 +24102,7 @@ snapshots:
     dependencies:
       node-int64: 0.4.0
 
-  buffer-crc32@0.2.13: {}
-
   buffer-crc32@1.0.0: {}
-
-  buffer-equal@0.0.1: {}
 
   buffer-from@1.1.2: {}
 
@@ -25334,10 +24854,6 @@ snapshots:
     optionalDependencies:
       supports-color: 5.5.0
 
-  debug@4.3.2:
-    dependencies:
-      ms: 2.1.2
-
   debug@4.3.5:
     dependencies:
       ms: 2.1.2
@@ -25537,8 +25053,6 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
-  devtools-protocol@0.0.937139: {}
-
   diff-sequences@27.5.1: {}
 
   diff-sequences@29.6.3: {}
@@ -25569,7 +25083,7 @@ snapshots:
 
   doctypes@1.1.0: {}
 
-  docus@5.12.1(d9b85ea07a2d7e296a55ed08e0dd5a55):
+  docus@5.12.1(c643f0c1e05997ad3a11d68c44b0dcde):
     dependencies:
       '@ai-sdk/gateway': 3.0.127(zod@4.4.3)
       '@ai-sdk/mcp': 1.0.47(zod@4.4.3)
@@ -25601,7 +25115,7 @@ snapshots:
       motion-v: 2.3.0(@vueuse/core@14.3.0(vue@3.5.13(typescript@5.7.3)))(vue@3.5.13(typescript@5.7.3))
       nuxt: 4.4.8(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@types/node@25.2.0)(@vue/compiler-sfc@3.5.13)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(encoding@0.1.13)(eslint@9.39.2(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.61.1))(rollup@4.61.1)(sass@1.77.6)(stylelint@16.26.1(typescript@5.7.3))(terser@5.31.1)(tsx@4.19.3)(typescript@5.7.3)(vite@7.3.5(@types/node@25.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.77.6)(terser@5.31.1)(tsx@4.19.3)(yaml@2.9.0))(vue-tsc@2.2.4(typescript@5.7.3))(yaml@2.9.0)
       nuxt-llms: 0.2.0(magicast@0.5.3)
-      nuxt-og-image: 6.5.3(55083befa199cd7493282c85c5cc12c3)
+      nuxt-og-image: 6.5.3(0f96a5ff1ae9185635eb944f24b9b27f)
       pathe: 2.0.3
       pkg-types: 2.3.1
       scule: 1.3.0
@@ -25724,8 +25238,6 @@ snapshots:
       domelementtype: 3.0.0
       domhandler: 6.0.1
       entities: 8.0.0
-
-  dom-walk@0.1.2: {}
 
   domelementtype@1.3.1: {}
 
@@ -26720,8 +26232,6 @@ snapshots:
       signal-exit: 4.1.0
       strip-final-newline: 3.0.0
 
-  exif-parser@0.1.12: {}
-
   exit@0.1.2: {}
 
   expand-template@2.0.3: {}
@@ -26838,16 +26348,6 @@ snapshots:
       pathe: 1.1.2
       ufo: 1.6.4
 
-  extract-zip@2.0.1:
-    dependencies:
-      debug: 4.4.3
-      get-stream: 5.2.0
-      yauzl: 2.10.0
-    optionalDependencies:
-      '@types/yauzl': 2.10.3
-    transitivePeerDependencies:
-      - supports-color
-
   fake-indexeddb@6.2.5: {}
 
   fast-bmp@2.0.1:
@@ -26917,10 +26417,6 @@ snapshots:
     dependencies:
       bser: 2.1.1
 
-  fd-slicer@1.1.0:
-    dependencies:
-      pend: 1.2.0
-
   fdir@6.4.3(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
@@ -26948,12 +26444,6 @@ snapshots:
       flat-cache: 4.0.1
 
   file-type@10.11.0: {}
-
-  file-type@16.5.4:
-    dependencies:
-      readable-web-to-node-stream: 3.0.2
-      strtok3: 6.3.0
-      token-types: 4.2.1
 
   file-uri-to-path@1.0.0: {}
 
@@ -27296,10 +26786,6 @@ snapshots:
 
   get-stdin@5.0.1: {}
 
-  get-stream@5.2.0:
-    dependencies:
-      pump: 3.0.0
-
   get-stream@6.0.1: {}
 
   get-stream@8.0.1: {}
@@ -27313,11 +26799,6 @@ snapshots:
   get-tsconfig@4.7.5:
     dependencies:
       resolve-pkg-maps: 1.0.0
-
-  gifwrap@0.9.4:
-    dependencies:
-      image-q: 4.0.0
-      omggif: 1.0.10
 
   giget@3.2.0: {}
 
@@ -27402,11 +26883,6 @@ snapshots:
       ini: 1.3.8
       kind-of: 6.0.3
       which: 1.3.1
-
-  global@4.4.0:
-    dependencies:
-      min-document: 2.19.0
-      process: 0.11.10
 
   globals@11.12.0: {}
 
@@ -27820,13 +27296,6 @@ snapshots:
 
   http-shutdown@1.2.2: {}
 
-  https-proxy-agent@5.0.0:
-    dependencies:
-      agent-base: 6.0.2
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
-
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
@@ -27902,10 +27371,6 @@ snapshots:
       web-worker-manager: 0.2.0
 
   image-meta@0.2.2: {}
-
-  image-q@4.0.0:
-    dependencies:
-      '@types/node': 16.9.1
 
   image-type@4.1.0:
     dependencies:
@@ -28105,8 +27570,6 @@ snapshots:
   is-fullwidth-code-point@2.0.0: {}
 
   is-fullwidth-code-point@3.0.0: {}
-
-  is-function@1.0.2: {}
 
   is-generator-fn@2.1.0: {}
 
@@ -29157,14 +28620,6 @@ snapshots:
       - supports-color
       - ts-node
 
-  jimp@0.16.13:
-    dependencies:
-      '@babel/runtime': 7.24.7
-      '@jimp/custom': 0.16.13
-      '@jimp/plugins': 0.16.13(@jimp/custom@0.16.13)
-      '@jimp/types': 0.16.13(@jimp/custom@0.16.13)
-      regenerator-runtime: 0.13.11
-
   jiti@2.6.1: {}
 
   jiti@2.7.0: {}
@@ -29476,17 +28931,6 @@ snapshots:
       ufo: 1.6.4
       untun: 0.1.3
       uqr: 0.1.3
-
-  load-bmfont@1.4.1:
-    dependencies:
-      buffer-equal: 0.0.1
-      mime: 1.6.0
-      parse-bmfont-ascii: 1.0.6
-      parse-bmfont-binary: 1.0.6
-      parse-bmfont-xml: 1.1.6
-      phin: 2.9.3
-      xhr: 2.6.0
-      xtend: 4.0.2
 
   local-pkg@0.5.1:
     dependencies:
@@ -30161,10 +29605,6 @@ snapshots:
 
   mimic-response@3.1.0: {}
 
-  min-document@2.19.0:
-    dependencies:
-      dom-walk: 0.1.2
-
   min-indent@1.0.1: {}
 
   minimark@0.2.0: {}
@@ -30777,10 +30217,6 @@ snapshots:
 
   node-fetch-native@1.6.7: {}
 
-  node-fetch@2.6.5:
-    dependencies:
-      whatwg-url: 5.0.0
-
   node-fetch@2.7.0(encoding@0.1.13):
     dependencies:
       whatwg-url: 5.0.0
@@ -30888,7 +30324,7 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  nuxt-og-image@6.5.3(55083befa199cd7493282c85c5cc12c3):
+  nuxt-og-image@6.5.3(0f96a5ff1ae9185635eb944f24b9b27f):
     dependencies:
       '@clack/prompts': 1.5.1
       '@nuxt/kit': 4.4.8(magicast@0.5.3)
@@ -30925,6 +30361,7 @@ snapshots:
       unplugin: 3.0.0
       unstorage: 1.17.5(db0@0.3.4(better-sqlite3@12.10.0))(ioredis@5.11.1)
     optionalDependencies:
+      '@resvg/resvg-js': 2.6.2
       '@takumi-rs/core': 1.8.1
       fontless: 0.2.1(db0@0.3.4(better-sqlite3@12.10.0))(ioredis@5.11.1)(vite@7.3.5(@types/node@25.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.77.6)(terser@5.31.1)(tsx@4.19.3)(yaml@2.9.0))
       nitropack: 2.13.4(better-sqlite3@12.10.0)(encoding@0.1.13)(oxc-parser@0.133.0)
@@ -31498,8 +30935,6 @@ snapshots:
 
   ohash@2.0.11: {}
 
-  omggif@1.0.10: {}
-
   on-change@6.0.2: {}
 
   on-finished@2.4.1:
@@ -31909,15 +31344,6 @@ snapshots:
     dependencies:
       callsites: 3.1.0
 
-  parse-bmfont-ascii@1.0.6: {}
-
-  parse-bmfont-binary@1.0.6: {}
-
-  parse-bmfont-xml@1.1.6:
-    dependencies:
-      xml-parse-from-string: 1.0.1
-      xml2js: 0.5.0
-
   parse-entities@4.0.2:
     dependencies:
       '@types/unist': 2.0.11
@@ -31927,8 +31353,6 @@ snapshots:
       is-alphanumerical: 2.0.1
       is-decimal: 2.0.1
       is-hexadecimal: 2.0.1
-
-  parse-headers@2.0.5: {}
 
   parse-json@5.2.0:
     dependencies:
@@ -32015,15 +31439,9 @@ snapshots:
 
   pathval@2.0.0: {}
 
-  peek-readable@4.1.0: {}
-
-  pend@1.2.0: {}
-
   perfect-debounce@1.0.0: {}
 
   perfect-debounce@2.1.0: {}
-
-  phin@2.9.3: {}
 
   picocolors@1.0.1: {}
 
@@ -32040,10 +31458,6 @@ snapshots:
   pify@4.0.1: {}
 
   pirates@4.0.6: {}
-
-  pixelmatch@4.0.2:
-    dependencies:
-      pngjs: 3.4.0
 
   pixelmatch@5.3.0:
     dependencies:
@@ -32561,8 +31975,6 @@ snapshots:
 
   process@0.11.10: {}
 
-  progress@2.0.3: {}
-
   promise@7.3.1:
     dependencies:
       asap: 2.0.6
@@ -32802,25 +32214,6 @@ snapshots:
 
   punycode@2.3.1: {}
 
-  puppeteer@12.0.1:
-    dependencies:
-      debug: 4.3.2
-      devtools-protocol: 0.0.937139
-      extract-zip: 2.0.1
-      https-proxy-agent: 5.0.0
-      node-fetch: 2.6.5
-      pkg-dir: 4.2.0
-      progress: 2.0.3
-      proxy-from-env: 1.1.0
-      rimraf: 3.0.2
-      tar-fs: 2.1.1
-      unbzip2-stream: 1.4.3
-      ws: 8.2.3
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
   pure-rand@6.1.0: {}
 
   qified@0.5.3:
@@ -32940,10 +32333,6 @@ snapshots:
       process: 0.11.10
       string_decoder: 1.3.0
 
-  readable-web-to-node-stream@3.0.2:
-    dependencies:
-      readable-stream: 3.6.2
-
   readdir-glob@1.1.3:
     dependencies:
       minimatch: 5.1.6
@@ -32982,8 +32371,6 @@ snapshots:
   redis-parser@3.0.0:
     dependencies:
       redis-errors: 1.2.0
-
-  regenerator-runtime@0.13.11: {}
 
   regenerator-runtime@0.14.1: {}
 
@@ -33402,8 +32789,6 @@ snapshots:
       chokidar: 3.6.0
       immutable: 4.3.6
       source-map-js: 1.2.1
-
-  sax@1.4.1: {}
 
   sax@1.6.0: {}
 
@@ -33934,11 +33319,6 @@ snapshots:
     dependencies:
       js-tokens: 9.0.1
 
-  strtok3@6.3.0:
-    dependencies:
-      '@tokenizer/token': 0.3.0
-      peek-readable: 4.1.0
-
   structured-clone-es@2.0.0: {}
 
   style-mod@4.1.2: {}
@@ -34139,17 +33519,6 @@ snapshots:
 
   svg-tags@1.0.0: {}
 
-  svgo-autocrop@1.1.1:
-    dependencies:
-      jimp: 0.16.13
-      puppeteer: 12.0.1
-      svg-pathdata: 6.0.3
-      svgo: 2.8.0
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
   svgo@2.8.0:
     dependencies:
       '@trysound/sax': 0.2.0
@@ -34288,8 +33657,6 @@ snapshots:
       readable-stream: 2.3.8
       xtend: 4.0.2
 
-  through@2.3.8: {}
-
   tiff@2.1.0:
     dependencies:
       iobuffer: 2.1.0
@@ -34299,8 +33666,6 @@ snapshots:
       iobuffer: 5.3.2
       pako: 2.1.0
 
-  timm@1.7.1: {}
-
   tiny-inflate@1.0.3: {}
 
   tiny-invariant@1.3.3: {}
@@ -34308,8 +33673,6 @@ snapshots:
   tinybench@2.9.0: {}
 
   tinyclip@0.1.14: {}
-
-  tinycolor2@1.6.0: {}
 
   tinyexec@0.3.2: {}
 
@@ -34375,11 +33738,6 @@ snapshots:
   toidentifier@1.0.1: {}
 
   token-stream@1.0.0: {}
-
-  token-types@4.2.1:
-    dependencies:
-      '@tokenizer/token': 0.3.0
-      ieee754: 1.2.1
 
   tosource@2.0.0-alpha.3: {}
 
@@ -34837,11 +34195,6 @@ snapshots:
       has-symbols: 1.0.3
       which-boxed-primitive: 1.0.2
 
-  unbzip2-stream@1.4.3:
-    dependencies:
-      buffer: 5.7.1
-      through: 2.3.8
-
   unconfig-core@7.5.0:
     dependencies:
       '@quansync/fs': 1.0.0
@@ -35152,10 +34505,6 @@ snapshots:
     dependencies:
       querystringify: 2.2.0
       requires-port: 1.0.0
-
-  utif@2.0.1:
-    dependencies:
-      pako: 1.0.11
 
   util-deprecate@1.0.2: {}
 
@@ -35848,6 +35197,8 @@ snapshots:
 
   vue-component-type-helpers@3.3.6: {}
 
+  vue-component-type-helpers@3.3.8: {}
+
   vue-demi@0.14.10(vue@3.5.13(typescript@5.7.3)):
     dependencies:
       vue: 3.5.13(typescript@5.7.3)
@@ -36264,8 +35615,6 @@ snapshots:
 
   ws@8.18.3: {}
 
-  ws@8.2.3: {}
-
   ws@8.20.1: {}
 
   ws@8.21.0: {}
@@ -36279,29 +35628,13 @@ snapshots:
       is-wsl: 3.1.0
       powershell-utils: 0.1.0
 
-  xhr@2.6.0:
-    dependencies:
-      global: 4.4.0
-      is-function: 1.0.2
-      parse-headers: 2.0.5
-      xtend: 4.0.2
-
   xml-name-validator@3.0.0: {}
 
   xml-name-validator@4.0.0: {}
 
   xml-name-validator@5.0.0: {}
 
-  xml-parse-from-string@1.0.1: {}
-
-  xml2js@0.5.0:
-    dependencies:
-      sax: 1.4.1
-      xmlbuilder: 11.0.1
-
   xml@1.0.1: {}
-
-  xmlbuilder@11.0.1: {}
 
   xmlchars@2.2.0: {}
 
@@ -36410,11 +35743,6 @@ snapshots:
       string-width: 7.2.0
       y18n: 5.0.8
       yargs-parser: 22.0.0
-
-  yauzl@2.10.0:
-    dependencies:
-      buffer-crc32: 0.2.13
-      fd-slicer: 1.1.0
 
   yjs@13.6.31:
     dependencies:


### PR DESCRIPTION
## What?
Replace the unmaintained svgo-autocrop dependency (and its transitive puppeteer + jimp) with a vendored copy under src/autocrop that rasterises via @resvg/resvg-js.

## Why?
svgo-autocrop renders each icon in headless Chrome just to compute a crop box, so puppeteer downloaded a Chromium binary on nearly every install — slow and flaky in CI — and the package is no longer maintained. @resvg/resvg-js is a prebuilt Rust binary (no browser). 

## How?
- Vendored svgo-autocrop's crop/translate logic, swapping only the renderer: Chrome screenshot → resvg render.
- Dropped svgo-autocrop,
- added @resvg/resvg-js + svg-pathdata; 
- removed the npx @puppeteer/browsers install chrome step from the update-icons workflow.
- Restructured index.ts: phase 1 downloads concurrently (network-bound), phase 2 optimizes sequentially (CPU-bound, no open sockets).

## Testing?
- Verified locally and in CI/CD environment, confirmed it does not cause modifications to existing icons.  
- Verified byte-for-byte identical output across all 891 real input→output pairs from run.log. 
- lint:types and lint:eslint pass.