### PR TITLE
fix: guard service permissions by Shopware version

### DIFF
--- a/.changeset/add-service-permission-events.md
+++ b/.changeset/add-service-permission-events.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": patch
+---
+
+Add success and error events to the service permission banner and document the banner and its `useServicePermission` composable.

--- a/apps/docs/content/3.utilities/composables/use-service-permission.md
+++ b/apps/docs/content/3.utilities/composables/use-service-permission.md
@@ -1,0 +1,44 @@
+---
+title: useServicePermission
+description: Manages Shopware Services consent and permission state for service extensions.
+---
+
+## Usage
+
+`useServicePermission` resolves whether the current extension is a Shopware Service and whether the required Shopware Services consent has been granted. Use it when building a custom permission UI.
+
+```ts
+import { useServicePermission } from "@shopware-ag/meteor-component-library";
+
+const {
+  isService,
+  permissionGranted,
+  isShowPermissionUI,
+  grant,
+} = useServicePermission();
+
+if (isShowPermissionUI.value) {
+  await grant();
+}
+```
+
+## API
+
+`useServicePermission()` returns:
+
+| Member | Type | Description |
+| --- | --- | --- |
+| `isLegacySWVersion` | `Ref<boolean \| null>` | Whether the Administration predates the native service-permission API. `null` means the version could not be resolved. |
+| `isLegacySWVersionEvaluating` | `Ref<boolean>` | Whether the Administration version check is still running. |
+| `isGranting` | `Ref<boolean>` | Whether a native permission request is currently running. |
+| `isService` | `Ref<boolean>` | Whether the current extension is running as a Shopware Service. |
+| `permissionGranted` | `Ref<boolean \| null>` | Whether Shopware Services consent is granted. `null` means the state could not be resolved. |
+| `isShowPermissionUI` | `ComputedRef<boolean>` | Whether permission UI should be shown. |
+| `grant` | `() => Promise<void>` | Requests Shopware Services consent or opens the Services settings page on legacy Administrations. Rejects when the grant flow fails. |
+
+## Behavior
+
+- On Shopware 6.7.14.0 and later, consent is resolved and requested through the native service-permission API.
+- On older Administrations, `system_config:read` is used as the legacy signal for Shopware Services consent, and `grant()` opens the Services settings page.
+- `grant()` rejects after logging an error, so callers can show their own error state or emit an error event.
+- The permission UI should only be rendered when `isShowPermissionUI.value` is `true`.

--- a/packages/admin-sdk/src/_private/context/README.md
+++ b/packages/admin-sdk/src/_private/context/README.md
@@ -2,6 +2,10 @@
 
 This private SDK API is available to Shopware Services through the `_private` namespace.
 
+This method is supported by Shopware `6.7.14.0` and newer. On older
+Administrations, it throws an error without sending an unsupported channel
+message.
+
 ## `isService()`
 
 ```ts

--- a/packages/admin-sdk/src/_private/context/index.spec.ts
+++ b/packages/admin-sdk/src/_private/context/index.spec.ts
@@ -1,11 +1,20 @@
 import { createSender } from '../../channel';
 import { isService } from './index';
+import { compareIsShopwareVersion } from '../../context';
 
 jest.mock('../../channel', () => ({
   createSender: jest.fn(() => jest.fn()),
 }));
 
+jest.mock('../../context', () => ({
+  compareIsShopwareVersion: jest.fn(),
+}));
+
 describe('Private Service Context', () => {
+  beforeEach(() => {
+    (compareIsShopwareVersion as jest.Mock).mockResolvedValue(false);
+  });
+
   it('creates a sender for the service check', () => {
     expect(createSender).toHaveBeenCalledWith('contextIsService', {});
     expect(isService).toEqual(expect.any(Function));
@@ -17,5 +26,18 @@ describe('Private Service Context', () => {
     await isService();
 
     expect(sender).toHaveBeenCalledWith();
+  });
+
+  it('throws without sending the service check before Shopware 6.7.14.0', async () => {
+    const sender = (createSender as jest.Mock).mock.results[0]?.value as jest.Mock;
+    (compareIsShopwareVersion as jest.Mock).mockResolvedValue(true);
+    sender.mockClear();
+
+    await expect(isService()).rejects.toThrow(
+      'isService() requires Shopware 6.7.14.0 or newer',
+    );
+
+    expect(compareIsShopwareVersion).toHaveBeenCalledWith('<', '6.7.14.0');
+    expect(sender).not.toHaveBeenCalled();
   });
 });

--- a/packages/admin-sdk/src/_private/context/index.ts
+++ b/packages/admin-sdk/src/_private/context/index.ts
@@ -1,11 +1,21 @@
 import { createSender } from '../../channel';
+import { compareIsShopwareVersion } from '../../context';
+
+const getServiceContext = createSender('contextIsService', {});
 
 /**
  * Check whether the current extension is a Shopware Service.
  *
  * @private
+ * @since 6.7.14.0
  */
-export const isService = createSender('contextIsService', {});
+export async function isService(): Promise<boolean> {
+  if (await compareIsShopwareVersion('<', '6.7.14.0')) {
+    throw new Error('isService() requires Shopware 6.7.14.0 or newer');
+  }
+
+  return (await getServiceContext()) ?? false;
+}
 
 export type contextIsService = {
   responseType: boolean,

--- a/packages/admin-sdk/src/_private/permissions/README.md
+++ b/packages/admin-sdk/src/_private/permissions/README.md
@@ -2,6 +2,10 @@
 
 This private SDK API is available to Shopware Services through the `_private` namespace.
 
+Both methods are supported by Shopware `6.7.14.0` and newer. On older
+Administrations, they throw an error without sending unsupported channel
+messages.
+
 ## `grant()`
 
 ```ts

--- a/packages/admin-sdk/src/_private/permissions/index.spec.ts
+++ b/packages/admin-sdk/src/_private/permissions/index.spec.ts
@@ -1,11 +1,20 @@
 import { createSender } from '../../channel';
 import { grant, isGranted } from './index';
+import { compareIsShopwareVersion } from '../../context';
 
 jest.mock('../../channel', () => ({
   createSender: jest.fn(() => jest.fn()),
 }));
 
