### PR TITLE
feat: apply explicit color scheme to embedded app documents

### DIFF
--- a/.changeset/admin-sdk-explicit-color-scheme.md
+++ b/.changeset/admin-sdk-explicit-color-scheme.md
@@ -2,4 +2,4 @@
 "@shopware-ag/meteor-admin-sdk": minor
 ---
 
-Embedded app documents now always receive an explicit color scheme instead of `color-scheme: light dark`. The initial scheme is read from the `color-scheme` URL param that theme-aware Administrations append to the iframe src, so the correct scheme applies before the first paint. Without the param the document is pinned to `light`, which matches Administrations without theme support and prevents the OS dark mode preference from switching embedded apps to dark. Documents that declare `data-theme` themselves stay untouched.
+Embedded app documents now always receive an explicit color scheme instead of `color-scheme: light dark`. The initial scheme is read from the `color-scheme` URL param that theme-aware Administrations append to the iframe src, so the correct scheme applies before the first paint. Without the param the document is pinned to `light`, which matches Administrations without theme support and prevents the OS dark mode preference from switching embedded apps to dark. Documents that declare `data-theme` themselves stay untouched and are responsible for declaring a matching `color-scheme` in their own styles.

--- a/.changeset/admin-sdk-explicit-color-scheme.md
+++ b/.changeset/admin-sdk-explicit-color-scheme.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-admin-sdk": minor
+---
+
+Embedded app documents now always receive an explicit color scheme instead of `color-scheme: light dark`. The initial scheme is read from the `color-scheme` URL param that theme-aware Administrations append to the iframe src, so the correct scheme applies before the first paint. Without the param the document is pinned to `light`, which matches Administrations without theme support and prevents the OS dark mode preference from switching embedded apps to dark. Documents that declare `data-theme` themselves stay untouched.

