### PR TITLE
fix(component-library): shrink mt-floating-ui inside the reference's scroll panes

### DIFF
--- a/.changeset/hungry-panthers-hide.md
+++ b/.changeset/hungry-panthers-hide.md
@@ -2,4 +2,4 @@
 "@shopware-ag/meteor-component-library": patch
 ---
 
-mt-floating-ui: hide the floating content while its reference element is fully scrolled out of view, instead of letting it float over unrelated UI
+mt-floating-ui: hide the floating content while its reference element is fully scrolled out of view, instead of letting it float over unrelated UI; consumer-supplied `floatingUiOptions.middleware` now extends the default middleware instead of replacing it

--- a/.changeset/hungry-panthers-hide.md
+++ b/.changeset/hungry-panthers-hide.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": patch
+---
+
+mt-floating-ui: hide the floating content while its reference element is fully scrolled out of view, instead of letting it float over unrelated UI; consumer-supplied `floatingUiOptions.middleware` now extends the default middleware instead of replacing it

--- a/.changeset/hungry-panthers-hide.md
+++ b/.changeset/hungry-panthers-hide.md
@@ -2,4 +2,4 @@
 "@shopware-ag/meteor-component-library": patch
 ---
 
-mt-floating-ui: hide the floating content while its reference element is fully scrolled out of view, instead of letting it float over unrelated UI; consumer-supplied `floatingUiOptions.middleware` now extends the default middleware instead of replacing it
+mt-floating-ui: hide the floating content while its reference element is fully scrolled out of view, instead of letting it float over unrelated UI

--- a/.changeset/soft-donkeys-attend.md
+++ b/.changeset/soft-donkeys-attend.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": patch
+---
+
+mt-floating-ui: flip the floating content inside the scrollable ancestors of its reference element, so a dropdown opened low in a modal body or scroll pane no longer covers that container's buttons

--- a/.changeset/soft-donkeys-attend.md
+++ b/.changeset/soft-donkeys-attend.md
@@ -2,4 +2,4 @@
 "@shopware-ag/meteor-component-library": patch
 ---
 
-mt-floating-ui: flip the floating content inside the scrollable ancestors of its reference element, so a dropdown opened low in a modal body or scroll pane no longer covers that container's buttons
+mt-floating-ui: shrink the floating content to the space left in the scrollable ancestors of its reference element, and flip it only when that space is unusable, so a dropdown opened low in a modal body or scroll pane no longer covers that container's buttons

--- a/packages/component-library/src/components/mt-floating-ui/mt-floating-ui-positioning.spec.ts
+++ b/packages/component-library/src/components/mt-floating-ui/mt-floating-ui-positioning.spec.ts
@@ -2,7 +2,14 @@
 // tests mock @floating-ui/dom, while the tests over there need the real one.
 import { mount } from "@vue/test-utils";
 import flushPromises from "flush-promises";
