### PR TITLE
feat: automate changeset in icon-kit workflow

### DIFF
--- a/.github/workflows/update-icons.yml
+++ b/.github/workflows/update-icons.yml
@@ -28,9 +28,6 @@ jobs:
       - name: Update icons
         run: pnpm --filter @shopware-ag/meteor-icon-kit run start
 
-      # Derives the changeset from what the sync actually changed in icons/, so
-      # the release notes list the added/modified/removed icons by name. A no-op
-      # sync writes no changeset.
       - name: Generate changeset
         run: pnpm --filter @shopware-ag/meteor-icon-kit run changeset
 

--- a/.github/workflows/update-icons.yml
+++ b/.github/workflows/update-icons.yml
@@ -28,6 +28,12 @@ jobs:
       - name: Update icons
         run: pnpm --filter @shopware-ag/meteor-icon-kit run start
 
+      # Derives the changeset from what the sync actually changed in icons/, so
+      # the release notes list the added/modified/removed icons by name. A no-op
+      # sync writes no changeset.
+      - name: Generate changeset
+        run: pnpm --filter @shopware-ag/meteor-icon-kit run changeset
+
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v8
         with:

--- a/packages/icon-kit/package.json
+++ b/packages/icon-kit/package.json
@@ -30,6 +30,7 @@
     "lint:eslint": "eslint ./src",
     "lint:types": "tsc --noEmit",
     "start": "tsx ./src/index.ts",
+    "changeset": "tsx ./src/changeset/index.ts",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test:unit": "vitest"

--- a/packages/icon-kit/src/changeset/changeset-file.test.ts
+++ b/packages/icon-kit/src/changeset/changeset-file.test.ts
@@ -1,0 +1,125 @@
+import { expect, test } from "vitest";
+import { ChangesetFile } from "./changeset-file.js";
+
+const PACKAGE_NAME = "@shopware-ag/meteor-icon-kit";
+
+test("renders added and modified icons", () => {
+  // ARRANGE
+  const subject = new ChangesetFile(PACKAGE_NAME, "minor", {
+    added: [
+      "regular-panel-bottom",
+      "regular-panel-left",
+      "regular-panel-right",
+      "regular-panel-top",
+      "regular-shopware-copilot",
+      "solid-panel-bottom",
+      "solid-panel-left",
+      "solid-panel-right",
+      "solid-panel-top",
+      "solid-shopware-copilot",
+    ],
+    modified: ["regular-cog", "solid-cog"],
+    removed: [],
+  });
+
+  // ACT
+  const result = subject.toString();
+
+  // ASSERT
+  expect(result).toMatchInlineSnapshot(`
+    "---
+    "@shopware-ag/meteor-icon-kit": minor
+    ---
+
+    Added multiple icons:
+    \`regular-panel-bottom\`
+    \`regular-panel-left\`
+    \`regular-panel-right\`
+    \`regular-panel-top\`
+    \`regular-shopware-copilot\`
+    \`solid-panel-bottom\`
+    \`solid-panel-left\`
+    \`solid-panel-right\`
+    \`solid-panel-top\`
+    \`solid-shopware-copilot\`
+
+    Modified icons:
+    \`regular-cog\`
+    \`solid-cog\`
+    "
+  `);
+});
+
+test("uses singular headings for a single icon", () => {
+  // ARRANGE
+  const subject = new ChangesetFile(PACKAGE_NAME, "minor", {
+    added: ["regular-trust"],
+    modified: [],
+    removed: ["solid-legacy"],
+  });
+
+  // ACT
+  const result = subject.toString();
+
+  // ASSERT
+  expect(result).toMatchInlineSnapshot(`
+    "---
+    "@shopware-ag/meteor-icon-kit": minor
+    ---
+
+    Added icon:
+    \`regular-trust\`
+
+    Removed icon:
+    \`solid-legacy\`
+    "
+  `);
+});
+
+test("omits sections without changes", () => {
+  // ARRANGE
+  const subject = new ChangesetFile(PACKAGE_NAME, "minor", {
+    added: [],
+    modified: ["regular-cog", "solid-cog"],
+    removed: [],
+  });
+
+  // ACT
+  const result = subject.toString();
+
+  // ASSERT
+  expect(result).toMatchInlineSnapshot(`
+    "---
+    "@shopware-ag/meteor-icon-kit": minor
+    ---
+
+    Modified icons:
+    \`regular-cog\`
+    \`solid-cog\`
+    "
+  `);
+});
+
+test("renders removed icons", () => {
+  // ARRANGE
+  const subject = new ChangesetFile(PACKAGE_NAME, "minor", {
+    added: [],
+    modified: [],
+    removed: ["regular-cog", "solid-cog"],
+  });
+
+  // ACT
+  const result = subject.toString();
+
+  // ASSERT
+  expect(result).toMatchInlineSnapshot(`
+    "---
+    "@shopware-ag/meteor-icon-kit": minor
+    ---
+
+    Removed icons:
+    \`regular-cog\`
+    \`solid-cog\`
+    "
+  `);
+});