+jest.mock('../../context', () => ({
+  compareIsShopwareVersion: jest.fn(),
+}));
+
 describe('Private Service Permissions', () => {
+  beforeEach(() => {
+    (compareIsShopwareVersion as jest.Mock).mockResolvedValue(false);
+  });
+
   it('creates a sender for granting permissions', () => {
     expect(createSender).toHaveBeenCalledWith('servicePermissionGrant', {});
     expect(grant).toEqual(expect.any(Function));
@@ -30,5 +39,31 @@ describe('Private Service Permissions', () => {
     await isGranted();
 
     expect(sender).toHaveBeenCalledWith();
+  });
+
+  it('throws without sending the grant request before Shopware 6.7.14.0', async () => {
+    const sender = (createSender as jest.Mock).mock.results[0]?.value as jest.Mock;
+    (compareIsShopwareVersion as jest.Mock).mockResolvedValue(true);
+    sender.mockClear();
+
+    await expect(grant()).rejects.toThrow(
+      'grant() requires Shopware 6.7.14.0 or newer',
+    );
+
+    expect(compareIsShopwareVersion).toHaveBeenCalledWith('<', '6.7.14.0');
+    expect(sender).not.toHaveBeenCalled();
+  });
+
+  it('throws without sending the granted check before Shopware 6.7.14.0', async () => {
+    const sender = (createSender as jest.Mock).mock.results[1]?.value as jest.Mock;
+    (compareIsShopwareVersion as jest.Mock).mockResolvedValue(true);
+    sender.mockClear();
+
+    await expect(isGranted()).rejects.toThrow(
+      'isGranted() requires Shopware 6.7.14.0 or newer',
+    );
+
+    expect(compareIsShopwareVersion).toHaveBeenCalledWith('<', '6.7.14.0');
+    expect(sender).not.toHaveBeenCalled();
   });
 });

--- a/packages/admin-sdk/src/_private/permissions/index.ts
+++ b/packages/admin-sdk/src/_private/permissions/index.ts
@@ -1,11 +1,24 @@
 import { createSender } from '../../channel';
+import { compareIsShopwareVersion } from '../../context';
+
+const grantPermission = createSender('servicePermissionGrant', {});
+const checkPermission = createSender('servicePermissionIsGranted', {});
+
+const minimumSupportedVersion = '6.7.14.0';
 
 /**
  * Grant the permissions required by Shopware Services.
  *
  * @private
+ * @since 6.7.14.0
  */
-export const grant = createSender('servicePermissionGrant', {});
+export async function grant(): Promise<void> {
+  if (await compareIsShopwareVersion('<', minimumSupportedVersion)) {
+    throw new Error('grant() requires Shopware 6.7.14.0 or newer');
+  }
+
+  await grantPermission();
+}
 
 /**
  * Check whether the Shopware Services consent is already granted (or not needed).
@@ -13,8 +26,15 @@ export const grant = createSender('servicePermissionGrant', {});
  * has been consented to, or Shopware Services are disabled.
  *
  * @private
+ * @since 6.7.14.0
  */
-export const isGranted = createSender('servicePermissionIsGranted', {});
+export async function isGranted(): Promise<boolean> {
+  if (await compareIsShopwareVersion('<', minimumSupportedVersion)) {
+    throw new Error('isGranted() requires Shopware 6.7.14.0 or newer');
+  }
+
+  return (await checkPermission()) ?? true;
+}
 
 export type servicePermissionGrant = {
   responseType: void,

--- a/packages/component-library/src/components/_internal/mt-grant-permission-service-banner/mt-grant-permission-service-banner.spec.ts
+++ b/packages/component-library/src/components/_internal/mt-grant-permission-service-banner/mt-grant-permission-service-banner.spec.ts
@@ -337,6 +337,52 @@ describe("mt-grant-permission-service-banner", () => {
     expect(grant).toHaveBeenCalledTimes(1);
   });
 
+  it("emits grant-success once after the grant finishes", async () => {
+    // ARRANGE
+    const user = userEvent.setup();
+    let resolveGrant: () => void = () => {};
+    grant.mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveGrant = resolve;
+      }),
+    );
+
+    const { emitted } = await renderBanner();
+
+    // ACT
+    await user.click(getGrantButton());
+
+    // ASSERT
+    expect(emitted("grant-success")).toBeUndefined();
+
+    // ACT
+    resolveGrant();
+    await flushPromises();
+
+    // ASSERT
+    expect(emitted("grant-success")).toEqual([[]]);
+    expect(emitted("grant-error")).toBeUndefined();
+  });
+
+  it("emits grant-error once when the grant fails", async () => {
+    // ARRANGE
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const user = userEvent.setup();
+    const permissionError = new Error("permission denied");
+    grant.mockRejectedValue(permissionError);
+
+    const { emitted } = await renderBanner();
+
+    // ACT
+    await user.click(getGrantButton());
+
+    // ASSERT
+    expect(emitted("grant-error")).toEqual([[permissionError]]);
+    expect(emitted("grant-success")).toBeUndefined();
+
+    consoleError.mockRestore();
+  });
+
   it("recovers from a failed permission request", async () => {
     // ARRANGE
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
@@ -442,6 +488,18 @@ describe("mt-grant-permission-service-banner", () => {
     expect(dispatch).toHaveBeenCalledWith({
       event: "SwagExample_grant_permission_more_info",
     });
+  });
+
+  it("emits more-info once when the link is clicked", async () => {
+    // ARRANGE
+    const user = userEvent.setup();
+    const { emitted } = await renderBanner();
+
+    // ACT
+    await user.click(screen.getByRole("link", { name: "More info" }));
+
+    // ASSERT
+    expect(emitted("more-info")).toEqual([[]]);
   });
 
   it("opens the more info target in a new tab", async () => {

--- a/packages/component-library/src/components/_internal/mt-grant-permission-service-banner/mt-grant-permission-service-banner.spec.ts
+++ b/packages/component-library/src/components/_internal/mt-grant-permission-service-banner/mt-grant-permission-service-banner.spec.ts
@@ -128,7 +128,7 @@ describe("mt-grant-permission-service-banner", () => {
   it("uses the system config privilege on Administrations without service context support", async () => {
     // ARRANGE
     compareIsShopwareVersion.mockResolvedValue(true);
-    can.mockResolvedValue(true);
+    can.mockResolvedValue(false);
 
     // ACT
     await renderBanner();
@@ -140,10 +140,10 @@ describe("mt-grant-permission-service-banner", () => {
     expect(screen.getByRole("region")).toBeInTheDocument();
   });
 
-  it("hides on older Administrations without the system config privilege", async () => {
+  it("hides on older Administrations with the system config privilege", async () => {
     // ARRANGE
     compareIsShopwareVersion.mockResolvedValue(true);
-    can.mockResolvedValue(false);
+    can.mockResolvedValue(true);
 
     // ACT
     await renderBanner();
@@ -229,6 +229,7 @@ describe("mt-grant-permission-service-banner", () => {
     // ARRANGE
     const user = userEvent.setup();
     compareIsShopwareVersion.mockResolvedValue(true);
+    can.mockResolvedValue(false);
 
     await renderBanner();
 
@@ -244,6 +245,7 @@ describe("mt-grant-permission-service-banner", () => {
     // ARRANGE
     const user = userEvent.setup();
     compareIsShopwareVersion.mockResolvedValue(true);
+    can.mockResolvedValue(false);
 
     await renderBanner();
 
@@ -271,6 +273,7 @@ describe("mt-grant-permission-service-banner", () => {
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
     const user = userEvent.setup();
     compareIsShopwareVersion.mockResolvedValue(true);
+    can.mockResolvedValue(false);
     routerPush.mockRejectedValue(new Error("unknown route"));
 
     await renderBanner();
@@ -378,6 +381,7 @@ describe("mt-grant-permission-service-banner", () => {
     // ARRANGE
     const user = userEvent.setup();
     compareIsShopwareVersion.mockResolvedValue(true);
+    can.mockResolvedValue(false);
 
     await renderBanner();
 

--- a/packages/component-library/src/components/_internal/mt-grant-permission-service-banner/mt-grant-permission-service-banner.spec.ts
+++ b/packages/component-library/src/components/_internal/mt-grant-permission-service-banner/mt-grant-permission-service-banner.spec.ts
@@ -7,6 +7,7 @@ import MtGrantPermissionServiceBanner from "./mt-grant-permission-service-banner
 const isService = vi.hoisted(() => vi.fn());
 const grant = vi.hoisted(() => vi.fn());
 const isGranted = vi.hoisted(() => vi.fn());
+const can = vi.hoisted(() => vi.fn());
 const compareIsShopwareVersion = vi.hoisted(() => vi.fn());
 const getAppInformation = vi.hoisted(() => vi.fn());
 const routerPush = vi.hoisted(() => vi.fn());
@@ -15,6 +16,7 @@ const dispatch = vi.hoisted(() => vi.fn());
 vi.mock("@shopware-ag/meteor-admin-sdk/es/window", () => ({ routerPush }));
 
 vi.mock("@shopware-ag/meteor-admin-sdk/es/context", () => ({
+  can,
   compareIsShopwareVersion,
   getAppInformation,
 }));
@@ -66,6 +68,7 @@ beforeEach(() => {
   isService.mockResolvedValue(true);
   grant.mockResolvedValue(undefined);
   isGranted.mockResolvedValue(false);
+  can.mockResolvedValue(true);
   compareIsShopwareVersion.mockResolvedValue(false);
   getAppInformation.mockResolvedValue({
     name: "SwagExample",
@@ -119,6 +122,36 @@ describe("mt-grant-permission-service-banner", () => {
     await renderBanner();
 
     // ASSERT
+    expect(screen.queryByRole("region")).not.toBeInTheDocument();
+  });
+
+  it("uses the system config privilege on Administrations without service context support", async () => {
+    // ARRANGE
+    compareIsShopwareVersion.mockResolvedValue(true);
+    can.mockResolvedValue(true);
+
+    // ACT
+    await renderBanner();
+
+    // ASSERT
+    expect(can).toHaveBeenCalledWith("system_config:read");
+    expect(isService).not.toHaveBeenCalled();
+    expect(isGranted).not.toHaveBeenCalled();
+    expect(screen.getByRole("region")).toBeInTheDocument();
+  });
+
+  it("hides on older Administrations without the system config privilege", async () => {
+    // ARRANGE
+    compareIsShopwareVersion.mockResolvedValue(true);
+    can.mockResolvedValue(false);
+
+    // ACT
+    await renderBanner();
+
+    // ASSERT
+    expect(can).toHaveBeenCalledWith("system_config:read");
+    expect(isService).not.toHaveBeenCalled();
+    expect(isGranted).not.toHaveBeenCalled();
     expect(screen.queryByRole("region")).not.toBeInTheDocument();
   });
 
@@ -221,22 +254,16 @@ describe("mt-grant-permission-service-banner", () => {
     expect(getGrantButton()).toBeEnabled();
   });
 
-  it("does not route away when the version check fails", async () => {
+  it("hides when the version check fails", async () => {
     // ARRANGE
-    const user = userEvent.setup();
     compareIsShopwareVersion.mockRejectedValue(new Error("no channel counterpart"));
 
-    const { errors } = await renderBanner();
-
-    // ACT
-    await user.click(getGrantButton());
+    await renderBanner();
 
     // ASSERT
+    expect(screen.queryByRole("region")).not.toBeInTheDocument();
     expect(routerPush).not.toHaveBeenCalled();
     expect(grant).not.toHaveBeenCalled();
-    // The version check sits outside the handler's own try/catch, so the
-    // failure leaves the handler and is reported by Vue.
-    expect(errors).toContainEqual(new Error("no channel counterpart"));
   });
 
   it("recovers when the route change is rejected", async () => {

--- a/packages/component-library/src/components/_internal/mt-grant-permission-service-banner/mt-grant-permission-service-banner.spec.ts
+++ b/packages/component-library/src/components/_internal/mt-grant-permission-service-banner/mt-grant-permission-service-banner.spec.ts
@@ -13,22 +13,30 @@ const getAppInformation = vi.hoisted(() => vi.fn());
 const routerPush = vi.hoisted(() => vi.fn());
 const dispatch = vi.hoisted(() => vi.fn());
 
-vi.mock("@shopware-ag/meteor-admin-sdk/es/window", () => ({ routerPush }));
+vi.mock("@shopware-ag/meteor-admin-sdk", () => ({
+  context: {
+    can,
+    compareIsShopwareVersion,
+  },
+  _private: {
+    context: {
+      isService,
+    },
+    permissions: {
+      grant,
+      isGranted,
+    },
+  },
+  window: {
+    routerPush,
+  },
+}));
 
 vi.mock("@shopware-ag/meteor-admin-sdk/es/context", () => ({
-  can,
-  compareIsShopwareVersion,
   getAppInformation,
 }));
 
 vi.mock("@shopware-ag/meteor-admin-sdk/es/telemetry", () => ({ dispatch }));
-
-vi.mock("@shopware-ag/meteor-admin-sdk/es/_private/context", () => ({ isService }));
-
-vi.mock("@shopware-ag/meteor-admin-sdk/es/_private/permissions", () => ({
-  grant,
-  isGranted,
-}));
 
 /**
  * Renders the banner and waits for the `isService` round-trip to settle, because
@@ -268,21 +276,27 @@ describe("mt-grant-permission-service-banner", () => {
 
   it("recovers when the route change is rejected", async () => {
     // ARRANGE
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
     const user = userEvent.setup();
     compareIsShopwareVersion.mockResolvedValue(true);
     routerPush.mockRejectedValue(new Error("unknown route"));
 
-    const { errors } = await renderBanner();
+    await renderBanner();
 
     // ACT
     await user.click(getGrantButton());
 
     // ASSERT
-    expect(errors).toContainEqual(new Error("unknown route"));
+    expect(consoleError).toHaveBeenCalledWith(
+      "Error granting permission:",
+      new Error("unknown route"),
+    );
     expect(grant).not.toHaveBeenCalled();
     // A rejected route change must not leave the button stuck in its loading
     // state, otherwise the banner becomes unusable.
     expect(getGrantButton()).toBeEnabled();
+
+    consoleError.mockRestore();
   });
 
   it("shows a loading state while the permission is being granted", async () => {

--- a/packages/component-library/src/components/_internal/mt-grant-permission-service-banner/mt-grant-permission-service-banner.spec.ts
+++ b/packages/component-library/src/components/_internal/mt-grant-permission-service-banner/mt-grant-permission-service-banner.spec.ts
@@ -13,30 +13,22 @@ const getAppInformation = vi.hoisted(() => vi.fn());
 const routerPush = vi.hoisted(() => vi.fn());
 const dispatch = vi.hoisted(() => vi.fn());
 
-vi.mock("@shopware-ag/meteor-admin-sdk", () => ({
-  context: {
-    can,
-    compareIsShopwareVersion,
-  },
-  _private: {
-    context: {
-      isService,
-    },
-    permissions: {
-      grant,
-      isGranted,
-    },
-  },
-  window: {
-    routerPush,
-  },
-}));
-
 vi.mock("@shopware-ag/meteor-admin-sdk/es/context", () => ({
+  can,
+  compareIsShopwareVersion,
   getAppInformation,
 }));
 
 vi.mock("@shopware-ag/meteor-admin-sdk/es/telemetry", () => ({ dispatch }));
+
+vi.mock("@shopware-ag/meteor-admin-sdk/es/_private/context", () => ({ isService }));
+
+vi.mock("@shopware-ag/meteor-admin-sdk/es/_private/permissions", () => ({
+  grant,
+  isGranted,
+}));
+
+vi.mock("@shopware-ag/meteor-admin-sdk/es/window", () => ({ routerPush }));
 
 /**
  * Renders the banner and waits for the `isService` round-trip to settle, because

--- a/packages/component-library/src/components/_internal/mt-grant-permission-service-banner/mt-grant-permission-service-banner.vue
+++ b/packages/component-library/src/components/_internal/mt-grant-permission-service-banner/mt-grant-permission-service-banner.vue
@@ -60,6 +60,17 @@
   </div>
 </template>
 
+<script lang="ts">
+/**
+ * For internal Shopware Services only.
+ *
+ * Displays a permission grant section for Shopware Services.
+ */
+export default {
+  name: "MtGrantPermissionServiceBanner",
+};
+</script>
+
 <script setup lang="ts">
 import { useId } from "vue";
 import { asyncComputed } from "@vueuse/core";

--- a/packages/component-library/src/components/_internal/mt-grant-permission-service-banner/mt-grant-permission-service-banner.vue
+++ b/packages/component-library/src/components/_internal/mt-grant-permission-service-banner/mt-grant-permission-service-banner.vue
@@ -69,6 +69,7 @@ import MtText from "@/components/mt-text/mt-text.vue";
 import MtButton from "@/components/mt-button/mt-button.vue";
 import { routerPush } from "@shopware-ag/meteor-admin-sdk/es/window";
 import {
+  can,
   compareIsShopwareVersion,
   getAppInformation,
 } from "@shopware-ag/meteor-admin-sdk/es/context";
@@ -101,8 +102,29 @@ const titleId = useId();
 
 const isLoading = ref(false);
 const shopwareServicePagePath = "/sw/settings/services/index";
+const isLegacySWVersionEvaluating = ref(true);
+
+const isLegacySWVersion = asyncComputed<boolean | null>(
+  async () => {
+    try {
+      return await compareIsShopwareVersion("<", "6.7.14.0");
+    } catch {
+      return null;
+    }
+  },
+  null,
+  { evaluating: isLegacySWVersionEvaluating },
+);
 
 const isShowUI = asyncComputed(async () => {
+  if (isLegacySWVersionEvaluating.value || isLegacySWVersion.value === null) {
+    return false;
+  }
+
+  if (isLegacySWVersion.value) {
+    return await can("system_config:read");
+  }
+
   return (await isService()) && !(await isGranted());
 }, false);
 
@@ -123,7 +145,7 @@ async function handleGrantPermission() {
     shopware_version: appInfo.value?.version,
   });
 
-  if (await compareIsShopwareVersion("<", "6.7.14.0")) {
+  if (isLegacySWVersion.value) {
     await routerPush({ path: shopwareServicePagePath });
     return;
   }

--- a/packages/component-library/src/components/_internal/mt-grant-permission-service-banner/mt-grant-permission-service-banner.vue
+++ b/packages/component-library/src/components/_internal/mt-grant-permission-service-banner/mt-grant-permission-service-banner.vue
@@ -1,6 +1,6 @@
 <template>
   <!-- The container establishes the query context the banner sizes itself against. -->
-  <div v-if="isShowUI" class="mt-grant-permission-service-banner__container">
+  <div v-if="isShowPermissionUI" class="mt-grant-permission-service-banner__container">
     <section class="mt-grant-permission-service-banner" :aria-labelledby="titleId">
       <mt-icon
         class="mt-grant-permission-service-banner__icon"
@@ -33,7 +33,7 @@
         <mt-button
           variant="primary"
           class="mt-grant-permission-service-banner__grant"
-          :is-loading="isLoading"
+          :is-loading="isGranting"
           @click="handleGrantPermission"
         >
           <span class="mt-grant-permission-service-banner__label--short">
@@ -61,21 +61,15 @@
 </template>
 
 <script setup lang="ts">
-import { ref, useId } from "vue";
+import { useId } from "vue";
 import { asyncComputed } from "@vueuse/core";
 import { useI18n } from "vue-i18n";
 import MtIcon from "@/components/mt-icon/mt-icon.vue";
 import MtText from "@/components/mt-text/mt-text.vue";
 import MtButton from "@/components/mt-button/mt-button.vue";
-import { routerPush } from "@shopware-ag/meteor-admin-sdk/es/window";
-import {
-  can,
-  compareIsShopwareVersion,
-  getAppInformation,
-} from "@shopware-ag/meteor-admin-sdk/es/context";
+import { useServicePermission } from "@/composables/useServicePermission";
+import { getAppInformation } from "@shopware-ag/meteor-admin-sdk/es/context";
 import { dispatch } from "@shopware-ag/meteor-admin-sdk/es/telemetry";
-import { isService } from "@shopware-ag/meteor-admin-sdk/es/_private/context";
-import { grant, isGranted } from "@shopware-ag/meteor-admin-sdk/es/_private/permissions";
 
 const { t } = useI18n({
   messages: {
@@ -100,33 +94,7 @@ const { t } = useI18n({
 
 const titleId = useId();
 
-const isLoading = ref(false);
-const shopwareServicePagePath = "/sw/settings/services/index";
-const isLegacySWVersionEvaluating = ref(true);
-
-const isLegacySWVersion = asyncComputed<boolean | null>(
-  async () => {
-    try {
-      return await compareIsShopwareVersion("<", "6.7.14.0");
-    } catch {
-      return null;
-    }
-  },
-  null,
-  { evaluating: isLegacySWVersionEvaluating },
-);
-
-const isShowUI = asyncComputed(async () => {
-  if (isLegacySWVersionEvaluating.value || isLegacySWVersion.value === null) {
-    return false;
-  }
-
-  if (isLegacySWVersion.value) {
-    return await can("system_config:read");
-  }
-
-  return (await isService()) && !(await isGranted());
-}, false);
+const { isGranting, isShowPermissionUI, grant } = useServicePermission();
 
 // Resolving the app information is a channel round-trip, so the banner starts
 // out without it and the telemetry payload has to tolerate the empty state.
@@ -145,22 +113,7 @@ async function handleGrantPermission() {
     shopware_version: appInfo.value?.version,
   });
 
-  if (isLegacySWVersion.value) {
-    await routerPush({ path: shopwareServicePagePath });
-    return;
-  }
-
-  if (isLoading.value) return;
-
-  isLoading.value = true;
-
-  try {
-    await grant();
-  } catch (error) {
-    console.error("Error granting permission:", error);
-  } finally {
-    isLoading.value = false;
-  }
+  await grant();
 }
 
 function handleClickMoreInfo() {

--- a/packages/component-library/src/components/_internal/mt-grant-permission-service-banner/mt-grant-permission-service-banner.vue
+++ b/packages/component-library/src/components/_internal/mt-grant-permission-service-banner/mt-grant-permission-service-banner.vue
@@ -94,6 +94,12 @@ const { t } = useI18n({
 
 const titleId = useId();
 
+const emit = defineEmits<{
+  "grant-success": [];
+  "grant-error": [error: unknown];
+  "more-info": [];
+}>();
+
 const { isGranting, isShowPermissionUI, grant } = useServicePermission();
 
 // Resolving the app information is a channel round-trip, so the banner starts
@@ -113,11 +119,17 @@ async function handleGrantPermission() {
     shopware_version: appInfo.value?.version,
   });
 
-  await grant();
+  try {
+    await grant();
+    emit("grant-success");
+  } catch (error) {
+    emit("grant-error", error);
+  }
 }
 
 function handleClickMoreInfo() {
   track(`${appInfo.value?.name}_grant_permission_more_info`);
+  emit("more-info");
 }
 </script>
 

--- a/packages/component-library/src/components/mt-button/mt-button.vue
+++ b/packages/component-library/src/components/mt-button/mt-button.vue
@@ -47,6 +47,18 @@
   </component>
 </template>
 
+<script lang="ts">
+/**
+ * Displays the permission prompt required to activate a Shopware Service.
+ *
+ * The banner detects whether the current Administration supports native
+ * service permissions and provides the matching grant flow and more-info link.
+ */
+export default {
+  name: "MtButton",
+};
+</script>
+
 <script setup lang="ts">
 import { useIsInsideTooltip } from "@/components/mt-tooltip/composables/useIsInsideTooltip";
 import MtLoader from "../mt-loader/mt-loader.vue";

--- a/packages/component-library/src/composables/useServicePermission.spec.ts
+++ b/packages/component-library/src/composables/useServicePermission.spec.ts
@@ -18,23 +18,22 @@ const {
   mockRouterPush: vi.fn(),
 }));
 
-vi.mock("@shopware-ag/meteor-admin-sdk", () => ({
-  context: {
-    can: mockCan,
-    compareIsShopwareVersion: mockCompareIsShopwareVersion,
-  },
-  _private: {
-    context: {
-      isService: mockIsService,
-    },
-    permissions: {
-      grant: mockGrant,
-      isGranted: mockIsGranted,
-    },
-  },
-  window: {
-    routerPush: mockRouterPush,
-  },
+vi.mock("@shopware-ag/meteor-admin-sdk/es/context", () => ({
+  can: mockCan,
+  compareIsShopwareVersion: mockCompareIsShopwareVersion,
+}));
+
+vi.mock("@shopware-ag/meteor-admin-sdk/es/_private/context", () => ({
+  isService: mockIsService,
+}));
+
+vi.mock("@shopware-ag/meteor-admin-sdk/es/_private/permissions", () => ({
+  grant: mockGrant,
+  isGranted: mockIsGranted,
+}));
+
+vi.mock("@shopware-ag/meteor-admin-sdk/es/window", () => ({
+  routerPush: mockRouterPush,
 }));
 
 describe("useServicePermission", () => {
@@ -57,9 +56,6 @@ describe("useServicePermission", () => {
 
     const wrapper = mount(Harness);
     if (waitForAsyncState) {
-      await vi.waitFor(() => {
-        expect(api!.isLegacySWVersionEvaluating.value).toBe(false);
-      });
       await flushPromises();
     }
 

--- a/packages/component-library/src/composables/useServicePermission.spec.ts
+++ b/packages/component-library/src/composables/useServicePermission.spec.ts
@@ -57,6 +57,9 @@ describe("useServicePermission", () => {
 
     const wrapper = mount(Harness);
     if (waitForAsyncState) {
+      await vi.waitFor(() => {
+        expect(api!.isLegacySWVersionEvaluating.value).toBe(false);
+      });
       await flushPromises();
     }
 

--- a/packages/component-library/src/composables/useServicePermission.spec.ts
+++ b/packages/component-library/src/composables/useServicePermission.spec.ts
@@ -73,6 +73,18 @@ describe("useServicePermission", () => {
     expect(api.permissionGranted.value).toBe(true);
     expect(api.isLegacySWVersion.value).toBe(true);
     expect(api.isLegacySWVersionEvaluating.value).toBe(false);
+    expect(api.isShowPermissionUI.value).toBe(false);
+
+    wrapper.unmount();
+  });
+
+  it("shows the permission UI when the legacy permission is not granted", async () => {
+    mockCompareIsShopwareVersion.mockResolvedValue(true);
+    mockCan.mockResolvedValue(false);
+
+    const { api, wrapper } = await mountHarness();
+
+    expect(api.permissionGranted.value).toBe(false);
     expect(api.isShowPermissionUI.value).toBe(true);
 
     wrapper.unmount();

--- a/packages/component-library/src/composables/useServicePermission.spec.ts
+++ b/packages/component-library/src/composables/useServicePermission.spec.ts
@@ -1,0 +1,277 @@
+import { flushPromises, mount } from "@vue/test-utils";
+import { defineComponent, h } from "vue";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockCan,
+  mockCompareIsShopwareVersion,
+  mockGrant,
+  mockIsGranted,
+  mockIsService,
+  mockRouterPush,
+} = vi.hoisted(() => ({
+  mockCan: vi.fn(),
+  mockCompareIsShopwareVersion: vi.fn(),
+  mockGrant: vi.fn(),
+  mockIsGranted: vi.fn(),
+  mockIsService: vi.fn(),
+  mockRouterPush: vi.fn(),
+}));
+
+vi.mock("@shopware-ag/meteor-admin-sdk", () => ({
+  context: {
+    can: mockCan,
+    compareIsShopwareVersion: mockCompareIsShopwareVersion,
+  },
+  _private: {
+    context: {
+      isService: mockIsService,
+    },
+    permissions: {
+      grant: mockGrant,
+      isGranted: mockIsGranted,
+    },
+  },
+  window: {
+    routerPush: mockRouterPush,
+  },
+}));
+
+describe("useServicePermission", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCompareIsShopwareVersion.mockResolvedValue(false);
+    mockIsService.mockResolvedValue(false);
+  });
+
+  async function mountHarness(waitForAsyncState = true) {
+    const module = await import("./useServicePermission");
+    let api: ReturnType<typeof module.useServicePermission> | null = null;
+
+    const Harness = defineComponent({
+      setup() {
+        api = module.useServicePermission();
+        return () => h("div");
+      },
+    });
+
+    const wrapper = mount(Harness);
+    if (waitForAsyncState) {
+      await flushPromises();
+    }
+
+    return { api: api!, wrapper };
+  }
+
+  it("uses the legacy permission on Shopware versions before 6.7.14.0", async () => {
+    mockCompareIsShopwareVersion.mockResolvedValue(true);
+    mockCan.mockResolvedValue(true);
+
+    const { api, wrapper } = await mountHarness();
+
+    expect(mockCompareIsShopwareVersion).toHaveBeenCalledWith("<", "6.7.14.0");
+    expect(mockCan).toHaveBeenCalledWith("system_config:read");
+    expect(api.permissionGranted.value).toBe(true);
+    expect(api.isLegacySWVersion.value).toBe(true);
+    expect(api.isLegacySWVersionEvaluating.value).toBe(false);
+    expect(api.isShowPermissionUI.value).toBe(true);
+
+    wrapper.unmount();
+  });
+
+  it("uses the private permission API on Shopware 6.7.14.0 and later", async () => {
+    mockIsGranted.mockResolvedValue(true);
+
+    const { api, wrapper } = await mountHarness();
+
+    expect(mockCompareIsShopwareVersion).toHaveBeenCalledWith("<", "6.7.14.0");
+    expect(mockIsGranted).toHaveBeenCalledOnce();
+    expect(mockCan).not.toHaveBeenCalled();
+    expect(api.permissionGranted.value).toBe(true);
+    expect(api.isLegacySWVersion.value).toBe(false);
+    expect(api.isLegacySWVersionEvaluating.value).toBe(false);
+
+    wrapper.unmount();
+  });
+
+  it("exposes whether the current extension is a Shopware Service", async () => {
+    mockIsService.mockResolvedValue(true);
+    mockIsGranted.mockResolvedValue(false);
+
+    const { api, wrapper } = await mountHarness();
+
+    expect(mockIsService).toHaveBeenCalledOnce();
+    expect(api.isService.value).toBe(true);
+    expect(api.isShowPermissionUI.value).toBe(true);
+
+    wrapper.unmount();
+  });
+
+  it("does not call the unsupported service context API on legacy versions", async () => {
+    mockCompareIsShopwareVersion.mockResolvedValue(true);
+
+    const { api, wrapper } = await mountHarness();
+
+    expect(mockIsService).not.toHaveBeenCalled();
+    expect(api.isService.value).toBe(false);
+
+    wrapper.unmount();
+  });
+
+  it("uses null when the Shopware version cannot be resolved", async () => {
+    mockCompareIsShopwareVersion.mockRejectedValueOnce(new Error("Version unavailable"));
+
+    const { api, wrapper } = await mountHarness();
+
+    expect(api.isLegacySWVersion.value).toBeNull();
+    expect(api.isLegacySWVersionEvaluating.value).toBe(false);
+    expect(api.isService.value).toBe(false);
+    expect(api.permissionGranted.value).toBeNull();
+    expect(api.isShowPermissionUI.value).toBe(false);
+    expect(mockIsService).not.toHaveBeenCalled();
+    expect(mockIsGranted).not.toHaveBeenCalled();
+
+    wrapper.unmount();
+  });
+
+  it("keeps permissionGranted false when permission is denied", async () => {
+    mockIsGranted.mockResolvedValue(false);
+
+    const { api, wrapper } = await mountHarness();
+
+    expect(api.permissionGranted.value).toBe(false);
+
+    wrapper.unmount();
+  });
+
+  it("uses null when the permission state cannot be resolved", async () => {
+    mockIsGranted.mockRejectedValueOnce(new Error("Permission unavailable"));
+
+    const { api, wrapper } = await mountHarness();
+
+    expect(api.permissionGranted.value).toBeNull();
+
+    wrapper.unmount();
+  });
+
+  it("opens the Shopware Services page when granting on versions before 6.7.14.0", async () => {
+    mockCompareIsShopwareVersion.mockResolvedValue(true);
+
+    const { api, wrapper } = await mountHarness();
+
+    await api.grant();
+
+    expect(mockRouterPush).toHaveBeenCalledWith({ path: "/sw/settings/services/index" });
+    expect(mockGrant).not.toHaveBeenCalled();
+
+    wrapper.unmount();
+  });
+
+  it("grants service permissions through the private API on 6.7.14.0 and later", async () => {
+    const { api, wrapper } = await mountHarness();
+
+    await api.grant();
+
+    expect(mockGrant).toHaveBeenCalledOnce();
+    expect(mockRouterPush).not.toHaveBeenCalled();
+
+    wrapper.unmount();
+  });
+
+  it("returns without granting while the Shopware version is evaluating", async () => {
+    let resolveVersion!: (isLegacy: boolean) => void;
+    mockCompareIsShopwareVersion.mockImplementationOnce(
+      () =>
+        new Promise<boolean>((resolve) => {
+          resolveVersion = resolve;
+        }),
+    );
+
+    const { api, wrapper } = await mountHarness(false);
+
+    const grantPromise = api.grant();
+    await flushPromises();
+
+    resolveVersion(false);
+    await grantPromise;
+    await flushPromises();
+
+    expect(mockGrant).not.toHaveBeenCalled();
+    expect(mockRouterPush).not.toHaveBeenCalled();
+
+    wrapper.unmount();
+  });
+
+  it("resolves the Shopware version once per composable instance", async () => {
+    const { api, wrapper } = await mountHarness();
+
+    await api.grant();
+
+    expect(mockCompareIsShopwareVersion).toHaveBeenCalledOnce();
+
+    wrapper.unmount();
+  });
+
+  it("exposes loading state and ignores duplicate grant requests", async () => {
+    let resolveGrant!: () => void;
+    mockGrant.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveGrant = resolve;
+        }),
+    );
+
+    const { api, wrapper } = await mountHarness();
+
+    const grantPromise = api.grant();
+    await flushPromises();
+    const duplicateGrantPromise = api.grant();
+    await flushPromises();
+
+    expect(api.isGranting.value).toBe(true);
+    expect(mockGrant).toHaveBeenCalledOnce();
+
+    resolveGrant();
+    await Promise.all([grantPromise, duplicateGrantPromise]);
+
+    expect(api.isGranting.value).toBe(false);
+
+    wrapper.unmount();
+  });
+
+  it("resets loading state when granting fails", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    mockGrant.mockRejectedValueOnce(new Error("Grant failed"));
+
+    const { api, wrapper } = await mountHarness();
+
+    await api.grant();
+
+    expect(consoleError).toHaveBeenCalledWith(
+      "Error granting permission:",
+      new Error("Grant failed"),
+    );
+    expect(api.isGranting.value).toBe(false);
+
+    consoleError.mockRestore();
+    wrapper.unmount();
+  });
+
+  it("handles failures while opening the legacy Services page", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    mockCompareIsShopwareVersion.mockResolvedValue(true);
+    mockRouterPush.mockRejectedValueOnce(new Error("Route unavailable"));
+
+    const { api, wrapper } = await mountHarness();
+
+    await api.grant();
+
+    expect(consoleError).toHaveBeenCalledWith(
+      "Error granting permission:",
+      new Error("Route unavailable"),
+    );
+
+    consoleError.mockRestore();
+    wrapper.unmount();
+  });
+});

--- a/packages/component-library/src/composables/useServicePermission.spec.ts
+++ b/packages/component-library/src/composables/useServicePermission.spec.ts
@@ -256,7 +256,7 @@ describe("useServicePermission", () => {
 
     const { api, wrapper } = await mountHarness();
 
-    await api.grant();
+    await expect(api.grant()).rejects.toThrow("Grant failed");
 
     expect(consoleError).toHaveBeenCalledWith(
       "Error granting permission:",
@@ -275,7 +275,7 @@ describe("useServicePermission", () => {
 
     const { api, wrapper } = await mountHarness();
 
-    await api.grant();
+    await expect(api.grant()).rejects.toThrow("Route unavailable");
 
     expect(consoleError).toHaveBeenCalledWith(
       "Error granting permission:",

--- a/packages/component-library/src/composables/useServicePermission.ts
+++ b/packages/component-library/src/composables/useServicePermission.ts
@@ -1,4 +1,13 @@
-import { context, _private, window } from "@shopware-ag/meteor-admin-sdk";
+import {
+  can,
+  compareIsShopwareVersion,
+} from "@shopware-ag/meteor-admin-sdk/es/context";
+import { isService as checkIsService } from "@shopware-ag/meteor-admin-sdk/es/_private/context";
+import {
+  grant as grantPermission,
+  isGranted,
+} from "@shopware-ag/meteor-admin-sdk/es/_private/permissions";
+import { routerPush } from "@shopware-ag/meteor-admin-sdk/es/window";
 import { asyncComputed } from "@vueuse/core";
 import { computed, ref } from "vue";
 import type { ComputedRef, Ref } from "vue";
@@ -30,7 +39,7 @@ export function useServicePermission(): UseServicePermissionReturn {
   const isLegacySWVersion = asyncComputed<boolean | null>(
     async () => {
       try {
-        return await context.compareIsShopwareVersion("<", "6.7.14.0");
+        return await compareIsShopwareVersion("<", "6.7.14.0");
       } catch {
         return null;
       }
@@ -48,7 +57,7 @@ export function useServicePermission(): UseServicePermissionReturn {
       return false;
     }
 
-    return await _private.context.isService();
+    return await checkIsService();
   }, false);
 
   const permissionGranted = asyncComputed<boolean | null>(async () => {
@@ -58,10 +67,10 @@ export function useServicePermission(): UseServicePermissionReturn {
 
     try {
       if (isLegacySWVersion.value) {
-        return await context.can("system_config:read");
+        return await can("system_config:read");
       }
 
-      return await _private.permissions.isGranted();
+      return await isGranted();
     } catch {
       return null;
     }
@@ -90,7 +99,7 @@ export function useServicePermission(): UseServicePermissionReturn {
 
     if (isLegacySWVersion.value) {
       try {
-        await window.routerPush({ path: shopwareServicePagePath });
+        await routerPush({ path: shopwareServicePagePath });
       } catch (error) {
         console.error("Error granting permission:", error);
       }
@@ -103,7 +112,7 @@ export function useServicePermission(): UseServicePermissionReturn {
     isGranting.value = true;
 
     try {
-      await _private.permissions.grant();
+      await grantPermission();
     } catch (error) {
       console.error("Error granting permission:", error);
     } finally {

--- a/packages/component-library/src/composables/useServicePermission.ts
+++ b/packages/component-library/src/composables/useServicePermission.ts
@@ -83,7 +83,7 @@ export function useServicePermission(): UseServicePermissionReturn {
     }
 
     if (isLegacySWVersion.value) {
-      return permissionGranted.value;
+      return !permissionGranted.value;
     }
 
     return isService.value && !permissionGranted.value;

--- a/packages/component-library/src/composables/useServicePermission.ts
+++ b/packages/component-library/src/composables/useServicePermission.ts
@@ -64,6 +64,9 @@ export function useServicePermission(): UseServicePermissionReturn {
 
     try {
       if (isLegacySWVersion.value) {
+        // Legacy Administrations expose the Shopware Services consent through
+        // the system configuration privilege because the dedicated service
+        // permission API is only available from Shopware 6.7.14.0 onwards.
         return await can("system_config:read");
       }
 

--- a/packages/component-library/src/composables/useServicePermission.ts
+++ b/packages/component-library/src/composables/useServicePermission.ts
@@ -1,0 +1,123 @@
+import { context, _private, window } from "@shopware-ag/meteor-admin-sdk";
+import { asyncComputed } from "@vueuse/core";
+import { computed, ref } from "vue";
+import type { ComputedRef, Ref } from "vue";
+
+const shopwareServicePagePath = "/sw/settings/services/index";
+
+export interface UseServicePermissionReturn {
+  /** Whether the current Shopware version predates native service permissions. */
+  isLegacySWVersion: Ref<boolean | null>;
+  /** Whether the Shopware version check is still running. */
+  isLegacySWVersionEvaluating: Ref<boolean>;
+  /** Whether a native service permission request is currently running. */
+  isGranting: Ref<boolean>;
+  /** Whether the current extension is running as a Shopware Service. */
+  isService: Ref<boolean>;
+  /** Whether the required permission is granted, or `null` when it cannot be resolved. */
+  permissionGranted: Ref<boolean | null>;
+  /** Whether permission-related UI should be displayed. */
+  isShowPermissionUI: ComputedRef<boolean>;
+  /** Grants native service permissions or opens the Services page on legacy Shopware versions. */
+  grant: () => Promise<void>;
+}
+
+/** Resolves and grants permissions required by a Shopware Service. */
+export function useServicePermission(): UseServicePermissionReturn {
+  const isGranting = ref(false);
+  const isLegacySWVersionEvaluating = ref(true);
+
+  const isLegacySWVersion = asyncComputed<boolean | null>(
+    async () => {
+      try {
+        return await context.compareIsShopwareVersion("<", "6.7.14.0");
+      } catch {
+        return null;
+      }
+    },
+    null,
+    { evaluating: isLegacySWVersionEvaluating },
+  );
+
+  const isService = asyncComputed(async () => {
+    if (
+      isLegacySWVersionEvaluating.value ||
+      isLegacySWVersion.value === null ||
+      isLegacySWVersion.value
+    ) {
+      return false;
+    }
+
+    return await _private.context.isService();
+  }, false);
+
+  const permissionGranted = asyncComputed<boolean | null>(async () => {
+    if (isLegacySWVersionEvaluating.value || isLegacySWVersion.value === null) {
+      return null;
+    }
+
+    try {
+      if (isLegacySWVersion.value) {
+        return await context.can("system_config:read");
+      }
+
+      return await _private.permissions.isGranted();
+    } catch {
+      return null;
+    }
+  }, null);
+
+  const isShowPermissionUI = computed(() => {
+    if (
+      isLegacySWVersionEvaluating.value ||
+      isLegacySWVersion.value === null ||
+      permissionGranted.value === null
+    ) {
+      return false;
+    }
+
+    if (isLegacySWVersion.value) {
+      return permissionGranted.value;
+    }
+
+    return isService.value && !permissionGranted.value;
+  });
+
+  async function grant(): Promise<void> {
+    if (isLegacySWVersionEvaluating.value) return;
+
+    if (isLegacySWVersion.value === null) return;
+
+    if (isLegacySWVersion.value) {
+      try {
+        await window.routerPush({ path: shopwareServicePagePath });
+      } catch (error) {
+        console.error("Error granting permission:", error);
+      }
+
+      return;
+    }
+
+    if (isGranting.value) return;
+
+    isGranting.value = true;
+
+    try {
+      await _private.permissions.grant();
+    } catch (error) {
+      console.error("Error granting permission:", error);
+    } finally {
+      isGranting.value = false;
+    }
+  }
+
+  return {
+    isLegacySWVersion,
+    isLegacySWVersionEvaluating,
+    isGranting,
+    isService,
+    permissionGranted,
+    isShowPermissionUI,
+    grant,
+  };
+}

--- a/packages/component-library/src/composables/useServicePermission.ts
+++ b/packages/component-library/src/composables/useServicePermission.ts
@@ -1,7 +1,4 @@
-import {
-  can,
-  compareIsShopwareVersion,
-} from "@shopware-ag/meteor-admin-sdk/es/context";
+import { can, compareIsShopwareVersion } from "@shopware-ag/meteor-admin-sdk/es/context";
 import { isService as checkIsService } from "@shopware-ag/meteor-admin-sdk/es/_private/context";
 import {
   grant as grantPermission,

--- a/packages/component-library/src/composables/useServicePermission.ts
+++ b/packages/component-library/src/composables/useServicePermission.ts
@@ -99,6 +99,7 @@ export function useServicePermission(): UseServicePermissionReturn {
         await routerPush({ path: shopwareServicePagePath });
       } catch (error) {
         console.error("Error granting permission:", error);
+        throw error;
       }
 
       return;
@@ -112,6 +113,7 @@ export function useServicePermission(): UseServicePermissionReturn {
       await grantPermission();
     } catch (error) {
       console.error("Error granting permission:", error);
+      throw error;
     } finally {
       isGranting.value = false;
     }

--- a/packages/component-library/src/index.ts
+++ b/packages/component-library/src/index.ts
@@ -56,6 +56,10 @@ import {
   type UseThemeOptions,
   type UseThemeReturn,
 } from "./composables/useTheme";
+import {
+  useServicePermission,
+  type UseServicePermissionReturn,
+} from "./composables/useServicePermission";
 import TooltipDirective from "./directives/tooltip.directive";
 import DeviceHelperPlugin from "./plugin/device-helper.plugin";
 import MtTooltip from "./components/mt-tooltip/mt-tooltip.vue";
@@ -157,6 +161,8 @@ export {
   DeviceHelperPlugin,
   useSnackbar,
   useTheme,
+  useServicePermission,
+  type UseServicePermissionReturn,
   // @deprecated
   MtBanner as SwBanner,
   // @deprecated


### PR DESCRIPTION
## What?
Added Shopware version compatibility guards for Service permissions and context APIs.

## Why?
grant(), isGranted(), and isService() are only supported from Shopware 6.7.14.0. Calling them on older versions could send unsupported channel messages.

## How?
Throw clear errors when private APIs are used below 6.7.14.0.
Added legacy fallback in mt-grant-permission-service-banner using can("system_config:read").

