### PR TITLE
chore: add missing changeset for token update (#1331)

### DIFF
--- a/.changeset/update-color-tokens.md
+++ b/.changeset/update-color-tokens.md
@@ -1,0 +1,9 @@
+---
+"@shopware-ag/meteor-tokens": patch
+---
+
+- Changed `color/text/primary/default` to map to `color/zinc/100` instead of `color/zinc/50` in dark mode
+- Changed `color/icon/primary/default` to map to `color/zinc/100` instead of `color/zinc/50` in dark mode
+- Changed `color/text/primary/inverse` to map to `color/zinc/100` instead of `color/zinc/50` in light mode
+- Changed `color/icon/primary/inverse` to map to `color/zinc/100` instead of `color/zinc/50` in light mode
+- Changed `zinc/1000` to map to `#0E0E11` instead of `#09090B`


### PR DESCRIPTION
## Description

Adds the changeset that was missed in #1331 (Update tokens), so the token changes are included in the next release of `@shopware-ag/meteor-tokens`.

Changes covered:

- Changed `color/text/primary/default` to map to `color/zinc/100` instead of `color/zinc/50` in dark mode
- Changed `color/icon/primary/default` to map to `color/zinc/100` instead of `color/zinc/50` in dark mode
- Changed `color/text/primary/inverse` to map to `color/zinc/100` instead of `color/zinc/50` in light mode
- Changed `color/icon/primary/inverse` to map to `color/zinc/100` instead of `color/zinc/50` in light mode
- Changed `zinc/1000` to map to `#0E0E11` instead of `#09090B`