--- a/packages/icon-kit/src/changeset/changeset-file.ts
+++ b/packages/icon-kit/src/changeset/changeset-file.ts
@@ -1,0 +1,44 @@
+import {
+  ICON_CHANGE_KINDS,
+  type IconChangeKind,
+  type IconChanges,
+} from "./icon-changes.js";
+
+export type Bump = "major" | "minor" | "patch";
+
+const HEADINGS: Record<IconChangeKind, { singular: string; plural: string }> = {
+  added: { singular: "Added icon:", plural: "Added multiple icons:" },
+  modified: { singular: "Modified icon:", plural: "Modified icons:" },
+  removed: { singular: "Removed icon:", plural: "Removed icons:" },
+};
+
+/**
+ * A changeset for the icon kit, rendered in the format the icon changelog has
+ * used since v5.6.0: a bump for a single package, followed by one section per
+ * kind of change listing the affected icon names as inline code.
+ */
+export class ChangesetFile {
+  constructor(
+    private readonly packageName: string,
+    private readonly bump: Bump,
+    private readonly changes: IconChanges
+  ) {}
+
+  toString(): string {
+    const frontmatter = `---\n"${this.packageName}": ${this.bump}\n---`;
+
+    const sections = ICON_CHANGE_KINDS.flatMap((kind) => {
+      const icons = this.changes[kind];
+      if (icons.length === 0) {
+        return [];
+      }
+
+      const heading =
+        icons.length === 1 ? HEADINGS[kind].singular : HEADINGS[kind].plural;
+
+      return [[heading, ...icons.map((icon) => `\`${icon}\``)].join("\n")];
+    });
+
+    return `${[frontmatter, ...sections].join("\n\n")}\n`;
+  }
+}

