### PR TITLE
feat: adapt embedded app documents to the Administration theme

### DIFF
--- a/.changeset/admin-sdk-embedded-context.md
+++ b/.changeset/admin-sdk-embedded-context.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-admin-sdk": minor
+---
+
+Inside app iframes the SDK now marks the document root with a `data-embedded` attribute and unsets the body background, so embedded apps no longer paint an opaque light background over dark Administration themes. Documents that already declare `data-embedded` keep their own value. The theme sync additionally mirrors the resolved theme onto the document root's `color-scheme`, which keeps embedded iframes transparent (a color-scheme mismatch makes the browser paint an opaque backdrop behind the iframe).

--- a/docs/admin-sdk/api-reference/context.md
+++ b/docs/admin-sdk/api-reference/context.md
@@ -177,9 +177,15 @@ context.subscribeLocale(({ locale, fallbackLocale }) => {
 
 ## Automatic theme synchronization
 
-On startup, the SDK mirrors the resolved Administration theme onto the `data-theme` attribute of your document root (`<html data-theme="light|dark">`) and keeps it in sync. Because Meteor tokens are theme-aware through `data-theme`, updating the SDK dependency is all an app needs to follow the Administration theme.
+On startup, the SDK mirrors the resolved Administration theme onto the `data-theme` attribute and the `color-scheme` style of your document root (`<html data-theme="light|dark">`) and keeps both in sync. Because Meteor tokens are theme-aware through `data-theme`, updating the SDK dependency is all an app needs to follow the Administration theme. The matching `color-scheme` keeps the iframe transparent — on a mismatch the browser paints an opaque backdrop behind it.
 
 If your document already declares `data-theme` itself, the SDK does not interfere. On Administrations without theme support, the attribute is never set.
+
+## Embedded context
+
+When your app runs inside an iframe, the SDK marks the document root with a `data-embedded` attribute (`<html data-embedded>`) on startup, so stylesheets can adapt to the embedded context. It also unsets the body background (`html[data-embedded] body { background: unset; }`) as a sensible default for iframes inside of the administration.
+
+If your document already declares `data-embedded` itself, the SDK keeps your value.
 
 ## getTheme()
 

--- a/packages/admin-sdk/src/channel.spec.ts
+++ b/packages/admin-sdk/src/channel.spec.ts
@@ -7,6 +7,7 @@ import type {
   subscribe as subscribeType,
   publish as publishType,
   setExtensions as setExtensionsType,
+  applyEmbeddedContext as applyEmbeddedContextType,
 } from './channel';
 import MissingPrivilegesError from './_internals/privileges/missing-privileges-error';
 
@@ -20,6 +21,7 @@ let createHandler: typeof createHandlerType;
 let subscribe: typeof subscribeType;
 let publish: typeof publishType;
 let setExtensions: typeof setExtensionsType;
+let applyEmbeddedContext: typeof applyEmbeddedContextType;
 
 describe('Test the channel bridge from iFrame to admin', () => {
   beforeAll(async () => {
@@ -42,6 +44,7 @@ describe('Test the channel bridge from iFrame to admin', () => {
     subscribe = channel.subscribe;
     publish = channel.publish;
     setExtensions = channel.setExtensions;
+    applyEmbeddedContext = channel.applyEmbeddedContext;
 
     setExtensions({
       'test-extension': {
@@ -266,5 +269,33 @@ describe('Test the channel bridge from iFrame to admin', () => {
     removeHandle();
 
     expect(callback).toHaveBeenCalledTimes(0)
+  });
+
+  describe('embedded context', () => {
+    afterEach(() => {
+      delete document.documentElement.dataset.embedded;
+      document.getElementById('meteor-admin-sdk-embedded')?.remove();
+    });
+
+    it('should mark the document as embedded and unset the body background', () => {
+      applyEmbeddedContext();
+      // A second call must not duplicate anything
+      applyEmbeddedContext();
+
+      expect(document.documentElement.dataset.embedded).toBe('');
+
+      const styles = document.querySelectorAll('#meteor-admin-sdk-embedded');
+      expect(styles).toHaveLength(1);
+      expect(styles[0].textContent).toContain('html[data-embedded] { color-scheme: light dark; }');
+      expect(styles[0].textContent).toContain('html[data-embedded] body { background: unset; }');
+    });
+
+    it('should not overwrite an app-managed data-embedded value', () => {
+      document.documentElement.dataset.embedded = 'app-managed';
+
+      applyEmbeddedContext();
+
+      expect(document.documentElement.dataset.embedded).toBe('app-managed');
+    });
   });
 });

--- a/packages/admin-sdk/src/channel.ts
+++ b/packages/admin-sdk/src/channel.ts
@@ -508,6 +508,11 @@ const datasets = new Map<string, unknown>();
  */
 
 (async (): Promise<void> => {
+  // Mark embedded documents before the first paint (needs no channel)
+  if (window.parent !== window) {
+    applyEmbeddedContext();
+  }
+
   // Handle registrations at current window
   handle('__registerWindow__', ({ sdkVersion }, additionalOptions) => {
     let source: Window | undefined;
@@ -581,9 +586,15 @@ function isThemeValue(value: unknown): value is 'light' | 'dark' {
   return value === 'light' || value === 'dark';
 }
 
+function applyTheme(target: HTMLElement, theme: 'light' | 'dark'): void {
+  target.dataset.theme = theme;
+  // A matching color-scheme keeps embedded iframes transparent (on a mismatch the browser paints an opaque backdrop)
+  target.style.setProperty('color-scheme', theme);
+}
+
 /**
- * Keeps the `data-theme` attribute of `target` in sync with the resolved
- * Administration color theme
+ * Keeps the `data-theme` attribute and `color-scheme` of `target` in sync
+ * with the resolved Administration color theme
  *
  * @internal - used by the automatic sync below and `context.syncTheme()`
  */
@@ -597,13 +608,13 @@ export function startThemeSync(target: HTMLElement): { initialFetch: Promise<voi
     }
 
     hasReceivedUpdate = true;
-    target.dataset.theme = theme;
+    applyTheme(target, theme);
   });
 
   const initialFetch = send('contextTheme', {}).then((theme) => {
     // A theme published in the meantime is newer than the fetched value
     if (!hasReceivedUpdate && isThemeValue(theme)) {
-      target.dataset.theme = theme;
+      applyTheme(target, theme);
     }
   });
 
@@ -631,6 +642,35 @@ export function startAutoThemeSync(): () => void {
   initialFetch.catch(() => {});
 
   return stop;
+}
+
+/**
+ * Marks the document as embedded (`<html data-embedded>`) and unsets the
+ * body background so the Administration theme shows through instead of an
+ * opaque default background. The attribute stays untouched when the document
+ * declares it itself.
+ *
+ * @internal - runs automatically inside app iframes
+ */
+export function applyEmbeddedContext(): void {
+  const root = document.documentElement;
+
+  if (root.dataset.embedded === undefined) {
+    root.dataset.embedded = '';
+  }
+
+  if (document.getElementById('meteor-admin-sdk-embedded')) {
+    return;
+  }
+
+  const style = document.createElement('style');
+  style.id = 'meteor-admin-sdk-embedded';
+  // Supporting both schemes makes the document adopt the scheme the Administration propagates into the iframe until the theme sync pins the resolved one
+  style.textContent = [
+    'html[data-embedded] { color-scheme: light dark; }',
+    'html[data-embedded] body { background: unset; }',
+  ].join('\n');
+  document.head.appendChild(style);
 }
 
 // New dataset registered

--- a/packages/admin-sdk/src/context/theme.spec.ts
+++ b/packages/admin-sdk/src/context/theme.spec.ts
@@ -44,6 +44,7 @@ describe('context theme', () => {
   afterEach(() => {
     cleanups.splice(0).forEach((remove) => remove());
     delete document.documentElement.dataset.theme;
+    document.documentElement.style.removeProperty('color-scheme');
   });
 
   it('gets the current resolved theme', async () => {
@@ -87,10 +88,12 @@ describe('context theme', () => {
 
     track(await syncTheme());
     expect(document.documentElement.dataset.theme).toBe('dark');
+    expect(document.documentElement.style.getPropertyValue('color-scheme')).toBe('dark');
 
     publish('contextTheme', 'light');
     await flushPromises();
     expect(document.documentElement.dataset.theme).toBe('light');
+    expect(document.documentElement.style.getPropertyValue('color-scheme')).toBe('light');
   });
 
   it('syncs the theme to a custom target element', async () => {
@@ -100,6 +103,7 @@ describe('context theme', () => {
     track(await syncTheme({ target }));
 
     expect(target.dataset.theme).toBe('light');
+    expect(target.style.getPropertyValue('color-scheme')).toBe('light');
     expect(document.documentElement.dataset.theme).toBeUndefined();
   });
 


### PR DESCRIPTION
## What?

Inside app iframes the SDK now marks the document as embedded and neutralizes the default body background:

- `<html data-embedded>` is set on startup (skipped when the document declares it itself), so stylesheets can adapt to the embedded context.
- An injected style resets the body background (`html[data-embedded] body { background: unset; }`) and declares `color-scheme: light dark`, so the document adopts the color-scheme the Administration propagates into the iframe.
- The theme sync additionally mirrors the resolved theme onto the document root's `color-scheme` alongside `data-theme`.

## Why?

The component library ships a hardcoded light `body` background (deprecated, removal planned for the next major), and embedded documents defaulted to the light color-scheme. In dark Administrations this painted an opaque light page and white flashes over the theme. A matching `color-scheme` is required for iframe transparency — on a mismatch the browser paints an opaque backdrop.

Doing this in the SDK means extension developers only need to update the admin-sdk — no component-library update required.

## How?

Zero-config: `applyEmbeddedContext()` runs in the existing startup path guarded by `window.parent !== window`, before the channel handshake. The theme sync applies `color-scheme` through the shared `applyTheme()` helper.

## Testing?

Unit tests for the embedded marker (attribute, single style injection, app-ownership) and extended theme sync tests asserting the `color-scheme` mirroring. Verified manually in the Administration (dark/light/system) with an app iframe and the SDK CDN bundle.
