### PR TITLE
fix(component-library): load mt-datepicker locales through static imports

### DIFF
--- a/.changeset/datepicker-locale-loader-map.md
+++ b/.changeset/datepicker-locale-loader-map.md
@@ -2,4 +2,4 @@
 "@shopware-ag/meteor-component-library": patch
 ---
 
-mt-datepicker: fix the `locale` prop not applying in production builds. The date-fns locale was loaded through a runtime-constructed dynamic import that bundlers cannot statically analyze, so the import failed in consumer builds and the datepicker silently fell back to English month and weekday names. Locales are now loaded through statically analyzable imports, so every date-fns locale works in Vite, webpack and Rollup builds. Locale lookup is also case-insensitive now (e.g. `DE` or `en-gb` work).
+mt-datepicker: fix the `locale` prop not applying in production builds. The date-fns locale was loaded through a runtime-constructed dynamic import that bundlers cannot statically analyze, so the import failed in consumer builds and the datepicker silently fell back to English month and weekday names. Locales are now loaded through statically analyzable imports and `date-fns` is no longer bundled into the package, so the consumer's bundler code-splits each locale into a lazy chunk that is only loaded when needed. Locale lookup is also case-insensitive now (e.g. `DE` or `en-gb` work).

--- a/.changeset/datepicker-locale-loader-map.md
+++ b/.changeset/datepicker-locale-loader-map.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": patch
+---
+
+mt-datepicker: fix the `locale` prop not applying in production builds. The date-fns locale was loaded through a runtime-constructed dynamic import that bundlers cannot statically analyze, so the import failed in consumer builds and the datepicker silently fell back to English month and weekday names. Locales are now loaded through statically analyzable imports, so every date-fns locale works in Vite, webpack and Rollup builds. Locale lookup is also case-insensitive now (e.g. `DE` or `en-gb` work).

--- a/packages/component-library/.size-limit.ts
+++ b/packages/component-library/.size-limit.ts
@@ -1,7 +1,9 @@
 import type { SizeLimitConfig } from "size-limit";
 import { external } from "./vite.config";
 
-const ignore = [...external];
+// esbuild externalizes subpath imports only via a wildcard, so `date-fns/*`
+// covers the lazily imported locale modules (e.g. `date-fns/locale/de`).
+const ignore = [...external, "date-fns/*"];
 
 module.exports = [
   {

--- a/packages/component-library/src/components/mt-datepicker/date-fns-locale.spec.ts
+++ b/packages/component-library/src/components/mt-datepicker/date-fns-locale.spec.ts
@@ -22,8 +22,17 @@ describe("date-fns locale resolver", () => {
     expect(resolveDateFnsLocaleModule("de", { default: de })).toBe(de);
   });
 
+  it("imports locale paths case-insensitively", async () => {
+    await expect(importDateFnsLocaleModule("DE")).resolves.toBe(de);
+    await expect(importDateFnsLocaleModule("EN-gb")).resolves.toBe(enGB);
+  });
+
   it("rejects unsafe locale import paths", async () => {
     await expect(importDateFnsLocaleModule("../format")).resolves.toBeNull();
     await expect(importDateFnsLocaleModule("en/US")).resolves.toBeNull();
+  });
+
+  it("returns null for unknown locale paths", async () => {
+    await expect(importDateFnsLocaleModule("not-a-locale")).resolves.toBeNull();
   });
 });

--- a/packages/component-library/src/components/mt-datepicker/date-fns-locale.ts
+++ b/packages/component-library/src/components/mt-datepicker/date-fns-locale.ts
@@ -9,10 +9,6 @@ function isDateFnsLocale(value: unknown): value is Locale {
   return typeof value === "object" && value !== null && "localize" in value;
 }
 