--- a/packages/icon-kit/src/changeset/generate-changeset.test.ts
+++ b/packages/icon-kit/src/changeset/generate-changeset.test.ts
@@ -1,0 +1,201 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, expect, test } from "vitest";
+import { generateChangeset } from "./generate-changeset.js";
+
+const PACKAGE_NAME = "@shopware-ag/meteor-icon-kit";
+
+const repositories: string[] = [];
+
+afterEach(() => {
+  while (repositories.length > 0) {
+    fs.rmSync(repositories.pop()!, { recursive: true, force: true });
+  }
+});
+
+function git(args: string[], cwd: string): void {
+  execFileSync("git", args, { cwd, encoding: "utf-8" });
+}
+
+function writeIcon(iconDirectory: string, name: string, body = "<svg/>"): void {
+  fs.writeFileSync(path.join(iconDirectory, `${name}.svg`), body);
+}
+
+/**
+ * Creates a throwaway repository laid out like this one, with two committed
+ * icons, so `generateChangeset` runs against real `git status` output.
+ *
+ * The temp path is realpath'd because macOS resolves `os.tmpdir()` through a
+ * symlink, which would otherwise not match what `git rev-parse` reports.
+ */
+function createRepository(): { root: string; iconDirectory: string } {
+  const root = fs.realpathSync(
+    fs.mkdtempSync(path.join(os.tmpdir(), "icon-kit-changeset-"))
+  );
+  repositories.push(root);
+
+  git(["init", "--quiet", "-b", "main"], root);
+  // Local config only, so the test does not depend on — or care about — the
+  // committer's global git setup (commit signing included).
+  git(["config", "user.email", "test@example.com"], root);
+  git(["config", "user.name", "Test"], root);
+  git(["config", "commit.gpgsign", "false"], root);
+
+  fs.mkdirSync(path.join(root, ".changeset"));
+  fs.writeFileSync(path.join(root, ".changeset", "config.json"), "{}");
+
+  const iconDirectory = path.join(root, "packages", "icon-kit", "icons");
+  fs.mkdirSync(path.join(iconDirectory, "regular"), { recursive: true });
+  fs.mkdirSync(path.join(iconDirectory, "solid"), { recursive: true });
+  writeIcon(iconDirectory, "regular/cog");
+  writeIcon(iconDirectory, "solid/cog");
+  writeIcon(iconDirectory, "solid/legacy");
+  fs.writeFileSync(path.join(iconDirectory, "meta.json"), "{}");
+
+  git(["add", "--all"], root);
+  git(["commit", "--quiet", "-m", "baseline"], root);
+
+  return { root, iconDirectory };
+}
+
+function run(iconDirectory: string) {
+  return generateChangeset({
+    packageName: PACKAGE_NAME,
+    bump: "minor",
+    iconDirectory,
+  });
+}
+
+test("writes a changeset for icons the sync added, changed and removed", () => {
+  // ARRANGE
+  const { root, iconDirectory } = createRepository();
+  writeIcon(iconDirectory, "regular/panel-left");
+  writeIcon(iconDirectory, "solid/panel-left");
+  writeIcon(iconDirectory, "regular/cog", "<svg>changed</svg>");
+  fs.rmSync(path.join(iconDirectory, "solid/legacy.svg"));
+
+  // ACT
+  const result = run(iconDirectory);
+
+  // ASSERT
+  expect(result.repositoryRoot).toBe(root);
+  expect(result.changesetPath).toBeDefined();
+  expect(fs.readFileSync(result.changesetPath!, "utf-8"))
+    .toMatchInlineSnapshot(`
+      "---
+      "@shopware-ag/meteor-icon-kit": minor
+      ---
+
+      Added multiple icons:
+      \`regular-panel-left\`
+      \`solid-panel-left\`
+
+      Modified icon:
+      \`regular-cog\`
+
+      Removed icon:
+      \`solid-legacy\`
+      "
+    `);
+});
+
+test("writes the changeset into the repository's .changeset directory", () => {
+  // ARRANGE
+  const { root, iconDirectory } = createRepository();
+  writeIcon(iconDirectory, "regular/panel-left");
+
+  // ACT
+  const result = run(iconDirectory);
+
+  // ASSERT
+  expect(path.dirname(result.changesetPath!)).toBe(
+    path.join(root, ".changeset")
+  );
+  expect(path.basename(result.changesetPath!)).toMatch(
+    /^update-icons-[0-9a-f]{8}\.md$/
+  );
+});
+
+test("writes nothing when no icons changed", () => {
+  // ARRANGE
+  const { root, iconDirectory } = createRepository();
+
+  // ACT
+  const result = run(iconDirectory);
+
+  // ASSERT
+  expect(result.changesetPath).toBeUndefined();
+  expect(result.changes).toEqual({ added: [], modified: [], removed: [] });
+  expect(fs.readdirSync(path.join(root, ".changeset"))).toEqual([
+    "config.json",
+  ]);
+});
+
+test("ignores the generated artifacts the sync also rewrites", () => {
+  // ARRANGE
+  const { root, iconDirectory } = createRepository();
+  fs.writeFileSync(path.join(iconDirectory, "meta.json"), '{"changed":true}');
+  fs.writeFileSync(path.join(iconDirectory, "meteor-icon-kit.scss"), "// css");
+  // The stylesheet carries a content hash, so every sync looks like a rename.
+  fs.writeFileSync(path.join(iconDirectory, "meteor-icon-kit-abc123.css"), "");
+
+  // ACT
+  const result = run(iconDirectory);
+
+  // ASSERT
+  expect(result.changesetPath).toBeUndefined();
+  expect(fs.readdirSync(path.join(root, ".changeset"))).toEqual([
+    "config.json",
+  ]);
+});
+
+test("reuses the same file when re-run on an unchanged icon set", () => {
+  // ARRANGE
+  const { root, iconDirectory } = createRepository();
+  writeIcon(iconDirectory, "regular/panel-left");
+
+  // ACT
+  const first = run(iconDirectory);
+  const second = run(iconDirectory);
+
+  // ASSERT
+  expect(second.changesetPath).toBe(first.changesetPath);
+  expect(fs.readdirSync(path.join(root, ".changeset"))).toHaveLength(2);
+});
+
+test("writes a separate file when a later sync changes different icons", () => {
+  // ARRANGE
+  const { root, iconDirectory } = createRepository();
+  writeIcon(iconDirectory, "regular/panel-left");
+
+  // ACT
+  const first = run(iconDirectory);
+  writeIcon(iconDirectory, "regular/panel-right");
+  const second = run(iconDirectory);
+
+  // ASSERT
+  expect(second.changesetPath).not.toBe(first.changesetPath);
+  expect(fs.readdirSync(path.join(root, ".changeset"))).toHaveLength(3);
+});
+
+test("only reports icons, even when other files in the repository changed", () => {
+  // ARRANGE
+  const { iconDirectory } = createRepository();
+  writeIcon(iconDirectory, "regular/panel-left");
+  fs.writeFileSync(
+    path.join(iconDirectory, "..", "package.json"),
+    '{"name":"unrelated"}'
+  );
+
+  // ACT
+  const result = run(iconDirectory);
+
+  // ASSERT
+  expect(result.changes).toEqual({
+    added: ["regular-panel-left"],
+    modified: [],
+    removed: [],
+  });
+});

