### PR TITLE
docs: fix missing component api tables

### DIFF
--- a/apps/docs/content/2.components/action-menu.md
+++ b/apps/docs/content/2.components/action-menu.md
@@ -71,7 +71,17 @@ These parts are exported together so the pattern can be composed in one place.
 
 ## API reference
 
+### MtActionMenu
+
 :component-api
+
+### MtActionMenuItem
+
+:component-api{name="MtActionMenuItem"}
+
+### MtActionMenuGroup
+
+:component-api{name="MtActionMenuGroup"}
 
 ## Best practices
 

--- a/apps/docs/content/2.components/action-menu.md
+++ b/apps/docs/content/2.components/action-menu.md
@@ -71,17 +71,84 @@ These parts are exported together so the pattern can be composed in one place.
 
 ## API reference
 
+The `mt-action-menu-*` components wrap [Reka UI's Dropdown Menu](https://reka-ui.com/docs/components/dropdown-menu) primitives and forward any additional attributes to them. The tables below therefore list the props each wrapper declares itself, followed by the forwarded Reka UI props and events you can also use. The `mt-dropdown-menu-*` parts are direct re-exports of the Reka UI primitives.
+
 ### MtActionMenu
 
 :component-api
+
+#### Forwarded Reka UI props
+
+`mt-action-menu` renders Reka UI's `DropdownMenuContent` (`DropdownMenuSubContent` when `is-sub-menu` is set) and forwards all additional attributes to it. The most useful forwarded props:
+
+| Prop                       | Type                                          | Default                          |
+| -------------------------- | --------------------------------------------- | -------------------------------- |
+| `side`                     | `"top" \| "right" \| "bottom" \| "left"`      | `"bottom"`                       |
+| `side-offset`              | `number`                                      | `8` (set by `mt-action-menu`)    |
+| `align`                    | `"start" \| "center" \| "end"`                | `"start"` (set by `mt-action-menu`) |
+| `align-offset`             | `number`                                      | `0` (`-5` for submenus)          |
+| `avoid-collisions`         | `boolean`                                     | `true`                           |
+| `collision-padding`        | `number \| object`                            | `0`                              |
+| `collision-boundary`       | `Element \| Element[] \| null`                | `[]`                             |
+| `sticky`                   | `"partial" \| "always"`                       | `"partial"`                      |
+| `hide-when-detached`       | `boolean`                                     | `false`                          |
+| `position-strategy`        | `"absolute" \| "fixed"`                       | `"fixed"`                        |
+| `update-position-strategy` | `"optimized" \| "always"`                     | `"optimized"`                    |
+| `prioritize-position`      | `boolean`                                     | `false`                          |
+| `reference`                | `Element \| VirtualElement`                   | —                                |
+| `loop`                     | `boolean`                                     | `false`                          |
+| `force-mount`              | `boolean`                                     | —                                |
+
+Forwarded events: `@escape-key-down`, `@pointer-down-outside`, `@focus-outside`, `@interact-outside`, and `@close-auto-focus`.
+
+Attributes you pass take precedence over the defaults `mt-action-menu` sets, so `side-offset` and `align` can be overridden. Exception: submenus (`is-sub-menu`) position themselves automatically, so `side` and `align` have no effect there.
 
 ### MtActionMenuItem
 
 :component-api{name="MtActionMenuItem"}
 
+#### Forwarded Reka UI props
+
+`mt-action-menu-item` renders Reka UI's `DropdownMenuItem` (`DropdownMenuSubTrigger` when `is-sub-trigger` is set) and forwards all additional attributes to it:
+
+| Prop / Event | Type                    | Description                                                                                                                       |
+| ------------ | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `@select`    | `(event: Event) => void` | Fires when the action is selected via click or keyboard. Call `event.preventDefault()` to keep the menu open after the selection. |
+| `text-value` | `string`                | Overrides the text used for typeahead matching when the visible label is not plain text.                                           |
+| `as-child`   | `boolean`               | Merges the item behavior into its child element instead of rendering its own element.                                              |
+
+`@select` is not emitted for `is-sub-trigger` items, because sub-triggers open a submenu instead of performing an action.
+
 ### MtActionMenuGroup
 
 :component-api{name="MtActionMenuGroup"}
+
+`mt-action-menu-group` renders Reka UI's `DropdownMenuGroup` and additionally accepts its `as` and `as-child` props.
+
+### MtDropdownMenuRoot
+
+Re-export of Reka UI's [`DropdownMenuRoot`](https://reka-ui.com/docs/components/dropdown-menu#root). It manages the open state for the whole menu.
+
+| Prop           | Type                  | Default | Description                                                                                                       |
+| -------------- | --------------------- | ------- | ----------------------------------------------------------------------------------------------------------------- |
+| `open`         | `boolean`             | —       | Controlled open state, usable as `v-model:open`.                                                                   |
+| `default-open` | `boolean`             | `false` | Initial open state when uncontrolled.                                                                              |
+| `modal`        | `boolean`             | `true`  | When `true`, interaction with elements outside the menu is blocked and page scrolling is locked while it is open.   |
+| `dir`          | `"ltr" \| "rtl"`      | —       | Reading direction.                                                                                                  |
+
+Emits `update:open` and exposes the current state through the default slot binding `{ open }`.
+
+### MtDropdownMenuTrigger
+
+Re-export of Reka UI's [`DropdownMenuTrigger`](https://reka-ui.com/docs/components/dropdown-menu#trigger). Accepts `as`, `as-child`, and `disabled`. Use `as-child` to turn an existing element, such as a [**Button**](/components/button), into the trigger.
+
+### MtDropdownMenuPortal
+
+Re-export of Reka UI's [`DropdownMenuPortal`](https://reka-ui.com/docs/components/dropdown-menu#portal). Accepts `to` (teleport target, defaults to `body`), `disabled`, `defer`, and `force-mount`.
+
+### MtDropdownMenuSub
+
+Re-export of Reka UI's [`DropdownMenuSub`](https://reka-ui.com/docs/components/dropdown-menu#sub). Wraps a nested submenu and accepts `open` (`v-model:open`) and `default-open`, emits `update:open`, and exposes `{ open }` through its default slot.
 
 ## Best practices
 

--- a/apps/docs/content/2.components/collapsible.md
+++ b/apps/docs/content/2.components/collapsible.md
@@ -39,6 +39,8 @@ import {
 
 :component-api
 
+`mt-collapsible` wraps [Reka UI's `CollapsibleRoot`](https://reka-ui.com/docs/components/collapsible) and declares its full API, so the table above is complete. `keep-mounted` maps to Reka's `unmount-on-hide` (inverted). Avoid passing `unmount-on-hide` directly: it falls through to the primitive and silently overrides `keep-mounted`.
+
 ### MtCollapsibleTrigger
 
 :component-api{name="MtCollapsibleTrigger"}

--- a/apps/docs/content/2.components/collapsible.md
+++ b/apps/docs/content/2.components/collapsible.md
@@ -35,7 +35,17 @@ import {
 
 ## API reference
 
+### MtCollapsible
+
 :component-api
+
+### MtCollapsibleTrigger
+
+:component-api{name="MtCollapsibleTrigger"}
+
+### MtCollapsibleContent
+
+:component-api{name="MtCollapsibleContent"}
 
 ## Behavior
 

--- a/apps/docs/content/2.components/data-table.md
+++ b/apps/docs/content/2.components/data-table.md
@@ -87,20 +87,77 @@ A minimal table needs a `dataSource`, a `columns` definition, and handlers for t
 
 ## Column configuration
 
-Each column is described by a configuration object that controls how the cell is rendered and how it behaves:
+Each column is described by a configuration object that controls how the cell is rendered and how it behaves. All columns share a common base:
 
 ```typescript
-interface ColumnDefinition {
+interface BaseColumnDefinition {
   label: string; // Column header label
   property: string; // Property path in the data source object
-  renderer?: string; // How to render the cell ('text' | 'number' | 'price')
   position: number; // Column order (use increments of 100)
   sortable?: boolean; // Enable or disable sorting (default: true)
   width?: number; // Fixed column width
   allowResize?: boolean; // Allow column resizing
+  cellWrap?: "nowrap" | "normal"; // How cell content wraps
   visible?: boolean; // Show or hide the column
 }
 ```
+
+The required `renderer` selects one of four cell types, each with its own additional options:
+
+```typescript
+interface TextColumnDefinition extends BaseColumnDefinition {
+  renderer: "text";
+  clickable?: boolean; // Clicking the cell emits `open-details`
+  previewImage?: string; // Property path to a thumbnail shown before the text
+}
+
+interface NumberColumnDefinition extends BaseColumnDefinition {
+  renderer: "number";
+  clickable?: boolean;
+}
+
+interface PriceColumnDefinition extends BaseColumnDefinition {
+  renderer: "price";
+  rendererOptions: {
+    // required for price columns
+    currencyId: string;
+    currencyISOCode: string;
+    source: "gross" | "net";
+  };
+  clickable?: boolean;
+}
+
+interface BadgeColumnDefinition extends BaseColumnDefinition {
+  renderer: "badge";
+  rendererOptions: {
+    // required for badge columns
+    renderItemBadge(
+      data: unknown,
+      columnDefinition: BadgeColumnDefinition,
+    ): { label: string; variant: "critical" | "positive" | "info" };
+  };
+}
+
+type ColumnDefinition =
+  | TextColumnDefinition
+  | NumberColumnDefinition
+  | PriceColumnDefinition
+  | BadgeColumnDefinition;
+```
+
+### Custom cell rendering
+
+To take over the rendering of a column entirely, use the dynamic `column-<property>` slot. It receives the row data and the column definition:
+
+```html
+<mt-data-table :data-source="dataSource" :columns="columns">
+  <template #column-status="{ data, columnDefinition }">
+    <my-status-indicator :status="data.status" />
+  </template>
+</mt-data-table>
+```
+
+The slot name is derived from the column's `property`, so a column with `property: "status"` is customized through `#column-status`.
 
 ## Managing data
 

--- a/apps/docs/content/2.components/entity-select.md
+++ b/apps/docs/content/2.components/entity-select.md
@@ -35,6 +35,8 @@ import { MtEntitySelect } from "@shopware-ag/meteor-component-library";
 
 :component-api
 
+**Entity Select** wraps [**Select**](/components/select) and forwards all additional attributes and slots to it. Beyond the props listed above, the rest of the `MtSelect` API is available — for example `label`, `placeholder`, `error`, `hint`, and `small`, as well as slots such as `result-item`. The exceptions are `options`, `isLoading`, and `searchFunction`, which **Entity Select** manages itself through the repository.
+
 ## Best practices
 
 ::do-dont{vertical}

--- a/apps/docs/content/2.components/grant-permission-service-banner.md
+++ b/apps/docs/content/2.components/grant-permission-service-banner.md
@@ -1,0 +1,38 @@
+---
+title: Grant Permission Service Banner
+description: A banner that asks users to grant the permissions a Shopware Service needs before it can be activated.
+---
+
+## Usage
+
+**Grant Permission Service Banner** displays a permission request for a Shopware Service, with a primary action to grant the permissions and a secondary link to more information. It is intended for internal Shopware Services only.
+
+```ts
+import { MtGrantPermissionServiceBanner } from "@shopware-ag/meteor-component-library";
+```
+
+```html
+<template>
+  <mt-grant-permission-service-banner
+    @grant-success="onGranted"
+    @grant-error="onGrantFailed"
+  />
+</template>
+```
+
+## API reference
+
+:component-api
+
+## Behavior
+
+- The banner manages its own visibility through the [`useServicePermission`](/utilities/composables/use-service-permission) composable: it renders only while permissions still need to be granted and hides itself after a successful grant.
+- Clicking the primary action runs the grant flow and emits `grant-success` on success or `grant-error` with the error on failure.
+- The more-info action opens the Shopware Services documentation in a new tab and emits `more-info`.
+- Title, description, and action labels are built in and localized (English and German); they cannot be overridden.
+- The layout adapts to the width of its container, switching from a stacked to a horizontal arrangement as space allows.
+
+## Related
+
+- [**useServicePermission**](/utilities/composables/use-service-permission): the composable the banner uses, for building custom permission UI instead.
+- [**Banner**](/components/banner): for general inline notices that are not tied to service permissions.

--- a/apps/docs/content/2.components/modal.md
+++ b/apps/docs/content/2.components/modal.md
@@ -43,9 +43,9 @@ In most cases you open a modal through a trigger. Wrap the related parts in `mt-
       <template #default>This is my modal</template>
 
       <template #footer>
-        <mt-button-close :as="MtButton" variant="secondary">
+        <mt-modal-close :as="MtButton" variant="secondary">
           Close
-        </mt-button-close>
+        </mt-modal-close>
       </template>
     </mt-modal>
 
@@ -110,7 +110,25 @@ To open a modal from something other than a trigger, control the open state dire
 
 ## API reference
 
+### MtModal
+
 :component-api
+
+### MtModalRoot
+
+:component-api{name="MtModalRoot"}
+
+### MtModalTrigger
+
+:component-api{name="MtModalTrigger"}
+
+### MtModalAction
+
+:component-api{name="MtModalAction"}
+
+### MtModalClose
+
+:component-api{name="MtModalClose"}
 
 ## Best practices
 

--- a/apps/docs/content/2.components/modal.md
+++ b/apps/docs/content/2.components/modal.md
@@ -153,6 +153,7 @@ To open a modal from something other than a trigger, control the open state dire
 - `mt-modal-trigger`, `mt-modal-action`, and `mt-modal-close` support common opening and closing flows.
 - `mt-modal-action` receives a `done` callback so you can run work, such as a network request, before the modal closes.
 - Use the `isOpen` prop on `mt-modal-root` to control the open state directly when something other than a trigger opens the modal.
+- Set `closable` to `false` on `mt-modal-root` to prevent users from dismissing the modal themselves: it disables closing via backdrop click and the Escape key and hides the header close button, so the modal only closes through your own actions, such as `mt-modal-action` or controlled state.
 - Footer actions are usually the clearest place for confirmation and cancellation controls.
 
 ## Accessibility

--- a/apps/docs/content/2.components/popover.md
+++ b/apps/docs/content/2.components/popover.md
@@ -34,7 +34,17 @@ These parts are exported together so the pattern can be composed in one place.
 
 ## API reference
 
+### MtPopover
+
 :component-api
+
+### MtPopoverItem
+
+:component-api{name="MtPopoverItem"}
+
+### MtPopoverItemResult
+
+:component-api{name="MtPopoverItemResult"}
 
 ## Best practices
 

--- a/apps/docs/content/2.components/radio-group.md
+++ b/apps/docs/content/2.components/radio-group.md
@@ -41,7 +41,25 @@ Build fully custom option cards while keeping the shared radio-group state.
 
 ## API reference
 
+### MtRadioGroupRoot
+
 :component-api{name="MtRadioGroupRoot"}
+
+### MtRadioGroupList
+
+:component-api{name="MtRadioGroupList"}
+
+### MtRadioGroupItem
+
+:component-api{name="MtRadioGroupItem"}
+
+### MtRadioGroupCustomItem
+
+:component-api{name="MtRadioGroupCustomItem"}
+
+### MtRadioGroupIndicator
+
+:component-api{name="MtRadioGroupIndicator"}
 
 ## Best practices
 

--- a/apps/docs/content/2.components/text-editor.md
+++ b/apps/docs/content/2.components/text-editor.md
@@ -324,7 +324,15 @@ The component exposes a `validate()` method through a template ref. It checks th
 
 ## API reference
 
+### MtTextEditor
+
 :component-api
+
+### MtTextEditorToolbarButton
+
+Use this component inside a `button_<name>` slot to render a custom toolbar button that matches the built-in ones.
+
+:component-api{name="MtTextEditorToolbarButton"}
 
 ## Best practices
 

--- a/apps/docs/content/3.utilities/components/theme-provider.md
+++ b/apps/docs/content/3.utilities/components/theme-provider.md
@@ -34,6 +34,10 @@ The `future` prop takes an object. All flags default to `false`, so behavior is 
 | Opt into everything | `{ all: true }` |
 | Opt into everything except one | `{ all: true, removeCardWidth: false }` |
 
+## API reference
+
+:component-api{name="MtThemeProvider"}
+
 ## Future flags
 
 | Flag | Effect |

--- a/apps/docs/modules/meteor-components.ts
+++ b/apps/docs/modules/meteor-components.ts
@@ -24,12 +24,20 @@ export default defineNuxtModule({
     );
 
     const entries = await readdir(componentsRoot, { recursive: true });
-    // _internal components are excluded from the API docs, except
-    // mt-floating-ui which is publicly exported and has its own page.
+    // _internal components are excluded from the API docs, except the
+    // publicly exported ones that live in an _internal folder.
+    // mt-text-editor-toolbar-button is matched with its extension so the
+    // internal -color/-link/-table toolbar buttons stay excluded.
+    const internalExemptions = [
+      "mt-floating-ui",
+      "mt-text-editor-toolbar-button.vue",
+      "mt-grant-permission-service-banner",
+    ];
     const componentFiles = entries.filter(
       (file) =>
         /(^|\/)mt-[\w-]+\.vue$/.test(file) &&
-        (!file.includes("_internal") || file.includes("mt-floating-ui")),
+        (!file.includes("_internal") ||
+          internalExemptions.some((exemption) => file.includes(exemption))),
     );
 
     interface MetaParserOptions {


### PR DESCRIPTION
## Documentation: close component API gaps

We audited all component documentation against the library's public exports and found that consumers had to read source code to discover a significant part of the configurable surface. This PR closes those gaps — docs and docs tooling only, no component code changes.

### Why these gaps existed

The API tables are auto-generated (`nuxt-component-meta` → `:component-api`), which has three blind spots:

1. Components under `_internal/` are excluded from meta generation entirely — including two **publicly exported** components that happen to live there.
2. Only *declared* props are extracted, so props forwarded to Reka UI primitives via attribute fallthrough were invisible.
3. Every page rendered exactly one API table, so compound-component parts (e.g. `MtModalRoot`) had none.

### Changes

#### API tables for compound component parts

Added `:component-api{name="..."}` blocks for 15 exported components that previously had no table anywhere:

| Page | New tables |
| --- | --- |
| `modal` | `MtModalRoot`, `MtModalTrigger`, `MtModalAction`, `MtModalClose` |
| `radio-group` | `MtRadioGroupList`, `MtRadioGroupItem`, `MtRadioGroupCustomItem`, `MtRadioGroupIndicator` |
| `collapsible` | `MtCollapsibleTrigger`, `MtCollapsibleContent` |
| `action-menu` | `MtActionMenuItem`, `MtActionMenuGroup` |
| `popover` | `MtPopoverItem`, `MtPopoverItemResult` |
| `theme-provider` | `MtThemeProvider` |

Also fixes a broken example in `modal.md` (`<mt-button-close>` → `<mt-modal-close>`).

#### Forwarded Reka UI props

The Reka wrappers accept far more than their declared props via Vue attribute fallthrough. This is now documented (verified against the installed `reka-ui` 2.9.9 and with runtime tests):

- **`mt-action-menu`**: table of the forwarded `DropdownMenuContent` positioning/behavior props (`side`, `align`, `side-offset`, collision handling, `loop`, `force-mount`, …), the forwarded dismissal events, that consumer attrs override the pinned defaults, and the submenu caveat (`side`/`align` have no effect with `is-sub-menu`).
- **`mt-action-menu-item`**: `@select` (with `event.preventDefault()` to keep the menu open — the component's primary interaction API, previously undocumented), `text-value`, `as-child`, and that `@select` never fires on `is-sub-trigger` items.
- **`MtDropdownMenuRoot` / `Trigger` / `Portal` / `Sub`**: hand-written prop sections for the re-exported Reka primitives (`modal`, `v-model:open`, portal `to`, trigger `disabled`, …), which can never be auto-generated.
- **`mt-collapsible`**: note that `keep-mounted` maps to Reka's `unmount-on-hide` (inverted) and that passing `unmount-on-hide` directly silently overrides it.

#### Remaining gap fills

- **`meteor-components.ts`**: the `_internal` exclusion now exempts the two publicly exported components trapped by it — `MtTextEditorToolbarButton` (matched with its file extension so the internal `-color`/`-link`/`-table` toolbar buttons stay excluded) and `MtGrantPermissionServiceBanner`.
- **New page**: `grant-permission-service-banner.md` — the component was exported with zero documentation.
- **`text-editor.md`**: API table for `MtTextEditorToolbarButton`.
- **`data-table.md`**: the `ColumnDefinition` snippet now matches the real discriminated union — the missing `badge` renderer, the **required** `rendererOptions` for `price`/`badge` columns, `clickable`, `previewImage`, and `cellWrap` — and documents the dynamic `column-<property>` slot for custom cell rendering.
- **`entity-select.md`**: notes that all additional attributes and slots are forwarded to `MtSelect` (except the internally managed `options`, `isLoading`, `searchFunction`).
- **`modal.md`**: explains what `closable: false` on `mt-modal-root` actually does (disables backdrop/Escape close, hides the header close button).

### Verification

- Full docs build passes; all new `:component-api` references resolve to generated metadata, and the exemptions didn't leak any other `_internal` components into the meta index.
- The Reka passthrough claims were verified with runtime tests mounting the real components (`side`/`align` overrides land on the content, `@select` fires and `preventDefault()` keeps the menu open, `@escape-key-down` is received). The tests were for verification only and are not part of this PR.

No changeset: only the private `meteor-docs` app is touched, no published package changes.

