### PR TITLE
feat: add configurable payment modal options

### DIFF
--- a/.changeset/stale-ants-arrive.md
+++ b/.changeset/stale-ants-arrive.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-admin-sdk": minor
+---
+
+Add additional configuration options to the Admin SDK modal API (size variant and z-index).

--- a/packages/admin-sdk/src/_private/payment/index.spec.ts
+++ b/packages/admin-sdk/src/_private/payment/index.spec.ts
@@ -389,9 +389,43 @@ describe('Private Service Payment', () => {
         showHeader: false,
         showFooter: false,
         closable: false,
+        zIndex: undefined,
       });
       expect(flow).toBeDefined();
       expect(flow.subscribe).toBeInstanceOf(Function);
+    });
+
+    it('should pass a custom z-index to the modal when requested', async () => {
+      await startPaymentFlow({
+        variant: 'x-large',
+        zIndex: 2000,
+      });
+
+      expect(mockModalOpen).toHaveBeenCalledWith({
+        locationId: 'sw-service-payment-modal',
+        variant: 'x-large',
+        showHeader: false,
+        showFooter: false,
+        closable: false,
+        zIndex: 2000,
+      });
+    });
+
+    it('should allow overriding the existing modal visibility options', async () => {
+      await startPaymentFlow({
+        showHeader: true,
+        showFooter: true,
+        closable: true,
+      });
+
+      expect(mockModalOpen).toHaveBeenCalledWith({
+        locationId: 'sw-service-payment-modal',
+        variant: 'small',
+        showHeader: true,
+        showFooter: true,
+        closable: true,
+        zIndex: undefined,
+      });
     });
 
     it('should return a flow with subscribe method', async () => {
@@ -716,4 +750,3 @@ describe('Private Service Payment', () => {
   });
 
 });
-

--- a/packages/admin-sdk/src/_private/payment/index.ts
+++ b/packages/admin-sdk/src/_private/payment/index.ts
@@ -1,4 +1,5 @@
 import * as modal from '../../ui/modal';
+import type { uiModalOpen } from '../../ui/modal';
 import * as location from '../../location';
 import * as context from '../../context';
 import * as data from '../../data';
@@ -45,6 +46,16 @@ const getChannel = (): BroadcastChannel => {
   }
   return channel;
 };
+
+/**
+ * Configuration for the shared payment modal. The payment location is kept
+ * internal; callers can customise the modal without having to know how the
+ * payment iframe is mounted in Admin.
+ */
+export type PaymentFlowOptions = Pick<
+  uiModalOpen,
+  'variant' | 'zIndex' | 'showHeader' | 'showFooter' | 'closable'
+>;
 
 const servicePaymentModalLocationId = 'sw-service-payment-modal';
 
@@ -129,13 +140,24 @@ export const addPaymentIframe = async (
   return { iframeEl, unmount };
 };
 
-export const startPaymentFlow = async (): Promise<Flow> => {
+export const startPaymentFlow = async (
+  options: PaymentFlowOptions = {},
+): Promise<Flow> => {
+  const {
+    variant = 'small',
+    zIndex,
+    showHeader = false,
+    showFooter = false,
+    closable = false,
+  } = options;
+
   await modal.open({
     locationId: servicePaymentModalLocationId,
-    variant: 'small',
-    showHeader: false,
-    showFooter: false,
-    closable: false,
+    variant,
+    showHeader,
+    showFooter,
+    closable,
+    zIndex,
   });
 
   const flow = _createFlow();

--- a/packages/admin-sdk/src/ui/modal/index.ts
+++ b/packages/admin-sdk/src/ui/modal/index.ts
@@ -18,11 +18,12 @@ export type uiModalOpen =
     * Only simple text is supported.
     */
    textContent?: string,
-   variant?: 'default'|'small'|'large'|'full',
+   variant?: 'default'|'small'|'large'|'x-large'|'full',
    showHeader?: boolean,
    showFooter?: boolean,
    closable?: boolean,
    buttons?: buttonProps[],
+   zIndex?: number,
  }
 
 export type uiModalClose =


### PR DESCRIPTION
## What?

Extend the Meteor payment-flow API so services can configure the shared Shopware Admin payment modal through a typed options object.

- optional `variant`, including the new `x-large` variant (PR will be added to the Shopware repo shortly to utilise this variant)
- optional `zIndex` for controlling the modal stacking order
- optional `showHeader`, `showFooter`, and `closable` overrides
- existing defaults remain unchanged: small modal, hidden header/footer, and non-closable modal
- Shopware Admin support for the `x-large` variant and custom z-index values

## Why?

The Purchase Interface needs a wider modal and must appear above the Copilot sidebar. These values were not configurable through the existing payment-flow API. Named options make the configuration clearer and allow services to control only the values they need without relying on positional arguments.

## How?

- `startPaymentFlow` accepts a typed options object while keeping the payment location and iframe lifecycle internal to Meteor.
- Meteor forwards the supported modal options through the existing `uiModalOpen` message.
- Shopware Admin stores and forwards the new modal values to `sw-modal`.
- Merchant Assistant requests the `x-large` variant with `zIndex: 2000`.

## Testing?

- Focused payment SDK tests cover the default configuration, custom variant and z-index, and visibility-option overrides.
- TypeScript validation passed.

## Anything Else?

- Older Admin versions continue to support the existing defaults, but the new width and z-index behaviour requires the matching Admin changes to be released.
- The payment modal location remains controlled by Meteor; services cannot replace it through these options.

Before (current purchase interface):
<img width="1245" height="1213" alt="Screenshot 2026-08-13 at 18 02 55" src="https://github.com/user-attachments/assets/b1278f09-aaf5-4920-8c7b-4263b27fcb80" />


After (+Shopware admin change https://github.com/shopware/shopware/pull/19321):
<img width="1242" height="1207" alt="Screenshot 2026-08-13 at 18 02 47" src="https://github.com/user-attachments/assets/6ab94981-197f-4959-b954-e0d862b8c1fc" />

The new width is not shown in the screenshot because it will be introduced in a future release.