--- a/packages/icon-kit/src/changeset/generate-changeset.ts
+++ b/packages/icon-kit/src/changeset/generate-changeset.ts
@@ -1,0 +1,84 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { ChangesetFile, type Bump } from "./changeset-file.js";
+import {
+  countIconChanges,
+  parseIconChanges,
+  type IconChanges,
+} from "./icon-changes.js";
+import { md5 } from "../utils.js";
+
+export type GenerateChangesetResult = {
+  changes: IconChanges;
+  repositoryRoot: string;
+  /**
+   * Absolute path of the changeset that was written, or `undefined` when no
+   * icons changed and therefore nothing was written.
+   */
+  changesetPath: string | undefined;
+};
+
+function git(args: string[], cwd: string): string {
+  return execFileSync("git", args, { cwd, encoding: "utf-8" });
+}
+
+/**
+ * Writes a changeset describing how `iconDirectory` differs from what is
+ * committed, i.e. what the Figma sync just changed.
+ */
+export function generateChangeset(options: {
+  packageName: string;
+  bump: Bump;
+  iconDirectory: string;
+}): GenerateChangesetResult {
+  const { packageName, bump, iconDirectory } = options;
+
+  const repositoryRoot = git(
+    ["rev-parse", "--show-toplevel"],
+    iconDirectory
+  ).trim();
+
+  // git reports paths relative to the repository root, always with forward
+  // slashes, so build the prefix we match against the same way.
+  const iconsPrefix = `${path
+    .relative(repositoryRoot, iconDirectory)
+    .split(path.sep)
+    .join("/")}/`;
+
+  const changes = parseIconChanges(
+    git(
+      [
+        "status",
+        "--porcelain",
+        "-z",
+        "--untracked-files=all",
+        "--no-renames",
+        "--",
+        iconDirectory,
+      ],
+      repositoryRoot
+    ),
+    iconsPrefix
+  );
+
+  if (countIconChanges(changes) === 0) {
+    return { changes, repositoryRoot, changesetPath: undefined };
+  }
+
+  // Derive the filename from the changes themselves so re-running the sync on
+  // an unchanged icon set updates the existing changeset instead of piling up
+  // near-duplicates.
+  const changesetPath = path.join(
+    repositoryRoot,
+    ".changeset",
+    `update-icons-${md5(changes).slice(0, 8)}.md`
+  );
+
+  fs.writeFileSync(
+    changesetPath,
+    new ChangesetFile(packageName, bump, changes).toString()
+  );
+
+  return { changes, repositoryRoot, changesetPath };
+}