--- a/docs/admin-sdk/api-reference/context.md
+++ b/docs/admin-sdk/api-reference/context.md
@@ -177,7 +177,9 @@ context.subscribeLocale(({ locale, fallbackLocale }) => {
 
 ## Automatic theme synchronization
 
-On startup, the SDK mirrors the resolved Administration theme onto the `data-theme` attribute and the `color-scheme` style of your document root (`<html data-theme="light|dark">`) and keeps both in sync. Because Meteor tokens are theme-aware through `data-theme`, updating the SDK dependency is all an app needs to follow the Administration theme. The matching `color-scheme` keeps the iframe transparent — on a mismatch the browser paints an opaque backdrop behind it.
+On startup, the SDK mirrors the resolved Administration theme onto the `data-theme` attribute and the `color-scheme` style of your document root (`<html data-theme="light|dark">`) and keeps both in sync. Because Meteor tokens are theme-aware through `data-theme`, updating the SDK dependency is all an app needs to follow the Administration theme. The matching `color-scheme` keeps the iframe transparent: on a mismatch the browser paints an opaque backdrop behind it.
+
+The initial theme is read from the `color-scheme` URL param that theme-aware Administrations append to the iframe src, so the correct scheme is applied before the first paint. Administrations without theme support do not send the param; in that case the document is pinned to the light scheme, which matches those Administrations and prevents the OS dark mode preference from leaking into the app. Later theme changes arrive through the regular sync.
 
 If your document already declares `data-theme` itself, the SDK does not interfere. On Administrations without theme support, the attribute is never set.
 

--- a/docs/admin-sdk/api-reference/context.md
+++ b/docs/admin-sdk/api-reference/context.md
@@ -181,7 +181,7 @@ On startup, the SDK mirrors the resolved Administration theme onto the `data-the
 
 The initial theme is read from the `color-scheme` URL param that theme-aware Administrations append to the iframe src, so the correct scheme is applied before the first paint. Administrations without theme support do not send the param; in that case the document is pinned to the light scheme, which matches those Administrations and prevents the OS dark mode preference from leaking into the app. Later theme changes arrive through the regular sync.
 
-If your document already declares `data-theme` itself, the SDK does not interfere. On Administrations without theme support, the attribute is never set.
+If your document already declares `data-theme` itself, the SDK does not interfere. In that case, declare a matching `color-scheme` in your own styles: without one the browser falls back to the light scheme and paints an opaque backdrop behind the iframe in a dark Administration. On Administrations without theme support, the attribute is never set.
 
 ## Embedded context
 

--- a/packages/admin-sdk/e2e/channel.spec.ts
+++ b/packages/admin-sdk/e2e/channel.spec.ts
@@ -259,6 +259,62 @@ test.describe('Context tests', () => {
   });
 });
 
+test.describe('Embedded context', () => {
+  function embeddedState(subFrame: { evaluate: <T>(fn: () => T) => Promise<T> }) {
+    return subFrame.evaluate(() => ({
+      embedded: document.documentElement.dataset.embedded,
+      theme: document.documentElement.dataset.theme ?? null,
+      colorScheme: document.documentElement.style.getPropertyValue('color-scheme'),
+      hasStyle: !!document.getElementById('meteor-admin-sdk-embedded'),
+    }));
+  }
+
+  test('pins the light scheme when the iFrame URL declares no color scheme', async ({ page }) => {
+    const { subFrame } = await setup({ page });
+
+    const state = await embeddedState(subFrame);
+
+    expect(state.embedded).toBe('');
+    expect(state.theme).toBeNull();
+    expect(state.colorScheme).toBe('light');
+    expect(state.hasStyle).toBe(true);
+  });
+
+  test('applies the color scheme from the iFrame URL without Administration support', async ({ page }) => {
+    const { subFrame } = await setup({
+      page,
+      subFrameSrc: 'http://localhost:8182?location-id=test&color-scheme=dark',
+    });
+
+    const state = await embeddedState(subFrame);
+
+    expect(state.theme).toBe('dark');
+    expect(state.colorScheme).toBe('dark');
+  });
+
+  test('fetches the theme on boot and follows later theme changes', async ({ page }) => {
+    const { mainFrame, subFrame } = await setup({
+      page,
+      subFrameSrc: 'http://localhost:8182?color-scheme=light',
+      // The handler must exist before the sub frame registers
+      mainFrameSetup: (mainPage) => mainPage.evaluate(() => {
+        window.sw_internal.handle('contextTheme', () => 'dark' as const);
+      }),
+    });
+
+    // The initial fetch overrides the light pin from the URL
+    await expect.poll(async () => (await embeddedState(subFrame)).theme).toBe('dark');
+    expect((await embeddedState(subFrame)).colorScheme).toBe('dark');
+
+    await mainFrame.evaluate(async () => {
+      await window.sw_internal.publish('contextTheme', 'light');
+    });
+
+    await expect.poll(async () => (await embeddedState(subFrame)).theme).toBe('light');
+    expect((await embeddedState(subFrame)).colorScheme).toBe('light');
+  });
+});
+
 test.describe('Serializing tests', () => {
   test('send criteria to iFrame', async ({ page }) => {
     const { mainFrame, subFrame } = await setup({ page });

--- a/packages/admin-sdk/e2e/test.utils.ts
+++ b/packages/admin-sdk/e2e/test.utils.ts
@@ -1,6 +1,14 @@
 import { Page, expect } from "@playwright/test";
 
-export async function setup({ page }: { page: Page }) {
+export async function setup({
+  page,
+  subFrameSrc = 'http://localhost:8182',
+  mainFrameSetup,
+}: {
+  page: Page,
+  subFrameSrc?: string,
+  mainFrameSetup?: (page: Page) => Promise<void>,
+}) {
   await page.goto(`http://localhost:8181`);
   await expect(page.locator('h1')).toContainText('E2E channel test');
 
@@ -9,17 +17,22 @@ export async function setup({ page }: { page: Page }) {
     console.log(msg)
   })
 
+  // e.g. register handlers that must exist before the sub frame boots
+  if (mainFrameSetup) {
+    await mainFrameSetup(page);
+  }
+
   // create iFrame with other page
-  await page.evaluate(async () => {
+  await page.evaluate(async (src) => {
     // change headline to "Main window"
     document.body.innerHTML = `<h1>Main window</h1>`;
 
     // add iFrame with new page
     var iframe = document.createElement('iframe');
-    iframe.src = 'http://localhost:8182';
+    iframe.src = src;
     iframe.id = 'subFrame'
     document.body.appendChild(iframe);
-  })
+  }, subFrameSrc)
 
   await page.waitForLoadState('networkidle');
 

--- a/packages/admin-sdk/jest.afterEnv.js
+++ b/packages/admin-sdk/jest.afterEnv.js
@@ -1,3 +1,15 @@
 const failOnConsole = require('jest-fail-on-console');
 
 failOnConsole()
+
+// applyEmbeddedContext and the theme sync mutate the document root and the
+// URL; reset both here after every test instead of in each affected spec file
+const initialUrl = window.location.href;
+
+afterEach(() => {
+  delete document.documentElement.dataset.embedded;
+  delete document.documentElement.dataset.theme;
+  document.documentElement.style.removeProperty('color-scheme');
+  document.getElementById('meteor-admin-sdk-embedded')?.remove();
+  window.history.replaceState({}, '', initialUrl);
+});

--- a/packages/admin-sdk/src/_internals/utils.spec.ts
+++ b/packages/admin-sdk/src/_internals/utils.spec.ts
@@ -1,12 +1,7 @@
 import { getLocationId, getColorScheme } from './utils';
 
 describe('utils', () => {
-  const initialUrl = window.location.href;
-
-  afterEach(() => {
-    window.history.replaceState({}, '', initialUrl);
-  });
-
+  // The URL is restored globally in jest.afterEnv.js
   describe('getLocationId', () => {
     it('returns the location-id search param', () => {
       window.history.replaceState({}, '', '?location-id=my-location');

--- a/packages/admin-sdk/src/_internals/utils.spec.ts
+++ b/packages/admin-sdk/src/_internals/utils.spec.ts
@@ -1,0 +1,33 @@
+import { getLocationId, getColorScheme } from './utils';
+
+describe('utils', () => {
+  const initialUrl = window.location.href;
+
+  afterEach(() => {
+    window.history.replaceState({}, '', initialUrl);
+  });
+
+  describe('getLocationId', () => {
+    it('returns the location-id search param', () => {
+      window.history.replaceState({}, '', '?location-id=my-location');
+
+      expect(getLocationId()).toBe('my-location');
+    });
+
+    it('returns null without a location-id search param', () => {
+      expect(getLocationId()).toBeNull();
+    });
+  });
+
+  describe('getColorScheme', () => {
+    it('returns the color-scheme search param', () => {
+      window.history.replaceState({}, '', '?location-id=my-location&color-scheme=dark');
+
+      expect(getColorScheme()).toBe('dark');
+    });
+
+    it('returns null without a color-scheme search param', () => {
+      expect(getColorScheme()).toBeNull();
+    });
+  });
+});

--- a/packages/admin-sdk/src/_internals/utils.ts
+++ b/packages/admin-sdk/src/_internals/utils.ts
@@ -16,6 +16,12 @@ export function getLocationId():string|null {
   return params.get('location-id');
 }
 
+export function getColorScheme():string|null {
+  const params = new URLSearchParams(window.location.search);
+
+  return params.get('color-scheme');
+}
+
 export function getWindowSrc():string {
     const location = window.location as Location;
     const urlObject = new URL(location.pathname, location.origin);

--- a/packages/admin-sdk/src/_internals/utils.ts
+++ b/packages/admin-sdk/src/_internals/utils.ts
@@ -10,16 +10,16 @@ export function isObject(value: unknown): value is any {
   return value !== null && typeof value === 'object';
 }
 
-export function getLocationId():string|null {
-  const params = new URLSearchParams(window.location.search);
+function getSearchParam(name: string): string|null {
+  return new URLSearchParams(window.location.search).get(name);
+}
 
-  return params.get('location-id');
+export function getLocationId():string|null {
+  return getSearchParam('location-id');
 }
 
 export function getColorScheme():string|null {
-  const params = new URLSearchParams(window.location.search);
-
-  return params.get('color-scheme');
+  return getSearchParam('color-scheme');
 }
 
 export function getWindowSrc():string {

--- a/packages/admin-sdk/src/channel.spec.ts
+++ b/packages/admin-sdk/src/channel.spec.ts
@@ -303,18 +303,23 @@ describe('Test the channel bridge from iFrame to admin', () => {
       expect(document.documentElement.dataset.theme).toBeUndefined();
     });
 
-    it('should apply the color scheme from the URL param before the first sync', () => {
-      window.history.replaceState({}, '', '?location-id=my-location&color-scheme=dark');
+    it.each(['dark', 'light'] as const)('should apply the "%s" color scheme from the URL param before the first sync', (scheme) => {
+      window.history.replaceState({}, '', `?location-id=my-location&color-scheme=${scheme}`);
 
       const sdkOwnsTheme = applyEmbeddedContext();
 
       expect(sdkOwnsTheme).toBe(true);
-      expect(document.documentElement.dataset.theme).toBe('dark');
-      expect(document.documentElement.style.getPropertyValue('color-scheme')).toBe('dark');
+      expect(document.documentElement.dataset.theme).toBe(scheme);
+      expect(document.documentElement.style.getPropertyValue('color-scheme')).toBe(scheme);
     });
 
-    it('should treat an invalid color scheme param like a missing one', () => {
-      window.history.replaceState({}, '', '?color-scheme=not-a-scheme');
+    it.each([
+      'not-a-scheme',
+      'system',
+      'DARK',
+      '',
+    ])('should treat the invalid color scheme param "%s" like a missing one', (value) => {
+      window.history.replaceState({}, '', `?color-scheme=${value}`);
 
       applyEmbeddedContext();
 

--- a/packages/admin-sdk/src/channel.spec.ts
+++ b/packages/admin-sdk/src/channel.spec.ts
@@ -272,9 +272,14 @@ describe('Test the channel bridge from iFrame to admin', () => {
   });
 
   describe('embedded context', () => {
+    const initialUrl = window.location.href;
+
     afterEach(() => {
       delete document.documentElement.dataset.embedded;
+      delete document.documentElement.dataset.theme;
+      document.documentElement.style.removeProperty('color-scheme');
       document.getElementById('meteor-admin-sdk-embedded')?.remove();
+      window.history.replaceState({}, '', initialUrl);
     });
 
     it('should mark the document as embedded and unset the body background', () => {
@@ -286,8 +291,46 @@ describe('Test the channel bridge from iFrame to admin', () => {
 
       const styles = document.querySelectorAll('#meteor-admin-sdk-embedded');
       expect(styles).toHaveLength(1);
-      expect(styles[0].textContent).toContain('html[data-embedded] { color-scheme: light dark; }');
       expect(styles[0].textContent).toContain('html[data-embedded] body { background: unset; }');
+    });
+
+    it('should pin the light color scheme when the URL declares no scheme', () => {
+      const sdkOwnsTheme = applyEmbeddedContext();
+
+      expect(sdkOwnsTheme).toBe(true);
+      expect(document.documentElement.style.getPropertyValue('color-scheme')).toBe('light');
+      // Only a scheme provided by the Administration sets the theme attribute
+      expect(document.documentElement.dataset.theme).toBeUndefined();
+    });
+
+    it('should apply the color scheme from the URL param before the first sync', () => {
+      window.history.replaceState({}, '', '?location-id=my-location&color-scheme=dark');
+
+      const sdkOwnsTheme = applyEmbeddedContext();
+
+      expect(sdkOwnsTheme).toBe(true);
+      expect(document.documentElement.dataset.theme).toBe('dark');
+      expect(document.documentElement.style.getPropertyValue('color-scheme')).toBe('dark');
+    });
+
+    it('should treat an invalid color scheme param like a missing one', () => {
+      window.history.replaceState({}, '', '?color-scheme=not-a-scheme');
+
+      applyEmbeddedContext();
+
+      expect(document.documentElement.style.getPropertyValue('color-scheme')).toBe('light');
+      expect(document.documentElement.dataset.theme).toBeUndefined();
+    });
+
+    it('should not touch the theme when the app manages its own data-theme attribute', () => {
+      document.documentElement.dataset.theme = 'dark';
+      window.history.replaceState({}, '', '?color-scheme=light');
+
+      const sdkOwnsTheme = applyEmbeddedContext();
+
+      expect(sdkOwnsTheme).toBe(false);
+      expect(document.documentElement.dataset.theme).toBe('dark');
+      expect(document.documentElement.style.getPropertyValue('color-scheme')).toBe('');
     });
 
     it('should not overwrite an app-managed data-embedded value', () => {

--- a/packages/admin-sdk/src/channel.spec.ts
+++ b/packages/admin-sdk/src/channel.spec.ts
@@ -272,16 +272,6 @@ describe('Test the channel bridge from iFrame to admin', () => {
   });
 
   describe('embedded context', () => {
-    const initialUrl = window.location.href;
-
-    afterEach(() => {
-      delete document.documentElement.dataset.embedded;
-      delete document.documentElement.dataset.theme;
-      document.documentElement.style.removeProperty('color-scheme');
-      document.getElementById('meteor-admin-sdk-embedded')?.remove();
-      window.history.replaceState({}, '', initialUrl);
-    });
-
     it('should mark the document as embedded and unset the body background', () => {
       applyEmbeddedContext();
       // A second call must not duplicate anything
@@ -295,9 +285,9 @@ describe('Test the channel bridge from iFrame to admin', () => {
     });
 
     it('should pin the light color scheme when the URL declares no scheme', () => {
-      const sdkOwnsTheme = applyEmbeddedContext();
+      const pin = applyEmbeddedContext();
 
-      expect(sdkOwnsTheme).toBe(true);
+      expect(pin).toEqual({ theme: null, scheme: 'light' });
       expect(document.documentElement.style.getPropertyValue('color-scheme')).toBe('light');
       // Only a scheme provided by the Administration sets the theme attribute
       expect(document.documentElement.dataset.theme).toBeUndefined();
@@ -306,9 +296,9 @@ describe('Test the channel bridge from iFrame to admin', () => {
     it.each(['dark', 'light'] as const)('should apply the "%s" color scheme from the URL param before the first sync', (scheme) => {
       window.history.replaceState({}, '', `?location-id=my-location&color-scheme=${scheme}`);
 
-      const sdkOwnsTheme = applyEmbeddedContext();
+      const pin = applyEmbeddedContext();
 
-      expect(sdkOwnsTheme).toBe(true);
+      expect(pin).toEqual({ theme: scheme, scheme });
       expect(document.documentElement.dataset.theme).toBe(scheme);
       expect(document.documentElement.style.getPropertyValue('color-scheme')).toBe(scheme);
     });
@@ -331,11 +321,22 @@ describe('Test the channel bridge from iFrame to admin', () => {
       document.documentElement.dataset.theme = 'dark';
       window.history.replaceState({}, '', '?color-scheme=light');
 
-      const sdkOwnsTheme = applyEmbeddedContext();
+      const pin = applyEmbeddedContext();
 
-      expect(sdkOwnsTheme).toBe(false);
+      expect(pin).toEqual({ theme: null, scheme: null });
       expect(document.documentElement.dataset.theme).toBe('dark');
       expect(document.documentElement.style.getPropertyValue('color-scheme')).toBe('');
+    });
+
+    it('should treat an empty data-theme attribute as undeclared', () => {
+      document.documentElement.dataset.theme = '';
+      window.history.replaceState({}, '', '?color-scheme=dark');
+
+      const pin = applyEmbeddedContext();
+
+      expect(pin).toEqual({ theme: 'dark', scheme: 'dark' });
+      expect(document.documentElement.dataset.theme).toBe('dark');
+      expect(document.documentElement.style.getPropertyValue('color-scheme')).toBe('dark');
     });
 
     it('should not overwrite an app-managed data-embedded value', () => {

--- a/packages/admin-sdk/src/channel.ts
+++ b/packages/admin-sdk/src/channel.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-misused-promises */
 import type { ShopwareMessageTypes } from './message-types';
-import { generateUniqueId } from './_internals/utils';
+import { generateUniqueId, getColorScheme } from './_internals/utils';
 import type { extension, privilegeString } from './_internals/privileges';
 import MissingPrivilegesError from './_internals/privileges/missing-privileges-error';
 import SerializerFactory from './_internals/serializer';
@@ -508,10 +508,10 @@ const datasets = new Map<string, unknown>();
  */
 
 (async (): Promise<void> => {
-  // Mark embedded documents before the first paint (needs no channel)
-  if (window.parent !== window) {
-    applyEmbeddedContext();
-  }
+  const isEmbedded = window.parent !== window;
+
+  // Mark embedded documents and pin the color scheme before the first paint (needs no channel)
+  const sdkOwnsTheme = isEmbedded ? applyEmbeddedContext() : false;
 
   // Handle registrations at current window
   handle('__registerWindow__', ({ sdkVersion }, additionalOptions) => {
@@ -577,8 +577,8 @@ const datasets = new Map<string, unknown>();
   });
 
   // Mirror the Administration theme onto app iframes (the admin owns its own document)
-  if (window.parent !== window) {
-    startAutoThemeSync();
+  if (isEmbedded) {
+    startAutoThemeSync(sdkOwnsTheme);
   }
 })().catch((e) => console.error(e));
 
@@ -623,14 +623,16 @@ export function startThemeSync(target: HTMLElement): { initialFetch: Promise<voi
 
 /**
  * Starts the theme sync on the document root inside app iframes. Skipped
- * when the document declares `data-theme` itself (the app owns its theme)
+ * when the document declares `data-theme` itself (the app owns its theme).
+ * `sdkOwnsTheme` marks a `data-theme` value the SDK applied itself
+ * (from the `color-scheme` URL param), which must not block the sync
  *
  * @internal - apps that need explicit control use `context.syncTheme()`
  */
-export function startAutoThemeSync(): () => void {
+export function startAutoThemeSync(sdkOwnsTheme = false): () => void {
   const target = document.documentElement;
 
-  if (target.dataset.theme) {
+  if (target.dataset.theme && !sdkOwnsTheme) {
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     return () => {};
   }
@@ -645,32 +647,47 @@ export function startAutoThemeSync(): () => void {
 }
 
 /**
- * Marks the document as embedded (`<html data-embedded>`) and unsets the
- * body background so the Administration theme shows through instead of an
- * opaque default background. The attribute stays untouched when the document
- * declares it itself.
+ * Marks the document as embedded (`<html data-embedded>`), pins the initial
+ * color scheme and unsets the body background so the Administration theme
+ * shows through instead of an opaque default background.
+ *
+ * The initial theme comes from the `color-scheme` URL param the Administration
+ * appends to the iframe src. Without the param the scheme is pinned to `light`
+ * because Administrations without theme support are always light; an explicit
+ * value avoids `color-scheme: light dark`, which would follow the OS preference
+ * in those Administrations. The `data-embedded` attribute and `data-theme`
+ * stay untouched when the document declares them itself.
  *
  * @internal - runs automatically inside app iframes
+ * @returns whether the SDK owns the document theme (`data-theme` was not declared by the app)
  */
-export function applyEmbeddedContext(): void {
+export function applyEmbeddedContext(): boolean {
   const root = document.documentElement;
 
   if (root.dataset.embedded === undefined) {
     root.dataset.embedded = '';
   }
 
-  if (document.getElementById('meteor-admin-sdk-embedded')) {
-    return;
+  const sdkOwnsTheme = root.dataset.theme === undefined;
+
+  if (sdkOwnsTheme) {
+    const urlScheme = getColorScheme();
+
+    if (isThemeValue(urlScheme)) {
+      applyTheme(root, urlScheme);
+    } else {
+      root.style.setProperty('color-scheme', 'light');
+    }
   }
 
-  const style = document.createElement('style');
-  style.id = 'meteor-admin-sdk-embedded';
-  // Supporting both schemes makes the document adopt the scheme the Administration propagates into the iframe until the theme sync pins the resolved one
-  style.textContent = [
-    'html[data-embedded] { color-scheme: light dark; }',
-    'html[data-embedded] body { background: unset; }',
-  ].join('\n');
-  document.head.appendChild(style);
+  if (!document.getElementById('meteor-admin-sdk-embedded')) {
+    const style = document.createElement('style');
+    style.id = 'meteor-admin-sdk-embedded';
+    style.textContent = 'html[data-embedded] body { background: unset; }';
+    document.head.appendChild(style);
+  }
+
+  return sdkOwnsTheme;
 }
 
 // New dataset registered

--- a/packages/admin-sdk/src/channel.ts
+++ b/packages/admin-sdk/src/channel.ts
@@ -508,10 +508,8 @@ const datasets = new Map<string, unknown>();
  */
 
 (async (): Promise<void> => {
-  const isEmbedded = window.parent !== window;
-
   // Mark embedded documents and pin the color scheme before the first paint (needs no channel)
-  const sdkOwnsTheme = isEmbedded ? applyEmbeddedContext() : false;
+  const themePin = window.parent !== window ? applyEmbeddedContext() : null;
 
   // Handle registrations at current window
   handle('__registerWindow__', ({ sdkVersion }, additionalOptions) => {
@@ -577,8 +575,8 @@ const datasets = new Map<string, unknown>();
   });
 
   // Mirror the Administration theme onto app iframes (the admin owns its own document)
-  if (isEmbedded) {
-    startAutoThemeSync(sdkOwnsTheme);
+  if (themePin) {
+    startAutoThemeSync(themePin);
   }
 })().catch((e) => console.error(e));
 
@@ -624,15 +622,22 @@ export function startThemeSync(target: HTMLElement): { initialFetch: Promise<voi
 /**
  * Starts the theme sync on the document root inside app iframes. Skipped
  * when the document declares `data-theme` itself (the app owns its theme).
- * `sdkOwnsTheme` marks a `data-theme` value the SDK applied itself
- * (from the `color-scheme` URL param), which must not block the sync
+ * `pin` carries the values {@link applyEmbeddedContext} applied at boot,
+ * which must not count as an app-declared theme. The check runs here and
+ * not at pin time because module imports run before the importing app's
+ * own code: an app can declare its theme between the pin and this call
  *
  * @internal - apps that need explicit control use `context.syncTheme()`
  */
-export function startAutoThemeSync(sdkOwnsTheme = false): () => void {
+export function startAutoThemeSync(pin: EmbeddedThemePin = { theme: null, scheme: null }): () => void {
   const target = document.documentElement;
 
-  if (target.dataset.theme && !sdkOwnsTheme) {
+  if (target.dataset.theme && target.dataset.theme !== pin.theme) {
+    // Withdraw the boot pin (unless the app replaced it already) so the app's own color-scheme rules apply
+    if (pin.scheme && target.style.getPropertyValue('color-scheme') === pin.scheme) {
+      target.style.removeProperty('color-scheme');
+    }
+
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     return () => {};
   }
@@ -647,6 +652,18 @@ export function startAutoThemeSync(sdkOwnsTheme = false): () => void {
 }
 
 /**
+ * The theme values {@link applyEmbeddedContext} applied to the document at
+ * boot: the `data-theme` value taken from the URL param and the pinned
+ * `color-scheme`. Null fields mark values the SDK did not apply
+ *
+ * @internal
+ */
+export type EmbeddedThemePin = {
+  theme: 'light' | 'dark' | null,
+  scheme: 'light' | 'dark' | null,
+}
+
+/**
  * Marks the document as embedded (`<html data-embedded>`), pins the initial
  * color scheme and unsets the body background so the Administration theme
  * shows through instead of an opaque default background.
@@ -656,27 +673,31 @@ export function startAutoThemeSync(sdkOwnsTheme = false): () => void {
  * because Administrations without theme support are always light; an explicit
  * value avoids `color-scheme: light dark`, which would follow the OS preference
  * in those Administrations. The `data-embedded` attribute and `data-theme`
- * stay untouched when the document declares them itself.
+ * stay untouched when the document declares them itself (an empty `data-theme`
+ * attribute counts as undeclared).
  *
  * @internal - runs automatically inside app iframes
- * @returns whether the SDK owns the document theme (`data-theme` was not declared by the app)
+ * @returns the values the SDK applied, so the theme sync can tell them apart from app-declared ones
  */
-export function applyEmbeddedContext(): boolean {
+export function applyEmbeddedContext(): EmbeddedThemePin {
   const root = document.documentElement;
 
   if (root.dataset.embedded === undefined) {
     root.dataset.embedded = '';
   }
 
-  const sdkOwnsTheme = root.dataset.theme === undefined;
+  const pin: EmbeddedThemePin = { theme: null, scheme: null };
 
-  if (sdkOwnsTheme) {
+  if (!root.dataset.theme) {
     const urlScheme = getColorScheme();
 
     if (isThemeValue(urlScheme)) {
       applyTheme(root, urlScheme);
+      pin.theme = urlScheme;
+      pin.scheme = urlScheme;
     } else {
       root.style.setProperty('color-scheme', 'light');
+      pin.scheme = 'light';
     }
   }
 
@@ -687,7 +708,7 @@ export function applyEmbeddedContext(): boolean {
     document.head.appendChild(style);
   }
 
-  return sdkOwnsTheme;
+  return pin;
 }
 
 // New dataset registered

--- a/packages/admin-sdk/src/context/theme.spec.ts
+++ b/packages/admin-sdk/src/context/theme.spec.ts
@@ -48,15 +48,9 @@ describe('context theme', () => {
     syncTheme = context.syncTheme;
   });
 
-  const initialUrl = window.location.href;
-
+  // Document and URL state is reset globally in jest.afterEnv.js
   afterEach(() => {
     cleanups.splice(0).forEach((remove) => remove());
-    delete document.documentElement.dataset.theme;
-    delete document.documentElement.dataset.embedded;
-    document.documentElement.style.removeProperty('color-scheme');
-    document.getElementById('meteor-admin-sdk-embedded')?.remove();
-    window.history.replaceState({}, '', initialUrl);
   });
 
   it('gets the current resolved theme', async () => {
@@ -244,7 +238,7 @@ describe('context theme', () => {
       document.documentElement.dataset.theme = 'dark';
       track(handle('contextTheme', () => 'dark' as const));
 
-      track(startAutoThemeSync(true));
+      track(startAutoThemeSync({ theme: 'dark', scheme: 'dark' }));
       await flushPromises();
 
       publish('contextTheme', 'light');
@@ -259,11 +253,11 @@ describe('context theme', () => {
       track(handle('contextTheme', () => 'dark' as const));
 
       // The boot sequence inside app iframes
-      const sdkOwnsTheme = applyEmbeddedContext();
+      const pin = applyEmbeddedContext();
       expect(document.documentElement.dataset.theme).toBe('dark');
       expect(document.documentElement.style.getPropertyValue('color-scheme')).toBe('dark');
 
-      track(startAutoThemeSync(sdkOwnsTheme));
+      track(startAutoThemeSync(pin));
       await flushPromises();
       expect(document.documentElement.dataset.theme).toBe('dark');
 
@@ -274,15 +268,46 @@ describe('context theme', () => {
       expect(document.documentElement.style.getPropertyValue('color-scheme')).toBe('light');
     });
 
+    it('backs off when the app declares data-theme between the boot pin and the sync start', async () => {
+      const pin = applyEmbeddedContext();
+      expect(document.documentElement.style.getPropertyValue('color-scheme')).toBe('light');
+
+      // App boot code runs after the SDK import but before the registration round trip completes
+      document.documentElement.dataset.theme = 'dark';
+      track(handle('contextTheme', () => 'light' as const));
+
+      track(startAutoThemeSync(pin));
+      await flushPromises();
+
+      publish('contextTheme', 'light');
+      await flushPromises();
+
+      expect(document.documentElement.dataset.theme).toBe('dark');
+      // The boot pin is withdrawn so the app's own color-scheme rules apply
+      expect(document.documentElement.style.getPropertyValue('color-scheme')).toBe('');
+    });
+
+    it('keeps a color-scheme the app set itself when backing off', async () => {
+      const pin = applyEmbeddedContext();
+
+      document.documentElement.dataset.theme = 'dark';
+      document.documentElement.style.setProperty('color-scheme', 'dark');
+
+      track(startAutoThemeSync(pin));
+      await flushPromises();
+
+      expect(document.documentElement.style.getPropertyValue('color-scheme')).toBe('dark');
+    });
+
     it('keeps the light pin when no Administration answers the theme fetch', async () => {
       jest.useFakeTimers();
 
       try {
-        const sdkOwnsTheme = applyEmbeddedContext();
+        const pin = applyEmbeddedContext();
         expect(document.documentElement.style.getPropertyValue('color-scheme')).toBe('light');
 
         // No contextTheme handler exists, like in Administrations without theme support
-        track(startAutoThemeSync(sdkOwnsTheme));
+        track(startAutoThemeSync(pin));
         jest.advanceTimersByTime(8000);
         await Promise.resolve();
       } finally {

--- a/packages/admin-sdk/src/context/theme.spec.ts
+++ b/packages/admin-sdk/src/context/theme.spec.ts
@@ -1,10 +1,16 @@
 import flushPromises from 'flush-promises';
-import type { handle as handleType, publish as publishType, startAutoThemeSync as startAutoThemeSyncType } from '../channel';
+import type {
+  handle as handleType,
+  publish as publishType,
+  startAutoThemeSync as startAutoThemeSyncType,
+  applyEmbeddedContext as applyEmbeddedContextType,
+} from '../channel';
 import type { getTheme as getThemeType, subscribeTheme as subscribeThemeType, syncTheme as syncThemeType } from './index';
 
 let handle: typeof handleType;
 let publish: typeof publishType;
 let startAutoThemeSync: typeof startAutoThemeSyncType;
+let applyEmbeddedContext: typeof applyEmbeddedContextType;
 let getTheme: typeof getThemeType;
 let subscribeTheme: typeof subscribeThemeType;
 let syncTheme: typeof syncThemeType;
@@ -34,6 +40,7 @@ describe('context theme', () => {
     handle = channel.handle;
     publish = channel.publish;
     startAutoThemeSync = channel.startAutoThemeSync;
+    applyEmbeddedContext = channel.applyEmbeddedContext;
 
     const context = await import('./index');
     getTheme = context.getTheme;
@@ -41,10 +48,15 @@ describe('context theme', () => {
     syncTheme = context.syncTheme;
   });
 
+  const initialUrl = window.location.href;
+
   afterEach(() => {
     cleanups.splice(0).forEach((remove) => remove());
     delete document.documentElement.dataset.theme;
+    delete document.documentElement.dataset.embedded;
     document.documentElement.style.removeProperty('color-scheme');
+    document.getElementById('meteor-admin-sdk-embedded')?.remove();
+    window.history.replaceState({}, '', initialUrl);
   });
 
   it('gets the current resolved theme', async () => {
@@ -240,6 +252,46 @@ describe('context theme', () => {
 
       expect(document.documentElement.dataset.theme).toBe('light');
       expect(document.documentElement.style.getPropertyValue('color-scheme')).toBe('light');
+    });
+
+    it('pins the scheme from the URL param before the sync and follows later theme changes', async () => {
+      window.history.replaceState({}, '', '?color-scheme=dark');
+      track(handle('contextTheme', () => 'dark' as const));
+
+      // The boot sequence inside app iframes
+      const sdkOwnsTheme = applyEmbeddedContext();
+      expect(document.documentElement.dataset.theme).toBe('dark');
+      expect(document.documentElement.style.getPropertyValue('color-scheme')).toBe('dark');
+
+      track(startAutoThemeSync(sdkOwnsTheme));
+      await flushPromises();
+      expect(document.documentElement.dataset.theme).toBe('dark');
+
+      publish('contextTheme', 'light');
+      await flushPromises();
+
+      expect(document.documentElement.dataset.theme).toBe('light');
+      expect(document.documentElement.style.getPropertyValue('color-scheme')).toBe('light');
+    });
+
+    it('keeps the light pin when no Administration answers the theme fetch', async () => {
+      jest.useFakeTimers();
+
+      try {
+        const sdkOwnsTheme = applyEmbeddedContext();
+        expect(document.documentElement.style.getPropertyValue('color-scheme')).toBe('light');
+
+        // No contextTheme handler exists, like in Administrations without theme support
+        track(startAutoThemeSync(sdkOwnsTheme));
+        jest.advanceTimersByTime(8000);
+        await Promise.resolve();
+      } finally {
+        jest.useRealTimers();
+      }
+      await flushPromises();
+
+      expect(document.documentElement.style.getPropertyValue('color-scheme')).toBe('light');
+      expect(document.documentElement.dataset.theme).toBeUndefined();
     });
 
     it('ignores published values that are not a valid theme', async () => {

--- a/packages/admin-sdk/src/context/theme.spec.ts
+++ b/packages/admin-sdk/src/context/theme.spec.ts
@@ -227,6 +227,21 @@ describe('context theme', () => {
       expect(document.documentElement.dataset.theme).toBe('light');
     });
 
+    it('keeps syncing over a data-theme the SDK applied itself from the URL param', async () => {
+      // Simulates the boot pin from the color-scheme URL param
+      document.documentElement.dataset.theme = 'dark';
+      track(handle('contextTheme', () => 'dark' as const));
+
+      track(startAutoThemeSync(true));
+      await flushPromises();
+
+      publish('contextTheme', 'light');
+      await flushPromises();
+
+      expect(document.documentElement.dataset.theme).toBe('light');
+      expect(document.documentElement.style.getPropertyValue('color-scheme')).toBe('light');
+    });
+
     it('ignores published values that are not a valid theme', async () => {
       track(handle('contextTheme', () => 'dark' as const));
       track(startAutoThemeSync());


### PR DESCRIPTION
## What?

Embedded app documents now always receive an explicit color scheme instead of the injected `color-scheme: light dark`:

- On startup the SDK reads the new `color-scheme` URL param that theme-aware Administrations append to the iframe src and pins the resolved scheme (`data-theme` attribute plus inline `color-scheme`) before the first paint.
- Without the param (or with an invalid value) the document is pinned to `color-scheme: light` and `data-theme` stays unset.
- The injected embedded style now only contains `html[data-embedded] body { background: unset; }`.
- `startAutoThemeSync()` accepts a `sdkOwnsTheme` flag so the runtime theme sync keeps running over a `data-theme` the SDK applied itself, while still skipping documents that declare `data-theme` on their own.

## Why?

`color-scheme: light dark` resolves against the preferred color scheme of the iframe. Theme-aware Administrations propagate their scheme into the iframe, so the value resolves correctly there. Administrations without theme support propagate nothing, so the browser falls back to the OS preference: with a dark OS, embedded apps switched to dark mode inside an always-light Administration, and the theme sync never corrected it because those Administrations have no `contextTheme` handler (see the workaround in shopware/merchant-assistant-service@c122290).

An explicit scheme removes the guessing. The URL param makes the correct theme available synchronously before the first paint, so there is no flash in either direction: absence of the param is itself the signal that the Administration is light.

## How?

- `applyEmbeddedContext()` pins the initial scheme and returns whether the SDK owns the document theme; the boot sequence passes that into `startAutoThemeSync()`.
- New `getColorScheme()` helper in `_internals/utils`, following the `getLocationId()` pattern.

## Required follow-up

The Administration must append `&color-scheme=light|dark` to app iframe URLs (next to `location-id`) in the same release that ships Administration theming. Without the param, apps in dark Administrations would briefly render light until the postMessage sync corrects them. -> https://github.com/shopware/shopware/pull/15271/changes/7b01585f48ebffffe8f3069defb6d7afbe562afe

## Testing?

Extended unit tests: URL param applied before the first sync, missing param pins light, invalid param treated as missing, app-owned `data-theme` untouched, style injection deduplicated, and the auto sync continuing over an SDK-applied initial theme.