-import type { ComputePositionConfig, ComputePositionReturn, Middleware } from "@floating-ui/dom";
+import type {
+  ComputePositionConfig,
+  ComputePositionReturn,
+  FlipOptions,
+  Middleware,
+} from "@floating-ui/dom";
+
+const flipSpy = vi.hoisted(() => vi.fn());
 
 const computePositionMock = vi.hoisted(() =>
   vi.fn(
@@ -26,6 +33,12 @@ vi.mock("@floating-ui/dom", async (importOriginal) => {
 
   return {
     ...actual,
+    // Records the options while still building the real middleware.
+    flip: (options?: FlipOptions) => {
+      flipSpy(options);
+
+      return actual.flip(options);
+    },
     computePosition: computePositionMock,
     autoUpdate: (
       _reference: unknown,
@@ -65,10 +78,29 @@ function giveTriggerASize(wrapper: ReturnType<typeof createWrapper>) {
   }));
 }
 
-function createWrapper(props: Record<string, unknown> = {}) {
+// Nests the mount point in one ancestor per `overflow-y` value, outermost first.
+function nestMountPointIn(...overflows: string[]) {
+  const ancestors: HTMLElement[] = [];
+
+  const mountPoint = overflows.reduce((parent, overflowY) => {
+    const ancestor = document.createElement("div");
+    ancestor.style.overflowY = overflowY;
+    parent.appendChild(ancestor);
+    ancestors.push(ancestor);
+
+    return ancestor;
+  }, document.body as HTMLElement);
+
+  return { mountPoint, ancestors };
+}
+
+function createWrapper(
+  props: Record<string, unknown> = {},
+  mountPoint: HTMLElement = document.body,
+) {
   const appWrapper = document.createElement("div");
   appWrapper.setAttribute("id", "appWrapper");
-  document.body.appendChild(appWrapper);
+  mountPoint.appendChild(appWrapper);
 
   return mount(MtFloatingUi, {
     attachTo: appWrapper,
@@ -83,8 +115,12 @@ function createWrapper(props: Record<string, unknown> = {}) {
   });
 }
 
-async function openAndGetConfig(props: Record<string, unknown> = {}, measurable = true) {
-  const wrapper = createWrapper(props);
+async function openAndGetConfig(
+  props: Record<string, unknown> = {},
+  measurable = true,
+  mountPoint: HTMLElement = document.body,
+) {
+  const wrapper = createWrapper(props, mountPoint);
 
   if (measurable) {
     giveTriggerASize(wrapper);
@@ -104,9 +140,16 @@ function middlewareNames(config: ComputePositionConfig): string[] {
   return (config.middleware ?? []).filter(Boolean).map((m) => (m as Middleware).name);
 }
 
+function lastFlipOptions(): FlipOptions {
+  expect(flipSpy).toHaveBeenCalled();
+
+  return flipSpy.mock.calls.at(-1)![0] as FlipOptions;
+}
+
 describe("mt-floating-ui positioning config", () => {
   beforeEach(() => {
     computePositionMock.mockClear();
+    flipSpy.mockClear();
     document.body.innerHTML = "";
   });
 
@@ -141,6 +184,38 @@ describe("mt-floating-ui positioning config", () => {
     });
 
     expect(config.placement).toBe("top-end");
+
+    wrapper.unmount();
+  });
+
+  it("bounds the flip by the scrollable ancestors of the reference", async () => {
+    const { mountPoint, ancestors } = nestMountPointIn("auto");
+    const [scrollPane] = ancestors;
+
+    const { wrapper } = await openAndGetConfig({}, true, mountPoint);
+
+    expect(lastFlipOptions().boundary).toStrictEqual([scrollPane]);
+    expect(lastFlipOptions().fallbackStrategy).toBe("bestFit");
+
+    wrapper.unmount();
+  });
+
+  it("keeps overflow: hidden ancestors out of the flip boundary", async () => {
+    const { mountPoint, ancestors } = nestMountPointIn("auto", "hidden");
+    const [scrollPane, clippingBox] = ancestors;
+
+    const { wrapper } = await openAndGetConfig({}, true, mountPoint);
+
+    expect(lastFlipOptions().boundary).toContain(scrollPane);
+    expect(lastFlipOptions().boundary).not.toContain(clippingBox);
+
+    wrapper.unmount();
+  });
+
+  it("falls back to the clipping ancestors without a scrollable ancestor", async () => {
+    const { wrapper } = await openAndGetConfig();
+
+    expect(lastFlipOptions().boundary).toBe("clippingAncestors");
 
     wrapper.unmount();
   });

--- a/packages/component-library/src/components/mt-floating-ui/mt-floating-ui-positioning.spec.ts
+++ b/packages/component-library/src/components/mt-floating-ui/mt-floating-ui-positioning.spec.ts
@@ -1,3 +1,5 @@
+// Separate from mt-floating-ui.spec.ts because vi.mock is file-wide: these
+// tests mock @floating-ui/dom, while the tests over there need the real one.
 import { mount } from "@vue/test-utils";
 import flushPromises from "flush-promises";
 import type { ComputePositionConfig, ComputePositionReturn, Middleware } from "@floating-ui/dom";

--- a/packages/component-library/src/components/mt-floating-ui/mt-floating-ui-positioning.spec.ts
+++ b/packages/component-library/src/components/mt-floating-ui/mt-floating-ui-positioning.spec.ts
@@ -290,6 +290,21 @@ describe("mt-floating-ui positioning config", () => {
     wrapper.unmount();
   });
 
+  it("takes each edge of the boundary from the tightest scrollable ancestor", async () => {
+    const { mountPoint, ancestors } = nestMountPointIn("auto", "auto");
+    const [outerPane, innerPane] = ancestors;
+    givePaneVerticalBounds(outerPane, 150, 400);
+    givePaneVerticalBounds(innerPane, 100, 350);
+
+    const { wrapper } = await openAndGetConfig({}, true, mountPoint);
+
+    // Neither pane alone spans 150…350: the outer cuts the top, the inner the bottom.
+    expect(lastSizeOptions().boundary).toMatchObject({ y: 150, height: 200 });
+    expect(lastFlipOptions().boundary).toMatchObject({ y: 150, height: 200 });
+
+    wrapper.unmount();
+  });
+
   it("falls back to the clipping ancestors without a scrollable ancestor", async () => {
     const { wrapper } = await openAndGetConfig();
 

--- a/packages/component-library/src/components/mt-floating-ui/mt-floating-ui-positioning.spec.ts
+++ b/packages/component-library/src/components/mt-floating-ui/mt-floating-ui-positioning.spec.ts
@@ -93,23 +93,6 @@ describe("mt-floating-ui positioning config", () => {
     wrapper.unmount();
   });
 
-  it("keeps the default middleware when the consumer supplies its own", async () => {
-    const consumerMiddleware: Middleware = {
-      name: "consumerMiddleware",
-      fn: () => ({}),
-    };
-
-    const { wrapper, config } = await openAndGetConfig({
-      floatingUiOptions: { middleware: [consumerMiddleware] },
-    });
-
-    const names = middlewareNames(config);
-    expect(names).toContain("consumerMiddleware");
-    expect(names).toEqual(expect.arrayContaining(["offset", "flip", "size", "hide"]));
-
-    wrapper.unmount();
-  });
-
   it("still applies consumer placement overrides", async () => {
     const { wrapper, config } = await openAndGetConfig({
       floatingUiOptions: { placement: "top-end" },

--- a/packages/component-library/src/components/mt-floating-ui/mt-floating-ui-positioning.spec.ts
+++ b/packages/component-library/src/components/mt-floating-ui/mt-floating-ui-positioning.spec.ts
@@ -1,0 +1,156 @@
+import { mount } from "@vue/test-utils";
+import flushPromises from "flush-promises";
+import type { ComputePositionConfig, ComputePositionReturn, Middleware } from "@floating-ui/dom";
+
+const computePositionMock = vi.hoisted(() =>
+  vi.fn(
+    (
+      _reference: unknown,
+      _floating: unknown,
+      _config?: Partial<ComputePositionConfig>,
+    ): Promise<Partial<ComputePositionReturn>> =>
+      Promise.resolve({
+        x: 0,
+        y: 0,
+        placement: "bottom-start",
+        strategy: "fixed",
+        middlewareData: {},
+      }),
+  ),
+);
+
+vi.mock("@floating-ui/dom", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@floating-ui/dom")>();
+
+  return {
+    ...actual,
+    computePosition: computePositionMock,
+    autoUpdate: (
+      _reference: unknown,
+      _floating: unknown,
+      update: () => void,
+      _options: unknown,
+    ) => {
+      update();
+      return () => {};
+    },
+  };
+});
+
+import MtFloatingUi from "./mt-floating-ui.vue";
+
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+function createWrapper(props: Record<string, unknown> = {}) {
+  const appWrapper = document.createElement("div");
+  appWrapper.setAttribute("id", "appWrapper");
+  document.body.appendChild(appWrapper);
+
+  return mount(MtFloatingUi, {
+    attachTo: appWrapper,
+    slots: {
+      trigger: `<div id="triggerSlotContent">Trigger</div>`,
+      default: `<div id="defaultSlotContent">Content</div>`,
+    },
+    props: {
+      isOpened: false,
+      ...props,
+    },
+  });
+}
+
+async function openAndGetConfig(props: Record<string, unknown> = {}) {
+  const wrapper = createWrapper(props);
+  await wrapper.setProps({ isOpened: true });
+  await flushPromises();
+
+  expect(computePositionMock).toHaveBeenCalled();
+  const config = computePositionMock.mock.calls.at(-1)![2] as ComputePositionConfig;
+  expect(config).toBeDefined();
+
+  return { wrapper, config };
+}
+
+function middlewareNames(config: ComputePositionConfig): string[] {
+  return (config.middleware ?? []).filter(Boolean).map((m) => (m as Middleware).name);
+}
+
+describe("mt-floating-ui positioning config", () => {
+  beforeEach(() => {
+    computePositionMock.mockClear();
+    document.body.innerHTML = "";
+  });
+
+  it("includes the hide middleware so the content vanishes with its reference", async () => {
+    const { wrapper, config } = await openAndGetConfig();
+
+    expect(middlewareNames(config)).toContain("hide");
+
+    wrapper.unmount();
+  });
+
+  it("keeps the default middleware when the consumer supplies its own", async () => {
+    const consumerMiddleware: Middleware = {
+      name: "consumerMiddleware",
+      fn: () => ({}),
+    };
+
+    const { wrapper, config } = await openAndGetConfig({
+      floatingUiOptions: { middleware: [consumerMiddleware] },
+    });
+
+    const names = middlewareNames(config);
+    expect(names).toContain("consumerMiddleware");
+    expect(names).toEqual(expect.arrayContaining(["offset", "flip", "size", "hide"]));
+
+    wrapper.unmount();
+  });
+
+  it("still applies consumer placement overrides", async () => {
+    const { wrapper, config } = await openAndGetConfig({
+      floatingUiOptions: { placement: "top-end" },
+    });
+
+    expect(config.placement).toBe("top-end");
+
+    wrapper.unmount();
+  });
+
+  it("hides the content when the reference is fully clipped", async () => {
+    computePositionMock.mockResolvedValue({
+      x: 10,
+      y: 20,
+      placement: "bottom-start",
+      strategy: "fixed",
+      middlewareData: { hide: { referenceHidden: true } },
+    });
+
+    const { wrapper } = await openAndGetConfig();
+
+    const content = document.querySelector(".mt-floating-ui__content") as HTMLElement;
+    expect(content.style.visibility).toBe("hidden");
+
+    wrapper.unmount();
+  });
+
+  it("shows the content again when the reference is visible", async () => {
+    computePositionMock.mockResolvedValue({
+      x: 10,
+      y: 20,
+      placement: "bottom-start",
+      strategy: "fixed",
+      middlewareData: { hide: { referenceHidden: false } },
+    });
+
+    const { wrapper } = await openAndGetConfig();
+
+    const content = document.querySelector(".mt-floating-ui__content") as HTMLElement;
+    expect(content.style.visibility).toBe("visible");
+
+    wrapper.unmount();
+  });
+});

--- a/packages/component-library/src/components/mt-floating-ui/mt-floating-ui-positioning.spec.ts
+++ b/packages/component-library/src/components/mt-floating-ui/mt-floating-ui-positioning.spec.ts
@@ -85,6 +85,21 @@ function giveTriggerASize(wrapper: ReturnType<typeof createWrapper>) {
   }));
 }
 
+// The boundary is built from the panes' own rects, which jsdom leaves at 0×0.
+function givePaneVerticalBounds(pane: HTMLElement, top: number, bottom: number) {
+  pane.getBoundingClientRect = vi.fn(() => ({
+    width: 200,
+    height: bottom - top,
+    top,
+    left: 50,
+    bottom,
+    right: 250,
+    x: 50,
+    y: top,
+    toJSON: vi.fn(),
+  }));
+}
+
 // Nests the mount point in one ancestor per `overflow-y` value, outermost first.
 function nestMountPointIn(...overflows: string[]) {
   const ancestors: HTMLElement[] = [];
@@ -234,14 +249,28 @@ describe("mt-floating-ui positioning config", () => {
     wrapper.unmount();
   });
 
-  it("bounds sizing and flipping by the scrollable ancestors of the reference", async () => {
+  it("bounds sizing and flipping by the vertical space of the scrollable ancestors", async () => {
     const { mountPoint, ancestors } = nestMountPointIn("auto");
-    const [scrollPane] = ancestors;
+    givePaneVerticalBounds(ancestors[0], 100, 400);
 
     const { wrapper } = await openAndGetConfig({}, true, mountPoint);
 
-    expect(lastSizeOptions().boundary).toStrictEqual([scrollPane]);
-    expect(lastFlipOptions().boundary).toStrictEqual([scrollPane]);
+    expect(lastSizeOptions().boundary).toMatchObject({ y: 100, height: 300 });
+    expect(lastFlipOptions().boundary).toMatchObject({ y: 100, height: 300 });
+
+    wrapper.unmount();
+  });
+
+  it("leaves the width of the boundary to the viewport", async () => {
+    const { mountPoint, ancestors } = nestMountPointIn("auto");
+    givePaneVerticalBounds(ancestors[0], 100, 400);
+
+    const { wrapper } = await openAndGetConfig({}, true, mountPoint);
+
+    // Narrowing the boundary onto the pane would make the content change
+    // alignment at the pane's edge instead of at the edge of the screen.
+    expect(lastSizeOptions().boundary).toMatchObject({ x: 0, width: window.innerWidth });
+    expect(lastFlipOptions().boundary).toMatchObject({ x: 0, width: window.innerWidth });
 
     wrapper.unmount();
   });
@@ -249,12 +278,14 @@ describe("mt-floating-ui positioning config", () => {
   it("keeps overflow: hidden ancestors out of the boundary", async () => {
     const { mountPoint, ancestors } = nestMountPointIn("auto", "hidden");
     const [scrollPane, clippingBox] = ancestors;
+    givePaneVerticalBounds(scrollPane, 100, 400);
+    givePaneVerticalBounds(clippingBox, 150, 350);
 
     const { wrapper } = await openAndGetConfig({}, true, mountPoint);
 
-    expect(lastSizeOptions().boundary).toStrictEqual([scrollPane]);
-    expect(lastFlipOptions().boundary).toStrictEqual([scrollPane]);
-    expect(lastFlipOptions().boundary).not.toContain(clippingBox);
+    // Counting the clipping box would have tightened this to 150…350.
+    expect(lastSizeOptions().boundary).toMatchObject({ y: 100, height: 300 });
+    expect(lastFlipOptions().boundary).toMatchObject({ y: 100, height: 300 });
 
     wrapper.unmount();
   });

--- a/packages/component-library/src/components/mt-floating-ui/mt-floating-ui-positioning.spec.ts
+++ b/packages/component-library/src/components/mt-floating-ui/mt-floating-ui-positioning.spec.ts
@@ -118,6 +118,23 @@ describe("mt-floating-ui positioning config", () => {
     wrapper.unmount();
   });
 
+  it("keeps the default middleware when the consumer supplies its own", async () => {
+    const consumerMiddleware: Middleware = {
+      name: "consumerMiddleware",
+      fn: () => ({}),
+    };
+
+    const { wrapper, config } = await openAndGetConfig({
+      floatingUiOptions: { middleware: [consumerMiddleware] },
+    });
+
+    const names = middlewareNames(config);
+    expect(names).toContain("consumerMiddleware");
+    expect(names).toEqual(expect.arrayContaining(["offset", "flip", "size", "hide"]));
+
+    wrapper.unmount();
+  });
+
   it("still applies consumer placement overrides", async () => {
     const { wrapper, config } = await openAndGetConfig({
       floatingUiOptions: { placement: "top-end" },

--- a/packages/component-library/src/components/mt-floating-ui/mt-floating-ui-positioning.spec.ts
+++ b/packages/component-library/src/components/mt-floating-ui/mt-floating-ui-positioning.spec.ts
@@ -7,9 +7,11 @@ import type {
   ComputePositionReturn,
   FlipOptions,
   Middleware,
+  SizeOptions,
 } from "@floating-ui/dom";
 
 const flipSpy = vi.hoisted(() => vi.fn());
+const sizeSpy = vi.hoisted(() => vi.fn());
 
 const computePositionMock = vi.hoisted(() =>
   vi.fn(
@@ -38,6 +40,11 @@ vi.mock("@floating-ui/dom", async (importOriginal) => {
       flipSpy(options);
 
       return actual.flip(options);
+    },
+    size: (options?: SizeOptions) => {
+      sizeSpy(options);
+
+      return actual.size(options);
     },
     computePosition: computePositionMock,
     autoUpdate: (
@@ -146,10 +153,39 @@ function lastFlipOptions(): FlipOptions {
   return flipSpy.mock.calls.at(-1)![0] as FlipOptions;
 }
 
+function lastSizeOptions(): SizeOptions {
+  expect(sizeSpy).toHaveBeenCalled();
+
+  return sizeSpy.mock.calls.at(-1)![0] as SizeOptions;
+}
+
+type SizeApplyState = Parameters<NonNullable<SizeOptions["apply"]>>[0];
+
+// `computePosition` is mocked, so `size()` never runs `apply` itself — call the
+// recorded one with the fields the component reads and hand back the element it
+// styled. jsdom lays nothing out, so the content height is stubbed.
+function applySizeWith(availableHeight: number, contentHeight = 0): HTMLElement {
+  const floating = document.createElement("div");
+  Object.defineProperty(floating, "scrollHeight", { get: () => contentHeight });
+
+  lastSizeOptions().apply!({
+    availableHeight,
+    availableWidth: 200,
+    rects: {
+      reference: { width: 200, height: 40, x: 50, y: 100 },
+      floating: { width: 200, height: 400, x: 50, y: 146 },
+    },
+    elements: { reference: document.createElement("div"), floating },
+  } as unknown as SizeApplyState);
+
+  return floating;
+}
+
 describe("mt-floating-ui positioning config", () => {
   beforeEach(() => {
     computePositionMock.mockClear();
     flipSpy.mockClear();
+    sizeSpy.mockClear();
     document.body.innerHTML = "";
   });
 
@@ -188,25 +224,36 @@ describe("mt-floating-ui positioning config", () => {
     wrapper.unmount();
   });
 
-  it("bounds the flip by the scrollable ancestors of the reference", async () => {
+  it("shrinks the content before it flips it", async () => {
+    const { wrapper, config } = await openAndGetConfig();
+
+    const names = middlewareNames(config);
+    expect(names.indexOf("size")).toBeGreaterThan(-1);
+    expect(names.indexOf("size")).toBeLessThan(names.indexOf("flip"));
+
+    wrapper.unmount();
+  });
+
+  it("bounds sizing and flipping by the scrollable ancestors of the reference", async () => {
     const { mountPoint, ancestors } = nestMountPointIn("auto");
     const [scrollPane] = ancestors;
 
     const { wrapper } = await openAndGetConfig({}, true, mountPoint);
 
+    expect(lastSizeOptions().boundary).toStrictEqual([scrollPane]);
     expect(lastFlipOptions().boundary).toStrictEqual([scrollPane]);
-    expect(lastFlipOptions().fallbackStrategy).toBe("bestFit");
 
     wrapper.unmount();
   });
 
-  it("keeps overflow: hidden ancestors out of the flip boundary", async () => {
+  it("keeps overflow: hidden ancestors out of the boundary", async () => {
     const { mountPoint, ancestors } = nestMountPointIn("auto", "hidden");
     const [scrollPane, clippingBox] = ancestors;
 
     const { wrapper } = await openAndGetConfig({}, true, mountPoint);
 
-    expect(lastFlipOptions().boundary).toContain(scrollPane);
+    expect(lastSizeOptions().boundary).toStrictEqual([scrollPane]);
+    expect(lastFlipOptions().boundary).toStrictEqual([scrollPane]);
     expect(lastFlipOptions().boundary).not.toContain(clippingBox);
 
     wrapper.unmount();
@@ -215,7 +262,34 @@ describe("mt-floating-ui positioning config", () => {
   it("falls back to the clipping ancestors without a scrollable ancestor", async () => {
     const { wrapper } = await openAndGetConfig();
 
+    expect(lastSizeOptions().boundary).toBe("clippingAncestors");
     expect(lastFlipOptions().boundary).toBe("clippingAncestors");
+
+    wrapper.unmount();
+  });
+
+  it("caps the content at the space left in the boundary", async () => {
+    const { wrapper } = await openAndGetConfig();
+
+    expect(applySizeWith(420).style.maxHeight).toBe("420px");
+
+    wrapper.unmount();
+  });
+
+  it("never shrinks the content below the minimum height", async () => {
+    const { wrapper } = await openAndGetConfig();
+
+    // Overshooting the boundary on purpose: the leftover overflow is what makes
+    // `flip()` move the content when a side is genuinely too small for it.
+    expect(applySizeWith(12).style.maxHeight).toBe("150px");
+
+    wrapper.unmount();
+  });
+
+  it("caps nothing when the content will not shrink into the space", async () => {
+    const { wrapper } = await openAndGetConfig();
+
+    expect(applySizeWith(200, 400).style.maxHeight).toBe("");
 
     wrapper.unmount();
   });

--- a/packages/component-library/src/components/mt-floating-ui/mt-floating-ui-positioning.spec.ts
+++ b/packages/component-library/src/components/mt-floating-ui/mt-floating-ui-positioning.spec.ts
@@ -47,6 +47,24 @@ global.ResizeObserver = class ResizeObserver {
   disconnect() {}
 };
 
+// jsdom measures every element as 0×0, and a zero-area reference counts as
+// hidden — so give the trigger a size wherever the reference must be measurable.
+function giveTriggerASize(wrapper: ReturnType<typeof createWrapper>) {
+  const trigger = wrapper.find(".mt-floating-ui__trigger").element as HTMLElement;
+
+  trigger.getBoundingClientRect = vi.fn(() => ({
+    width: 200,
+    height: 40,
+    top: 100,
+    left: 50,
+    bottom: 140,
+    right: 250,
+    x: 50,
+    y: 100,
+    toJSON: vi.fn(),
+  }));
+}
+
 function createWrapper(props: Record<string, unknown> = {}) {
   const appWrapper = document.createElement("div");
   appWrapper.setAttribute("id", "appWrapper");
@@ -65,8 +83,13 @@ function createWrapper(props: Record<string, unknown> = {}) {
   });
 }
 
-async function openAndGetConfig(props: Record<string, unknown> = {}) {
+async function openAndGetConfig(props: Record<string, unknown> = {}, measurable = true) {
   const wrapper = createWrapper(props);
+
+  if (measurable) {
+    giveTriggerASize(wrapper);
+  }
+
   await wrapper.setProps({ isOpened: true });
   await flushPromises();
 
@@ -132,6 +155,23 @@ describe("mt-floating-ui positioning config", () => {
     });
 
     const { wrapper } = await openAndGetConfig();
+
+    const content = document.querySelector(".mt-floating-ui__content") as HTMLElement;
+    expect(content.style.visibility).toBe("visible");
+
+    wrapper.unmount();
+  });
+
+  it("keeps the content visible for a reference without a measurable size", async () => {
+    computePositionMock.mockResolvedValue({
+      x: 10,
+      y: 20,
+      placement: "bottom-start",
+      strategy: "fixed",
+      middlewareData: { hide: { referenceHidden: true } },
+    });
+
+    const { wrapper } = await openAndGetConfig({}, false);
 
     const content = document.querySelector(".mt-floating-ui__content") as HTMLElement;
     expect(content.style.visibility).toBe("visible");

--- a/packages/component-library/src/components/mt-floating-ui/mt-floating-ui.vue
+++ b/packages/component-library/src/components/mt-floating-ui/mt-floating-ui.vue
@@ -35,7 +35,7 @@
 
 <script setup lang="ts">
 import { ref, onBeforeUnmount, watch, nextTick, computed } from "vue";
-import type { AutoUpdateOptions, ComputePositionConfig } from "@floating-ui/dom";
+import type { AutoUpdateOptions, ComputePositionConfig, Rect } from "@floating-ui/dom";
 import {
   computePosition,
   autoUpdate,
@@ -107,7 +107,12 @@ const MIN_HEIGHT = 150;
 // bounded by the reference's scroll panes to learn about a dialog body it sits
 // in. Skip `overflow: hidden` ancestors: they are usually field-sized boxes
 // that would collapse the boundary onto the reference, leaving no side that fits.
-const scrollBoundariesOf = (referenceEl: Element): Element[] | "clippingAncestors" => {
+//
+// Only the vertical extent of those panes is a real limit — nothing clips the
+// content sideways. So the boundary keeps the viewport's full width: narrowing
+// it to the pane would move the content to the pane's edge instead of the
+// screen's, pulling a table's settings menu in over its own rows.
+const scrollBoundaryOf = (referenceEl: Element): Rect | "clippingAncestors" => {
   const scrollables = getOverflowAncestors(referenceEl).filter((ancestor): ancestor is Element => {
     if (!(ancestor instanceof Element) || ancestor === document.body) {
       return false;
@@ -118,7 +123,15 @@ const scrollBoundariesOf = (referenceEl: Element): Element[] | "clippingAncestor
     return overflowY === "auto" || overflowY === "scroll";
   });
 
-  return scrollables.length > 0 ? scrollables : "clippingAncestors";
+  if (scrollables.length === 0) {
+    return "clippingAncestors";
+  }
+
+  const rects = scrollables.map((scrollable) => scrollable.getBoundingClientRect());
+  const top = Math.max(...rects.map((rect) => rect.top));
+  const bottom = Math.min(...rects.map((rect) => rect.bottom));
+
+  return { x: 0, y: top, width: window.innerWidth, height: bottom - top };
 };
 
 const createFloatingUi = () => {
@@ -162,7 +175,7 @@ const createFloatingUi = () => {
           // too tall shrink and scroll where it is, instead of jumping over the
           // reference and covering the field it belongs to.
           size({
-            boundary: scrollBoundariesOf(referenceEl),
+            boundary: scrollBoundaryOf(referenceEl),
             apply({ availableHeight, rects, elements }) {
               referenceElementWidth.value = rects.reference.width ?? 0;
               referenceElementHeight.value = rects.reference.height ?? 0;
@@ -178,7 +191,7 @@ const createFloatingUi = () => {
               }
             },
           }),
-          flip({ boundary: scrollBoundariesOf(referenceEl) }),
+          flip({ boundary: scrollBoundaryOf(referenceEl) }),
           ...(consumerMiddleware ?? []),
           hide(),
         ],

--- a/packages/component-library/src/components/mt-floating-ui/mt-floating-ui.vue
+++ b/packages/component-library/src/components/mt-floating-ui/mt-floating-ui.vue
@@ -97,11 +97,16 @@ const contentStyles = computed(() => {
   return styles;
 });
 
+// Smallest content worth keeping on the preferred side: three 45px result rows
+// plus chrome. The floor may overshoot the pane on purpose — that leftover
+// overflow is what still lets `flip()` change sides.
+const MIN_HEIGHT = 150;
+
 // The content is teleported to `<body>` and positioned `fixed`, so its own
-// clipping ancestors are just the viewport — flipping has to be bounded by the
-// reference's scroll panes to learn about a dialog body it sits in. Skip
-// `overflow: hidden` ancestors: they are usually field-sized boxes that would
-// collapse the boundary onto the reference, leaving no side that fits.
+// clipping ancestors are just the viewport — sizing and flipping have to be
+// bounded by the reference's scroll panes to learn about a dialog body it sits
+// in. Skip `overflow: hidden` ancestors: they are usually field-sized boxes
+// that would collapse the boundary onto the reference, leaving no side that fits.
 const scrollBoundariesOf = (referenceEl: Element): Element[] | "clippingAncestors" => {
   const scrollables = getOverflowAncestors(referenceEl).filter((ancestor): ancestor is Element => {
     if (!(ancestor instanceof Element) || ancestor === document.body) {
@@ -153,19 +158,28 @@ const createFloatingUi = () => {
             }
             return [];
           })(),
-          flip({
-            boundary: scrollBoundariesOf(referenceEl),
-            // Keep the least-bad side when no side fits; the default
-            // `initialPlacement` would push the content out of a short scroll pane.
-            fallbackStrategy: "bestFit",
-          }),
-          ...(consumerMiddleware ?? []),
+          // Order matters: `size()` before `flip()` makes content that is merely
+          // too tall shrink and scroll where it is, instead of jumping over the
+          // reference and covering the field it belongs to.
           size({
-            apply({ rects }) {
+            boundary: scrollBoundariesOf(referenceEl),
+            apply({ availableHeight, rects, elements }) {
               referenceElementWidth.value = rects.reference.width ?? 0;
               referenceElementHeight.value = rects.reference.height ?? 0;
+
+              const cap = Math.max(availableHeight, MIN_HEIGHT);
+              elements.floating.style.maxHeight = `${cap}px`;
+
+              // Content with no scrollable region ignores the cap and paints
+              // past it, which would only hide that overflow from `flip()` — a
+              // context menu would sit half off-screen instead of changing sides.
+              if (elements.floating.scrollHeight > Math.ceil(cap)) {
+                elements.floating.style.maxHeight = "";
+              }
             },
           }),
+          flip({ boundary: scrollBoundariesOf(referenceEl) }),
+          ...(consumerMiddleware ?? []),
           hide(),
         ],
       }).then(({ x, y, middlewareData, placement, strategy }) => {
@@ -305,9 +319,13 @@ onBeforeUnmount(() => {
   top: 0;
   left: 0;
   z-index: 1070;
+  // Flex column so the `max-height` from `size()` reaches the slotted content:
+  // a block child with its own `max-height` paints past the capped box.
+  display: flex;
+  flex-direction: column;
 
   &[data-show] {
-    display: block;
+    display: flex;
   }
 
   /***

--- a/packages/component-library/src/components/mt-floating-ui/mt-floating-ui.vue
+++ b/packages/component-library/src/components/mt-floating-ui/mt-floating-ui.vue
@@ -44,6 +44,7 @@ import {
   flip,
   size,
   hide,
+  getOverflowAncestors,
 } from "@floating-ui/dom";
 import { vOnClickOutside } from "@vueuse/components";
 
@@ -96,6 +97,25 @@ const contentStyles = computed(() => {
   return styles;
 });
 
+// The content is teleported to `<body>` and positioned `fixed`, so its own
+// clipping ancestors are just the viewport — flipping has to be bounded by the
+// reference's scroll panes to learn about a dialog body it sits in. Skip
+// `overflow: hidden` ancestors: they are usually field-sized boxes that would
+// collapse the boundary onto the reference, leaving no side that fits.
+const scrollBoundariesOf = (referenceEl: Element): Element[] | "clippingAncestors" => {
+  const scrollables = getOverflowAncestors(referenceEl).filter((ancestor): ancestor is Element => {
+    if (!(ancestor instanceof Element) || ancestor === document.body) {
+      return false;
+    }
+
+    const { overflowY } = getComputedStyle(ancestor);
+
+    return overflowY === "auto" || overflowY === "scroll";
+  });
+
+  return scrollables.length > 0 ? scrollables : "clippingAncestors";
+};
+
 const createFloatingUi = () => {
   const referenceEl = props.anchorElement ?? floatingUiTrigger.value;
 
@@ -133,7 +153,12 @@ const createFloatingUi = () => {
             }
             return [];
           })(),
-          flip(),
+          flip({
+            boundary: scrollBoundariesOf(referenceEl),
+            // Keep the least-bad side when no side fits; the default
+            // `initialPlacement` would push the content out of a short scroll pane.
+            fallbackStrategy: "bestFit",
+          }),
           ...(consumerMiddleware ?? []),
           size({
             apply({ rects }) {

--- a/packages/component-library/src/components/mt-floating-ui/mt-floating-ui.vue
+++ b/packages/component-library/src/components/mt-floating-ui/mt-floating-ui.vue
@@ -161,6 +161,12 @@ const createFloatingUi = () => {
           });
         }
 
+        // A zero-area reference reports as hidden (all its overflow offsets are
+        // 0), so exclude it: anchors may legitimately be size-less markers, and
+        // in jsdom every element measures 0.
+        const referenceRect = referenceEl.getBoundingClientRect();
+        const referenceIsMeasurable = referenceRect.width > 0 && referenceRect.height > 0;
+
         // Set `position` inline (not just via CSS) so it always matches the
         // strategy the coordinates were computed for. Consumer classes are
         // copied onto this teleported element above, and a class carrying
@@ -174,7 +180,8 @@ const createFloatingUi = () => {
           // The content follows its reference on scroll; once the reference is
           // fully scrolled out of its clipping containers the content must not
           // stay visible (it would float over unrelated UI).
-          visibility: middlewareData.hide?.referenceHidden ? "hidden" : "visible",
+          visibility:
+            referenceIsMeasurable && middlewareData.hide?.referenceHidden ? "hidden" : "visible",
         });
 
         // remove all staticSide classes

--- a/packages/component-library/src/components/mt-floating-ui/mt-floating-ui.vue
+++ b/packages/component-library/src/components/mt-floating-ui/mt-floating-ui.vue
@@ -102,16 +102,10 @@ const contentStyles = computed(() => {
 // overflow is what still lets `flip()` change sides.
 const MIN_HEIGHT = 150;
 
-// The content is teleported to `<body>` and positioned `fixed`, so its own
-// clipping ancestors are just the viewport — sizing and flipping have to be
-// bounded by the reference's scroll panes to learn about a dialog body it sits
-// in. Skip `overflow: hidden` ancestors: they are usually field-sized boxes
-// that would collapse the boundary onto the reference, leaving no side that fits.
-//
-// Only the vertical extent of those panes is a real limit — nothing clips the
-// content sideways. So the boundary keeps the viewport's full width: narrowing
-// it to the pane would move the content to the pane's edge instead of the
-// screen's, pulling a table's settings menu in over its own rows.
+// Find the boundary up to where the floating ui should not further/overlay other ui.
+// The actual element is teleported to `<body>` and positioned `fixed`, so it needs
+// to find the boundaries of the referenced element for shrinking and flipping (to a direction that has more space)
+// Skip `overflow: hidden` boxes because the reference element is usually styled that way which would be a false positive
 const scrollBoundaryOf = (referenceEl: Element): Rect | "clippingAncestors" => {
   const scrollables = getOverflowAncestors(referenceEl).filter((ancestor): ancestor is Element => {
     if (!(ancestor instanceof Element) || ancestor === document.body) {

--- a/packages/component-library/src/components/mt-floating-ui/mt-floating-ui.vue
+++ b/packages/component-library/src/components/mt-floating-ui/mt-floating-ui.vue
@@ -109,6 +109,10 @@ const createFloatingUi = () => {
   ) as string[];
   floatingUiContent.value.classList.add(...givenClasses);
 
+  // `middleware` is pulled out so consumer-supplied middleware extends the
+  // defaults instead of replacing them via the config spread below.
+  const { middleware: consumerMiddleware, ...consumerOptions } = props.floatingUiOptions ?? {};
+
   cleanup = autoUpdate(
     referenceEl,
     floatingUiContent.value as HTMLElement,
@@ -120,6 +124,7 @@ const createFloatingUi = () => {
       computePosition(referenceEl, floatingUiContent.value as HTMLElement, {
         placement: "bottom-start",
         strategy: "fixed",
+        ...consumerOptions,
         middleware: [
           floatingUiOffset(props.offset ?? 6),
           ...(() => {
@@ -129,7 +134,7 @@ const createFloatingUi = () => {
             return [];
           })(),
           flip(),
-          ...(props.floatingUiOptions?.middleware ?? []),
+          ...(consumerMiddleware ?? []),
           size({
             apply({ rects }) {
               referenceElementWidth.value = rects.reference.width ?? 0;
@@ -138,7 +143,6 @@ const createFloatingUi = () => {
           }),
           hide(),
         ],
-        ...props.floatingUiOptions,
       }).then(({ x, y, middlewareData, placement, strategy }) => {
         if (!floatingUiContent.value) {
           return;

--- a/packages/component-library/src/components/mt-floating-ui/mt-floating-ui.vue
+++ b/packages/component-library/src/components/mt-floating-ui/mt-floating-ui.vue
@@ -109,10 +109,6 @@ const createFloatingUi = () => {
   ) as string[];
   floatingUiContent.value.classList.add(...givenClasses);
 
-  // `middleware` is pulled out so consumer-supplied middleware extends the
-  // defaults instead of replacing them via the config spread below.
-  const { middleware: consumerMiddleware, ...consumerOptions } = props.floatingUiOptions ?? {};
-
   cleanup = autoUpdate(
     referenceEl,
     floatingUiContent.value as HTMLElement,
@@ -124,7 +120,6 @@ const createFloatingUi = () => {
       computePosition(referenceEl, floatingUiContent.value as HTMLElement, {
         placement: "bottom-start",
         strategy: "fixed",
-        ...consumerOptions,
         middleware: [
           floatingUiOffset(props.offset ?? 6),
           ...(() => {
@@ -134,7 +129,7 @@ const createFloatingUi = () => {
             return [];
           })(),
           flip(),
-          ...(consumerMiddleware ?? []),
+          ...(props.floatingUiOptions?.middleware ?? []),
           size({
             apply({ rects }) {
               referenceElementWidth.value = rects.reference.width ?? 0;
@@ -143,6 +138,7 @@ const createFloatingUi = () => {
           }),
           hide(),
         ],
+        ...props.floatingUiOptions,
       }).then(({ x, y, middlewareData, placement, strategy }) => {
         if (!floatingUiContent.value) {
           return;

--- a/packages/component-library/src/components/mt-floating-ui/mt-floating-ui.vue
+++ b/packages/component-library/src/components/mt-floating-ui/mt-floating-ui.vue
@@ -43,6 +43,7 @@ import {
   arrow,
   flip,
   size,
+  hide,
 } from "@floating-ui/dom";
 import { vOnClickOutside } from "@vueuse/components";
 
@@ -108,6 +109,10 @@ const createFloatingUi = () => {
   ) as string[];
   floatingUiContent.value.classList.add(...givenClasses);
 
+  // `middleware` is pulled out so consumer-supplied middleware extends the
+  // defaults instead of replacing them via the config spread below.
+  const { middleware: consumerMiddleware, ...consumerOptions } = props.floatingUiOptions ?? {};
+
   cleanup = autoUpdate(
     referenceEl,
     floatingUiContent.value as HTMLElement,
@@ -119,6 +124,7 @@ const createFloatingUi = () => {
       computePosition(referenceEl, floatingUiContent.value as HTMLElement, {
         placement: "bottom-start",
         strategy: "fixed",
+        ...consumerOptions,
         middleware: [
           floatingUiOffset(props.offset ?? 6),
           ...(() => {
@@ -128,15 +134,15 @@ const createFloatingUi = () => {
             return [];
           })(),
           flip(),
-          ...(props.floatingUiOptions?.middleware ?? []),
+          ...(consumerMiddleware ?? []),
           size({
             apply({ rects }) {
               referenceElementWidth.value = rects.reference.width ?? 0;
               referenceElementHeight.value = rects.reference.height ?? 0;
             },
           }),
+          hide(),
         ],
-        ...props.floatingUiOptions,
       }).then(({ x, y, middlewareData, placement, strategy }) => {
         if (!floatingUiContent.value) {
           return;
@@ -169,6 +175,10 @@ const createFloatingUi = () => {
           position: strategy,
           left: `${x}px`,
           top: `${y}px`,
+          // The content follows its reference on scroll; once the reference is
+          // fully scrolled out of its clipping containers the content must not
+          // stay visible (it would float over unrelated UI).
+          visibility: middlewareData.hide?.referenceHidden ? "hidden" : "visible",
         });
 
         // remove all staticSide classes


### PR DESCRIPTION
## What?

`mt-floating-ui` now shrinks its floating content to the space left in the scroll pane its reference element belongs to, and flips it to the other side only when that space is unusable.

## Why?

The acceptance tests fail because of the issue: https://github.com/shopware/shopware/actions/runs/33373554496/job/99430820745

A dropdown opened low inside a dialog can extend past the dialog's bottom edge and cover its buttons.

Example: In the Shopware admin's Flow Builder "Add tag" modal the open tag list hides the whole footer, so clicking where "Add action" sits toggles a tag instead of confirming the dialog.

## How?

- Adds size() and flip() middlewares.
- It calculates the parent overflow boundaries of the referenced element
- min height is 150px

## Testing?

- added tests to `mt-floating-ui-positioning.spec.ts`
- AI verified manually in a Shopware admin build across page selects, modals, data-grid context menus, the admin menu flyout and the colorpicker.

## Screenshots (optional)

**Fixed.** Flow Builder "Send email", Template list opened low in a scrolled modal body.

*Before* — the list keeps its full 250px, so the footer is hidden and "Cancel" and "Add action" cannot be clicked.

![Template list overshooting the modal body and covering the modal footer](https://raw.githubusercontent.com/shopware/meteor/screenshots/mt-floating-ui-hide/screenshots/sendemail-before.png)

*After* — capped to the 164px left in the modal body and scrolling there, footer visible. That is three rows; with two-line entries the shrunk list does get small.

![Template list shrunk to the modal body, footer with Cancel and Add action visible](https://raw.githubusercontent.com/shopware/meteor/screenshots/mt-floating-ui-hide/screenshots/sendemail-after.png)

**Improved, not solved.** Flow Builder "Add tag" — 47px are left for the list below the Tags field, under the 150px floor.

*Before* — the list covers the whole footer.

![Tag list extending past the modal and covering its footer](https://raw.githubusercontent.com/shopware/meteor/screenshots/mt-floating-ui-hide/screenshots/addtag-before.png)

*After* — the footer is reachable again, but the list changes sides and covers the Entity field above.

![Tag list flipped above the Tags field, covering the Entity field, footer visible](https://raw.githubusercontent.com/shopware/meteor/screenshots/mt-floating-ui-hide/screenshots/addtag-after.png)

**Unchanged where there is room.** Settings › Products, "Default Sales Channel": 476px below the field for a 153px list. Both builds render this identically, down to the byte, so one shot stands for both.

![Sales channel list opening below its field on a settings page with room to spare](https://raw.githubusercontent.com/shopware/meteor/screenshots/mt-floating-ui-hide/screenshots/pageselect-unchanged.png)

> The images are hosted on the disposable `screenshots/mt-floating-ui-hide` branch. Please delete that branch once these PRs are closed.

## Anything Else?

**Stacked on #1349** (`fix/floating-ui-hide-and-boundary`) and targeted at that branch, so the diff here shows only the sizing change. It should merge after #1349.

**Known limitation:** the 150px floor can still exceed the room a short modal leaves below the field — see the "Add tag" pair above.

Context menus and other popovers whose content does not scroll are never capped and keep exactly their current behaviour.

This is the acceptance failure behind shopware/shopware#18182.