--- a/packages/icon-kit/src/changeset/icon-changes.test.ts
+++ b/packages/icon-kit/src/changeset/icon-changes.test.ts
@@ -1,0 +1,152 @@
+import { expect, test } from "vitest";
+import { countIconChanges, parseIconChanges } from "./icon-changes.js";
+
+const PREFIX = "packages/icon-kit/icons/";
+
+/** Builds the NUL-separated records `git status -z` emits. */
+function porcelain(...records: string[]): string {
+  return records.map((record) => `${record}\0`).join("");
+}
+
+test("returns nothing for a clean worktree", () => {
+  // ACT
+  const result = parseIconChanges("", PREFIX);
+
+  // ASSERT
+  expect(result).toEqual({ added: [], modified: [], removed: [] });
+  expect(countIconChanges(result)).toBe(0);
+});
+
+test("buckets untracked, modified and deleted icons", () => {
+  // ARRANGE
+  const status = porcelain(
+    "?? packages/icon-kit/icons/regular/panel-left.svg",
+    " M packages/icon-kit/icons/regular/cog.svg",
+    " D packages/icon-kit/icons/solid/legacy.svg"
+  );
+
+  // ACT
+  const result = parseIconChanges(status, PREFIX);
+
+  // ASSERT
+  expect(result).toEqual({
+    added: ["regular-panel-left"],
+    modified: ["regular-cog"],
+    removed: ["solid-legacy"],
+  });
+});
+
+test("names icons the way their CSS class is named", () => {
+  // ARRANGE
+  const status = porcelain(
+    "?? packages/icon-kit/icons/solid/shopware-copilot.svg",
+    "?? packages/icon-kit/icons/regular/nested/deeply.svg"
+  );
+
+  // ACT
+  const result = parseIconChanges(status, PREFIX);
+
+  // ASSERT
+  expect(result.added).toEqual([
+    "regular-nested-deeply",
+    "solid-shopware-copilot",
+  ]);
+});
+
+test("ignores generated artifacts that are not icons", () => {
+  // ARRANGE
+  const status = porcelain(
+    " M packages/icon-kit/icons/meta.json",
+    " M packages/icon-kit/icons/meteor-icon-kit.scss",
+    " D packages/icon-kit/icons/meteor-icon-kit-06d5d8be.css",
+    "?? packages/icon-kit/icons/meteor-icon-kit-a1b2c3d4.css",
+    " M packages/icon-kit/src/index.ts"
+  );
+
+  // ACT
+  const result = parseIconChanges(status, PREFIX);
+
+  // ASSERT
+  expect(result).toEqual({ added: [], modified: [], removed: [] });
+});
+
+test("treats staged changes the same as worktree changes", () => {
+  // ARRANGE
+  const status = porcelain(
+    "A  packages/icon-kit/icons/regular/added.svg",
+    "M  packages/icon-kit/icons/regular/staged.svg",
+    "MM packages/icon-kit/icons/regular/staged-and-dirty.svg",
+    "D  packages/icon-kit/icons/regular/gone.svg",
+    " T packages/icon-kit/icons/regular/typechange.svg"
+  );
+
+  // ACT
+  const result = parseIconChanges(status, PREFIX);
+
+  // ASSERT
+  expect(result).toEqual({
+    added: ["regular-added"],
+    modified: [
+      "regular-staged",
+      "regular-staged-and-dirty",
+      "regular-typechange",
+    ],
+    removed: ["regular-gone"],
+  });
+});
+
+test("sorts icon names alphabetically", () => {
+  // ARRANGE
+  const status = porcelain(
+    "?? packages/icon-kit/icons/solid/panel-top.svg",
+    "?? packages/icon-kit/icons/regular/panel-top.svg",
+    "?? packages/icon-kit/icons/regular/panel-bottom.svg"
+  );
+
+  // ACT
+  const result = parseIconChanges(status, PREFIX);
+
+  // ASSERT
+  expect(result.added).toEqual([
+    "regular-panel-bottom",
+    "regular-panel-top",
+    "solid-panel-top",
+  ]);
+});
+
+test("reports each icon once even when it shows up twice", () => {
+  // ARRANGE
+  const status = porcelain(
+    " M packages/icon-kit/icons/regular/cog.svg",
+    " M packages/icon-kit/icons/regular/cog.svg"
+  );
+
+  // ACT
+  const result = parseIconChanges(status, PREFIX);
+
+  // ASSERT
+  expect(result.modified).toEqual(["regular-cog"]);
+});
+
+test("refuses to guess at rename records", () => {
+  // ARRANGE
+  const status = porcelain(
+    "R  packages/icon-kit/icons/regular/new.svg",
+    "packages/icon-kit/icons/regular/old.svg"
+  );
+
+  // ACT & ASSERT
+  expect(() => parseIconChanges(status, PREFIX)).toThrowError(/--no-renames/);
+});
+
+test("counts every change", () => {
+  // ARRANGE
+  const changes = {
+    added: ["a", "b"],
+    modified: ["c"],
+    removed: [],
+  };
+
+  // ACT & ASSERT
+  expect(countIconChanges(changes)).toBe(3);
+});

