### PR TITLE
fix(component-library): remove datepicker positioning override

### DIFF
--- a/packages/component-library/src/components/mt-datepicker/mt-datepicker.vue
+++ b/packages/component-library/src/components/mt-datepicker/mt-datepicker.vue
@@ -553,7 +553,6 @@ onMounted(() => {
   font-weight: inherit;
   filter: drop-shadow(0px 1px 3px #0000000f);
   filter: drop-shadow(0px 1px 3px #0000001a);
-  left: 0 !important;
   overflow: visible !important;
 }
 


### PR DESCRIPTION
## What?

Remove the obsolete `left: 0 !important` override from `mt-datepicker`.

## Why?

The rule overrides the coordinates calculated by Floating UI, causing the datepicker menu to be positioned incorrectly.

## How?

Removed the `left: 0 !important` declaration from `.dp--menu-wrapper` and kept Floating UI responsible for positioning.

## Testing?

- Verified the diff with `git diff --check`.
- Manually verify the datepicker menu positioning in Storybook.

## Screenshots (optional)

Not applicable.

## Anything Else?

N/A