-function isSafeLocalePath(path: string): boolean {
-  return /^[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*$/.test(path);
-}
-
 export function resolveDateFnsLocaleModule(
   path: string,
   localeModule: DateFnsLocaleModule,
@@ -35,16 +31,118 @@ export function resolveDateFnsLocaleModule(
   return candidates.find(isDateFnsLocale) ?? null;
 }
 
+// Every loader uses a literal import specifier on purpose. A specifier
+// constructed at runtime (e.g. `import(`date-fns/locale/${path}`)`) cannot be
+// statically analyzed by bundlers, so the import rejects in production builds
+// and the datepicker silently falls back to enUS. Keys are lowercase BCP 47
+// tags of the locales shipped by date-fns v4; lookup is case-insensitive.
+const localeLoaders: Record<string, () => Promise<unknown>> = {
+  af: () => import("date-fns/locale/af"),
+  ar: () => import("date-fns/locale/ar"),
+  "ar-dz": () => import("date-fns/locale/ar-DZ"),
+  "ar-eg": () => import("date-fns/locale/ar-EG"),
+  "ar-ma": () => import("date-fns/locale/ar-MA"),
+  "ar-sa": () => import("date-fns/locale/ar-SA"),
+  "ar-tn": () => import("date-fns/locale/ar-TN"),
+  az: () => import("date-fns/locale/az"),
+  be: () => import("date-fns/locale/be"),
+  "be-tarask": () => import("date-fns/locale/be-tarask"),
+  bg: () => import("date-fns/locale/bg"),
+  bn: () => import("date-fns/locale/bn"),
+  bs: () => import("date-fns/locale/bs"),
+  ca: () => import("date-fns/locale/ca"),
+  ckb: () => import("date-fns/locale/ckb"),
+  cs: () => import("date-fns/locale/cs"),
+  cy: () => import("date-fns/locale/cy"),
+  da: () => import("date-fns/locale/da"),
+  de: () => import("date-fns/locale/de"),
+  "de-at": () => import("date-fns/locale/de-AT"),
+  el: () => import("date-fns/locale/el"),
+  "en-au": () => import("date-fns/locale/en-AU"),
+  "en-ca": () => import("date-fns/locale/en-CA"),
+  "en-gb": () => import("date-fns/locale/en-GB"),
+  "en-ie": () => import("date-fns/locale/en-IE"),
+  "en-in": () => import("date-fns/locale/en-IN"),
+  "en-nz": () => import("date-fns/locale/en-NZ"),
+  "en-us": () => import("date-fns/locale/en-US"),
+  "en-za": () => import("date-fns/locale/en-ZA"),
+  eo: () => import("date-fns/locale/eo"),
+  es: () => import("date-fns/locale/es"),
+  et: () => import("date-fns/locale/et"),
+  eu: () => import("date-fns/locale/eu"),
+  "fa-ir": () => import("date-fns/locale/fa-IR"),
+  fi: () => import("date-fns/locale/fi"),
+  fr: () => import("date-fns/locale/fr"),
+  "fr-ca": () => import("date-fns/locale/fr-CA"),
+  "fr-ch": () => import("date-fns/locale/fr-CH"),
+  fy: () => import("date-fns/locale/fy"),
+  gd: () => import("date-fns/locale/gd"),
+  gl: () => import("date-fns/locale/gl"),
+  gu: () => import("date-fns/locale/gu"),
+  he: () => import("date-fns/locale/he"),
+  hi: () => import("date-fns/locale/hi"),
+  hr: () => import("date-fns/locale/hr"),
+  ht: () => import("date-fns/locale/ht"),
+  hu: () => import("date-fns/locale/hu"),
+  hy: () => import("date-fns/locale/hy"),
+  id: () => import("date-fns/locale/id"),
+  is: () => import("date-fns/locale/is"),
+  it: () => import("date-fns/locale/it"),
+  "it-ch": () => import("date-fns/locale/it-CH"),
+  ja: () => import("date-fns/locale/ja"),
+  "ja-hira": () => import("date-fns/locale/ja-Hira"),
+  ka: () => import("date-fns/locale/ka"),
+  kk: () => import("date-fns/locale/kk"),
+  km: () => import("date-fns/locale/km"),
+  kn: () => import("date-fns/locale/kn"),
+  ko: () => import("date-fns/locale/ko"),
+  lb: () => import("date-fns/locale/lb"),
+  lt: () => import("date-fns/locale/lt"),
+  lv: () => import("date-fns/locale/lv"),
+  mk: () => import("date-fns/locale/mk"),
+  mn: () => import("date-fns/locale/mn"),
+  ms: () => import("date-fns/locale/ms"),
+  mt: () => import("date-fns/locale/mt"),
+  nb: () => import("date-fns/locale/nb"),
+  nl: () => import("date-fns/locale/nl"),
+  "nl-be": () => import("date-fns/locale/nl-BE"),
+  nn: () => import("date-fns/locale/nn"),
+  oc: () => import("date-fns/locale/oc"),
+  pl: () => import("date-fns/locale/pl"),
+  pt: () => import("date-fns/locale/pt"),
+  "pt-br": () => import("date-fns/locale/pt-BR"),
+  ro: () => import("date-fns/locale/ro"),
+  ru: () => import("date-fns/locale/ru"),
+  se: () => import("date-fns/locale/se"),
+  sk: () => import("date-fns/locale/sk"),
+  sl: () => import("date-fns/locale/sl"),
+  sq: () => import("date-fns/locale/sq"),
+  sr: () => import("date-fns/locale/sr"),
+  "sr-latn": () => import("date-fns/locale/sr-Latn"),
+  sv: () => import("date-fns/locale/sv"),
+  ta: () => import("date-fns/locale/ta"),
+  te: () => import("date-fns/locale/te"),
+  th: () => import("date-fns/locale/th"),
+  tr: () => import("date-fns/locale/tr"),
+  ug: () => import("date-fns/locale/ug"),
+  uk: () => import("date-fns/locale/uk"),
+  uz: () => import("date-fns/locale/uz"),
+  "uz-cyrl": () => import("date-fns/locale/uz-Cyrl"),
+  vi: () => import("date-fns/locale/vi"),
+  "zh-cn": () => import("date-fns/locale/zh-CN"),
+  "zh-hk": () => import("date-fns/locale/zh-HK"),
+  "zh-tw": () => import("date-fns/locale/zh-TW"),
+};
+
 export async function importDateFnsLocaleModule(path: string): Promise<Locale | null> {
-  if (!isSafeLocalePath(path)) {
+  const loader = localeLoaders[path.toLowerCase()];
+
+  if (!loader) {
     return null;
   }
 
   try {
-    const localeModule = (await import(
-      /* @vite-ignore */
-      `date-fns/locale/${path}`
-    )) as DateFnsLocaleModule;
+    const localeModule = (await loader()) as DateFnsLocaleModule;
 
     return resolveDateFnsLocaleModule(path, localeModule);
   } catch {

--- a/packages/component-library/src/components/mt-datepicker/mt-datepicker.spec.ts
+++ b/packages/component-library/src/components/mt-datepicker/mt-datepicker.spec.ts
@@ -706,6 +706,13 @@ describe("mt-datepicker", () => {
     await userEvent.click(screen.getByRole("textbox"));
     await waitUntil(() => document.querySelector(".dp__menu") !== null);
 
+    // The locale is loaded asynchronously, so wait until it is applied
+    await waitUntil(() =>
+      document
+        .querySelector('[data-test-id="month-toggle-overlay-0"]')
+        ?.textContent?.includes("juil."),
+    );
+
     const monthLabel = document.querySelector('[data-test-id="month-toggle-overlay-0"]');
     expect(monthLabel).toHaveTextContent("juil.");
   });

--- a/packages/component-library/vite.config.ts
+++ b/packages/component-library/vite.config.ts
@@ -11,7 +11,13 @@ import { emitInterFontAssets, getAllComponents, libInjectCss, toPascalCase } fro
 // Get all components and their paths
 const allComponents = getAllComponents();
 
-export const external = ["vue", "apexcharts", "vue-i18n"];
+export const external = ["vue", "apexcharts", "vue-i18n", "date-fns"];
+
+// Rollup treats string entries as exact matches, so subpath imports like
+// `date-fns/locale/de` need an explicit check. Keeping them external lets the
+// consumer's bundler code-split each locale into a lazy chunk instead of
+// shipping all locales inside this package.
+const isExternal = (id: string) => external.includes(id) || id.startsWith("date-fns/");
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -100,7 +106,7 @@ export default defineConfig({
     },
     cssCodeSplit: true,
     rollupOptions: {
-      external: external,
+      external: isExternal,
       output: {
         globals: {
           vue: "Vue",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What?

Fixes the `mt-datepicker` `locale` prop not applying in production builds: the datepicker always showed English month and weekday names no matter which locale was passed.

## Why?

The date-fns locale was loaded through a runtime-constructed dynamic import:

```ts
await import(/* @vite-ignore */ `date-fns/locale/${path}`)
```

Bundlers cannot statically analyze that specifier. In consumer production builds (Vite, webpack) the import rejects at runtime, the `catch` swallows it, and the component silently falls back to `enUS`. It only ever worked in dev/test environments where the import is resolved by the dev server.

A symptom visible in this repo: the `should display the correct locale when a locale string is given` spec failed consistently on `main` (expected `juil.`, got `Jul`).

## How?

- `date-fns-locale.ts` now uses an explicit loader map covering all 95 date-fns v4 locales, each with a literal `import("date-fns/locale/xx")` specifier that any bundler can statically analyze.
- `date-fns` is now external in the library build (like `vue` and `vue-i18n` already are). The dist output keeps the literal `import("date-fns/locale/xx")` specifiers, so the **consumer's** bundler code-splits each locale into a lazy chunk that is only loaded when needed — no locale data is shipped inside the package. `date-fns` remains a declared dependency, so consumers need no setup change. Side effect: the datepicker chunk shrinks (412 kB → 316 kB unminified) because date-fns core is no longer bundled either.
- Locale lookup is now case-insensitive (`DE`, `en-gb`, … all work); unknown or unsafe paths still return `null` and fall back to `enUS`.
- The existing module-shape resolver from #1161 is unchanged.
- `.size-limit.ts` ignores `date-fns/*` so the lazily loaded locales are not counted (esbuild only externalizes subpaths via wildcard).

## Testing?

- Fixed the race in `mt-datepicker.spec.ts`: the locale swap is asynchronous, so the spec now waits until the French month label is applied instead of asserting immediately after the menu opens.
- Added `date-fns-locale.spec.ts` coverage for case-insensitive imports and unknown locale paths.
- Full component-library suite passes: 55 files, 781 tests.
- `lint:types` (vue-tsc), ESLint and Prettier pass.
- `size-limit` passes: `index.js` is 915 kB against the 950 kB limit (was 1020 kB when the locales were bundled into dist).
- Verified the Vite library build emits analyzable `import("date-fns/locale/xx")` specifiers in both ESM and CJS outputs.

## Screenshots (optional)

## Anything Else?

Includes a patch changeset for `@shopware-ag/meteor-component-library`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f228a536-319b-47e7-91b5-e40ee2062a4d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f228a536-319b-47e7-91b5-e40ee2062a4d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