--- a/packages/icon-kit/src/changeset/icon-changes.ts
+++ b/packages/icon-kit/src/changeset/icon-changes.ts
@@ -1,0 +1,97 @@
+export const ICON_CHANGE_KINDS = ["added", "modified", "removed"] as const;
+
+export type IconChangeKind = (typeof ICON_CHANGE_KINDS)[number];
+
+export type IconChanges = Record<IconChangeKind, string[]>;
+
+const SVG_EXTENSION = ".svg";
+
+/**
+ * Turns a repository-relative path to an icon into the name the icon is
+ * published under, e.g. `packages/icon-kit/icons/regular/cog.svg` becomes
+ * `regular-cog`.
+ *
+ * This mirrors how `src/index.ts` derives the CSS class name for an icon, so
+ * the names in a changeset match the names consumers actually use.
+ */
+function toIconName(path: string, iconsPrefix: string): string | undefined {
+  if (!path.startsWith(iconsPrefix) || !path.endsWith(SVG_EXTENSION)) {
+    return undefined;
+  }
+
+  return path
+    .slice(iconsPrefix.length, -SVG_EXTENSION.length)
+    .replaceAll("/", "-");
+}
+
+/**
+ * Parses the output of
+ * `git status --porcelain -z --untracked-files=all --no-renames`
+ * into the set of added, modified and removed icons.
+ *
+ * `--no-renames` is required: with rename detection on, an entry carries a
+ * second NUL-separated path whose position in the record is ambiguous between
+ * git versions, so we refuse to guess and throw instead.
+ *
+ * @param porcelain Raw, NUL-separated `git status` output.
+ * @param iconsPrefix Repository-relative path of the icons directory,
+ * including a trailing slash, e.g. `packages/icon-kit/icons/`.
+ */
+export function parseIconChanges(
+  porcelain: string,
+  iconsPrefix: string
+): IconChanges {
+  const added = new Set<string>();
+  const modified = new Set<string>();
+  const removed = new Set<string>();
+
+  for (const record of porcelain.split("\0")) {
+    // A trailing NUL leaves an empty record behind.
+    if (record === "") {
+      continue;
+    }
+
+    const status = record.slice(0, 2);
+    const path = record.slice(3);
+
+    if (status.includes("R") || status.includes("C")) {
+      throw new Error(
+        `Unexpected rename/copy status "${status}" for "${path}". Run git status with --no-renames.`
+      );
+    }
+
+    const iconName = toIconName(path, iconsPrefix);
+    if (!iconName) {
+      // Generated artifacts such as meta.json or the stylesheets — those are
+      // not icons and have no place in the changeset.
+      continue;
+    }
+
+    // The index column (first character) and the worktree column (second) can
+    // disagree; a single icon only ever needs one bucket, so the most
+    // significant state wins.
+    if (status === "??" || status.includes("A")) {
+      added.add(iconName);
+    } else if (status.includes("D")) {
+      removed.add(iconName);
+    } else if (status.includes("M") || status.includes("T")) {
+      modified.add(iconName);
+    }
+  }
+
+  const sorted = (names: Set<string>) =>
+    Array.from(names).sort((a, b) => a.localeCompare(b));
+
+  return {
+    added: sorted(added),
+    modified: sorted(modified),
+    removed: sorted(removed),
+  };
+}
+
+export function countIconChanges(changes: IconChanges): number {
+  return ICON_CHANGE_KINDS.reduce(
+    (total, kind) => total + changes[kind].length,
+    0
+  );
+}

