### PR TITLE
fix: bump create-pull-request to v8 in update-tokens workflow

### DIFF
--- a/.github/workflows/update-tokens.yml
+++ b/.github/workflows/update-tokens.yml
@@ -29,7 +29,7 @@ jobs:
         run: pnpm --filter @shopware-ag/meteor-tokens run start
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v8
         with:
           commit-message: Update tokens
           committer: Dennis Mader <${{ secrets.ICON_KIT__COMMITTER }}>


### PR DESCRIPTION
## Why

The manual `Update tokens` workflow fails at the "Create Pull Request" step:

```
remote: Duplicate header: "Authorization"
fatal: unable to access 'https://github.com/shopware/meteor/': The requested URL returned error: 400
```

`actions/checkout@v6` persists credentials in a separate file instead of the repo-local `http.extraheader` git config. `peter-evans/create-pull-request@v6` does not know about that mechanism, adds its own auth header, and git ends up sending two Authorization headers, which GitHub rejects with a 400.

Example failing run: https://github.com/shopware/meteor/actions/runs/32354013302

## What

Bump `peter-evans/create-pull-request` from v6 to v8, matching the `Update icons` workflow, which already uses v8 with `checkout@v6` and ran successfully on main.