### PR TITLE
fix: Fix autofill in dark mode

### DIFF
--- a/.changeset/fix-autofill-dark-mode.md
+++ b/.changeset/fix-autofill-dark-mode.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": patch
+---
+
+Fix autofilled input fields rendering with a white background in dark mode: the `:-webkit-autofill` override hardcoded `#fff`, so Chrome's autofill and autofill-preview states painted the field white with unreadable light text. It now uses the themed background and text tokens, and matches the critical background when the field has an error

--- a/packages/component-library/src/components/_internal/mt-base-field/mt-base-field.vue
+++ b/packages/component-library/src/components/_internal/mt-base-field/mt-base-field.vue
@@ -289,7 +289,9 @@ export default defineComponent({
 }
 
 .mt-field input:-webkit-autofill {
-  -webkit-box-shadow: 0 0 0 1000px #fff inset;
+  -webkit-box-shadow: 0 0 0 1000px var(--color-background-primary-default) inset;
+  -webkit-text-fill-color: var(--color-text-primary-default);
+  caret-color: var(--color-text-primary-default);
 }
 
 .mt-field .mt-block-field__block {
@@ -358,6 +360,10 @@ export default defineComponent({
 
 .mt-field.has--error.mt-field input {
   background-color: var(--color-background-critical-default);
+}
+
+.mt-field.has--error input:-webkit-autofill {
+  -webkit-box-shadow: 0 0 0 1000px var(--color-background-critical-default) inset;
 }
 
 .mt-field.has--error .mt-field__addition {


### PR DESCRIPTION
## What?
Step 1: Go to login page, focus on username field
Step 2: Hover on password manager list

<img width="766" height="394" alt="Screenshot 2026-08-31 at 13 56 03" src="https://github.com/user-attachments/assets/32442ffb-2bae-462b-af4b-42cecc70e443" />

## Why?
`:-webkit-autofill` override hardcoded `#fff`, so Chrome's autofill and autofill-preview states painted the field white with unreadable light text

## How?
Autofilled input should have correct background and text color based on current theme

<img width="951" height="636" alt="Screenshot 2026-09-01 at 15 59 17" src="https://github.com/user-attachments/assets/a3888c70-b0c9-4a59-9698-986fd17e32c8" />

## Testing?

## Screenshots (optional)

## Anything Else?