--- a/packages/icon-kit/src/changeset/index.ts
+++ b/packages/icon-kit/src/changeset/index.ts
@@ -1,0 +1,84 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { ChangesetFile, type Bump } from "./changeset-file.js";
+import {
+  countIconChanges,
+  ICON_CHANGE_KINDS,
+  parseIconChanges,
+} from "./icon-changes.js";
+import { md5 } from "../utils.js";
+
+const PACKAGE_NAME = "@shopware-ag/meteor-icon-kit";
+
+// Every icon release since v5.6.0 has been a minor, whether icons were added or
+// only modified.
+const BUMP: Bump = "minor";
+
+function git(args: string[], cwd: string): string {
+  return execFileSync("git", args, { cwd, encoding: "utf-8" });
+}
+
+const iconDirectory = path.resolve(import.meta.dirname, "../../icons");
+const repositoryRoot = git(
+  ["rev-parse", "--show-toplevel"],
+  iconDirectory
+).trim();
+
+// git reports paths relative to the repository root, always with forward
+// slashes, so build the prefix we match against the same way.
+const iconsPrefix = `${path
+  .relative(repositoryRoot, iconDirectory)
+  .split(path.sep)
+  .join("/")}/`;
+
+const changes = parseIconChanges(
+  git(
+    [
+      "status",
+      "--porcelain",
+      "-z",
+      "--untracked-files=all",
+      "--no-renames",
+      "--",
+      iconDirectory,
+    ],
+    repositoryRoot
+  ),
+  iconsPrefix
+);
+
+if (countIconChanges(changes) === 0) {
+  console.log("No icon changes detected — skipping changeset.");
+  process.exit(0);
+}
+
+const changeset = new ChangesetFile(PACKAGE_NAME, BUMP, changes);
+
+// Derive the filename from the changes themselves so re-running the sync on an
+// unchanged icon set updates the existing changeset instead of piling up
+// near-duplicates.
+const changesetPath = path.join(
+  repositoryRoot,
+  ".changeset",
+  `update-icons-${md5(changes).slice(0, 8)}.md`
+);
+
+fs.writeFileSync(changesetPath, changeset.toString());
+
+for (const kind of ICON_CHANGE_KINDS) {
+  if (changes[kind].length > 0) {
+    console.log(`${kind}: ${changes[kind].join(", ")}`);
+  }
+}
+
+if (changes.removed.length > 0) {
+  console.warn(
+    "Icons were removed, which is a breaking change for consumers. " +
+      "Edit the changeset by hand if this needs a major bump."
+  );
+}
+
+console.log(
+  `Wrote ${path.relative(repositoryRoot, changesetPath)} (${BUMP} bump).`
+);

--- a/packages/icon-kit/src/changeset/index.ts
+++ b/packages/icon-kit/src/changeset/index.ts
@@ -1,13 +1,7 @@
-import { execFileSync } from "node:child_process";
-import fs from "node:fs";
 import path from "node:path";
