### PR TITLE
fix(component-library): remove broken CommonJS build, ship ESM only

### DIFF
--- a/.changeset/remove-broken-cjs-build.md
+++ b/.changeset/remove-broken-cjs-build.md
@@ -3,3 +3,5 @@
 ---
 
 Remove the CommonJS build. The published CJS files mixed ESM `import` statements into CommonJS modules, so `require("@shopware-ag/meteor-component-library")` always failed with a syntax error and the format was unusable. The package now ships ESM only; the `require` export conditions are removed and `main` points to the ESM entry. Use `import` (or a bundler) to consume the library, which was already the only working way to load it.
+
+Shared chunks are now emitted as `.js` instead of `.mjs`, so CommonJS-based tooling that transpiles the package on the fly (e.g. Jest with an swc or babel transform) can process every file it imports. Test setups that previously mapped imports to `dist/common` should map them to `dist/esm` instead and ensure the package is excluded from `transformIgnorePatterns`.

--- a/.changeset/remove-broken-cjs-build.md
+++ b/.changeset/remove-broken-cjs-build.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": major
+---
+
+Remove the CommonJS build. The published CJS files mixed ESM `import` statements into CommonJS modules, so `require("@shopware-ag/meteor-component-library")` always failed with a syntax error and the format was unusable. The package now ships ESM only; the `require` export conditions are removed and `main` points to the ESM entry. Use `import` (or a bundler) to consume the library, which was already the only working way to load it.

--- a/.changeset/remove-broken-cjs-build.md
+++ b/.changeset/remove-broken-cjs-build.md
@@ -1,5 +1,5 @@
 ---
-"@shopware-ag/meteor-component-library": major
+"@shopware-ag/meteor-component-library": minor
 ---
 
 Remove the CommonJS build. The published CJS files mixed ESM `import` statements into CommonJS modules, so `require("@shopware-ag/meteor-component-library")` always failed with a syntax error and the format was unusable. The package now ships ESM only; the `require` export conditions are removed and `main` points to the ESM entry. Use `import` (or a bundler) to consume the library, which was already the only working way to load it.

--- a/packages/component-library/package.json
+++ b/packages/component-library/package.json
@@ -7,27 +7,24 @@
   },
   "license": "MIT",
   "author": "shopware AG",
-  "main": "dist/common/index.js",
+  "main": "dist/esm/index.js",
   "module": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/esm/index.d.ts",
-      "import": "./dist/esm/index.js",
-      "require": "./dist/common/index.js"
+      "import": "./dist/esm/index.js"
     },
     "./styles.css": "./dist/index.css",
     "./font.css": "./dist/fonts.css",
     "./fonts": {
       "types": "./dist/esm/fonts.d.ts",
-      "import": "./dist/esm/fonts.js",
-      "require": "./dist/common/fonts.js"
+      "import": "./dist/esm/fonts.js"
     },
     "./dist/*": "./dist/*",
     "./*": {
       "types": "./dist/esm/*.d.ts",
-      "import": "./dist/esm/*.js",
-      "require": "./dist/common/*.js"
+      "import": "./dist/esm/*.js"
     }
   },
   "files": [

--- a/packages/component-library/vite.config.ts
+++ b/packages/component-library/vite.config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
     vue({}),
     svg(),
     dts({
-      outDir: ["dist/esm", "dist/common"],
+      outDir: ["dist/esm"],
       cleanVueFileName: true,
       copyDtsFiles: true,
       tsconfigPath: path.resolve(__dirname, "tsconfig.vitest.json"),
@@ -40,15 +40,11 @@ export default defineConfig({
         // filePath is an absolute path, so we need to handle it accordingly
         if (!filePath.endsWith(".d.ts")) return;
 
-        // Check if it's in esm or common directory
         const esmMatch = filePath.match(/\/dist\/esm\/(.+)\.d\.ts$/);
-        const commonMatch = filePath.match(/\/dist\/common\/(.+)\.d\.ts$/);
 
-        if (!esmMatch && !commonMatch) return;
+        if (!esmMatch) return;
 
-        const match = esmMatch || commonMatch;
-        const format = esmMatch ? "esm" : "common";
-        const relativePath = match?.[1]; // e.g., "components/form/mt-button/mt-button"
+        const relativePath = esmMatch[1]; // e.g., "components/form/mt-button/mt-button"
 
         // Extract the component file name (e.g., "mt-button" from "components/form/mt-button/mt-button")
         const fileName = relativePath ? path.basename(relativePath) : "";
@@ -59,7 +55,7 @@ export default defineConfig({
           // Transform to flat structure: /absolute/path/dist/esm/MtButton.d.ts
           const distIndex = filePath.indexOf("/dist/");
           const basePath = filePath.substring(0, distIndex);
-          const newFilePath = `${basePath}/dist/${format}/${pascalCaseName}.d.ts`;
+          const newFilePath = `${basePath}/dist/esm/${pascalCaseName}.d.ts`;
           return { filePath: newFilePath };
         }
       },
@@ -90,8 +86,8 @@ export default defineConfig({
         fonts: path.resolve(__dirname, "src/fonts.ts"),
         ...allComponents,
       },
-      formats: ["es", "cjs"],
-      fileName: (format, entryName) => `${format === "es" ? "esm" : "common"}/${entryName}.js`,
+      formats: ["es"],
+      fileName: (_format, entryName) => `esm/${entryName}.js`,
     },
     cssCodeSplit: true,
     rollupOptions: {

--- a/packages/component-library/vite.config.ts
+++ b/packages/component-library/vite.config.ts
@@ -93,6 +93,7 @@ export default defineConfig({
     rollupOptions: {
       external: external,
       output: {
+        chunkFileNames: "[name]-[hash].js",
         globals: {
           vue: "Vue",
         },


### PR DESCRIPTION
## What?
Removes the CommonJS version of the component library. The package now ships in the modern ESM format only. Solves #1299.

## Why?
The CommonJS files were broken and always had been — any project loading the library that way crashed immediately, so nobody can be using it. Keeping it only doubled build time and package size for output that never worked.

## How?
The build now produces only the ESM format, and the package no longer advertises a `require` entry. A changeset (minor) is included.

## Testing?
Did a clean rebuild and confirmed the old format is gone, all entry points and type files are present, and the package shrank from 56 MB to 12 MB. All eight size-limit budget checks still pass.

## Anything Else?
The changeset is a **minor**, not a major. Dropping a format would normally be a breaking change, but this one never worked in the first place — there's no consumer who could have been depending on it, so nothing that works today stops working. Treating it as a fix rather than a break keeps the version history honest about what actually changed for users.