-import { ChangesetFile, type Bump } from "./changeset-file.js";
-import {
-  countIconChanges,
-  ICON_CHANGE_KINDS,
-  parseIconChanges,
-} from "./icon-changes.js";
-import { md5 } from "../utils.js";
+import { type Bump } from "./changeset-file.js";
+import { generateChangeset } from "./generate-changeset.js";
+import { ICON_CHANGE_KINDS } from "./icon-changes.js";
 
 const PACKAGE_NAME = "@shopware-ag/meteor-icon-kit";
 
@@ -15,56 +9,16 @@ const PACKAGE_NAME = "@shopware-ag/meteor-icon-kit";
 // only modified.
 const BUMP: Bump = "minor";
 
-function git(args: string[], cwd: string): string {
-  return execFileSync("git", args, { cwd, encoding: "utf-8" });
-}
+const { changes, repositoryRoot, changesetPath } = generateChangeset({
+  packageName: PACKAGE_NAME,
+  bump: BUMP,
+  iconDirectory: path.resolve(import.meta.dirname, "../../icons"),
+});
 
-const iconDirectory = path.resolve(import.meta.dirname, "../../icons");
-const repositoryRoot = git(
-  ["rev-parse", "--show-toplevel"],
-  iconDirectory
-).trim();
-
-// git reports paths relative to the repository root, always with forward
-// slashes, so build the prefix we match against the same way.
-const iconsPrefix = `${path
-  .relative(repositoryRoot, iconDirectory)
-  .split(path.sep)
-  .join("/")}/`;
-
-const changes = parseIconChanges(
-  git(
-    [
-      "status",
-      "--porcelain",
-      "-z",
-      "--untracked-files=all",
-      "--no-renames",
-      "--",
-      iconDirectory,
-    ],
-    repositoryRoot
-  ),
-  iconsPrefix
-);
-
-if (countIconChanges(changes) === 0) {
+if (!changesetPath) {
   console.log("No icon changes detected — skipping changeset.");
   process.exit(0);
 }
-
-const changeset = new ChangesetFile(PACKAGE_NAME, BUMP, changes);
-
-// Derive the filename from the changes themselves so re-running the sync on an
-// unchanged icon set updates the existing changeset instead of piling up
-// near-duplicates.
-const changesetPath = path.join(
-  repositoryRoot,
-  ".changeset",
-  `update-icons-${md5(changes).slice(0, 8)}.md`
-);
-
-fs.writeFileSync(changesetPath, changeset.toString());
 
 for (const kind of ICON_CHANGE_KINDS) {
   if (changes[kind].length > 0) {


### PR DESCRIPTION
## What?
Closes #1313

Adds a `changeset` script to `@shopware-ag/meteor-icon-kit` that inspects what the Figma icon sync changed and writes a matching changeset file into `.changeset/`. The "Update icons" GitHub workflow now runs this step right after the sync, so the automated "Update icons" PR ships with its changeset already included.

## Why?

The automated icon PRs land without a changeset, so someone has to write one by hand before a release can be cut, and the icon names have to be copied over manually. That is tedious and easy to forget or get wrong. The changelog format for icon releases has been stable since v5.6.0 (a minor bump plus lists of added, modified and removed icons), so it can be generated reliably.

## How?

- **Diff via git.** After the sync, `git status --porcelain` scoped to the icons directory gives the exact set of added, modified and removed SVGs. Generated artifacts like `meta.json` and the stylesheets are filtered out, so a sync with no real icon changes writes nothing.
- **Render the existing format.** Paths become published icon names (`regular-cog`), and the file is written as a `minor` bump with one section per change kind, matching the changelog since v5.6.0.
- **Stable filename.** The file is named from a hash of the changes, so re-running the sync on the same icon set updates the existing changeset instead of creating duplicates.
- **Wiring and tests.** New `changeset` script in `package.json`, a "Generate changeset" step in `update-icons.yml`, and unit plus end-to-end tests against a throwaway git repository.

