### PR TITLE
fix(component-library): make mt-tooltip content prop reactive

### DIFF
--- a/.changeset/fix-mt-tooltip-content-reactivity.md
+++ b/.changeset/fix-mt-tooltip-content-reactivity.md
@@ -1,0 +1,5 @@
+---
+"@shopware-ag/meteor-component-library": patch
+---
+
+Fix `mt-tooltip` not updating when the `content` prop changes

--- a/packages/component-library/src/components/mt-tooltip/mt-tooltip.spec.ts
+++ b/packages/component-library/src/components/mt-tooltip/mt-tooltip.spec.ts
@@ -1121,4 +1121,48 @@ describe("mt-tooltip", () => {
     // ASSERT
     expect(screen.getByRole("tooltip", { name: "Tooltip" })).toBeVisible();
   });
+
+  it("updates the accessible description when the content changes", async () => {
+    // ARRANGE
+    const { rerender } = render(MtTooltip, {
+      props: {
+        content: "First",
+      },
+      slots: {
+        default: "<button v-bind='params'>Open tooltip</button>",
+      },
+    });
+
+    // ACT
+    await rerender({ content: "Second" });
+
+    // ASSERT
+    expect(screen.getByRole("button", { name: "Open tooltip" })).toHaveAccessibleDescription(
+      "Second",
+    );
+  });
+
+  it("updates the content of an open tooltip when the content changes", async () => {
+    // ARRANGE
+    const { rerender } = render(MtTooltip, {
+      props: {
+        content: "First",
+      },
+      slots: {
+        default: "<button v-bind='params'>Open tooltip</button>",
+      },
+    });
+
+    const user = userEvent.setup({
+      advanceTimers: vi.advanceTimersByTime,
+    });
+
+    await user.tab();
+
+    // ACT
+    await rerender({ content: "Second" });
+
+    // ASSERT
+    expect(screen.getByRole("tooltip")).toHaveTextContent("Second");
+  });
 });

--- a/packages/component-library/src/components/mt-tooltip/mt-tooltip.vue
+++ b/packages/component-library/src/components/mt-tooltip/mt-tooltip.vue
@@ -73,7 +73,17 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, ref, nextTick, computed, provide, useId, type ComputedRef } from "vue";
+import {
+  onMounted,
+  ref,
+  nextTick,
+  computed,
+  provide,
+  useId,
+  toValue,
+  type ComputedRef,
+  type MaybeRefOrGetter,
+} from "vue";
 import {
   autoUpdate,
   flip,
@@ -105,7 +115,7 @@ const props = withDefaults(
   },
 );
 
-const sanitizedContent = useSanitizedHtml(props.content);
+const sanitizedContent = useSanitizedHtml(() => props.content);
 
 const id = useId();
 
@@ -203,9 +213,9 @@ provide(TooltipContext, true);
  * It returns the value as a computed read-only property.
  * The sanitization is done using the `sanitize` function from DOMPurify.
  */
-function useSanitizedHtml(html: string): ComputedRef<string> {
+function useSanitizedHtml(html: MaybeRefOrGetter<string>): ComputedRef<string> {
   return computed(() => {
-    return DOMPurify.sanitize(html, {
+    return DOMPurify.sanitize(toValue(html), {
       ALLOWED_TAGS: ["a", "b", "br", "strong", "i", "em", "u", "s", "li", "ul", "img", "svg"],
     });
   });


### PR DESCRIPTION
## What?

Makes the `content` prop of `mt-tooltip` reactive. Until now the tooltip rendered its `content`
once, at setup, and ignored every later change to the bound value for the lifetime of the
component — no error, no warning, the text just went stale.

## Why?

The `content` prop is documented and typed as a normal prop, so consumers reasonably bind a
computed or template literal to it. This also affects everything that forwards a tooltip, most
visibly the `helpText` prop on form components (`mt-switch`, `mt-number-field`, …), which renders
`mt-help-text` → `<mt-tooltip :content="text">`.

Minimal reproduction:

```vue
<script setup>
import { ref } from "vue";
const count = ref(1);
</script>

<template>
  <button @click="count++">increment</button>
  <mt-switch :help-text="`assigned: ${count}`" label="Example" />
</template>
```

Clicking the button and opening the help tooltip shows `assigned: 1` no matter how often you
increment. Re-opening, blurring and re-focusing all keep the stale text — the
`.mt-tooltip__content` span persists in the DOM holding the original string, so this is not a
re-open or timing artefact.

This is a regression from #657 (*"feat: allow specific sanitized HTML values inside tooltip"*),
which introduced the `useSanitizedHtml` helper. Before that, the content was bound directly in
the template and stayed reactive.

## How?

`useSanitizedHtml` was typed to take a plain `string`:

```ts
const sanitizedContent = useSanitizedHtml(props.content);

function useSanitizedHtml(html: string): ComputedRef<string> {
  return computed(() => DOMPurify.sanitize(html, { /* … */ }));
}
```

`props.content` is therefore dereferenced *at the call site* and the resulting plain string is
captured in the closure. The `computed()` never reads a reactive source: it registers no
dependency, nothing invalidates its cache, and it returns the same sanitized string forever. The
`computed()` wrapper makes this look reactive at a glance — reactivity is lost one line earlier.

The fix accepts a `MaybeRefOrGetter<string>` and reads it with `toValue()` *inside* the computed,
so the dependency is registered on every re-evaluation:

```ts
const sanitizedContent = useSanitizedHtml(() => props.content);

function useSanitizedHtml(html: MaybeRefOrGetter<string>): ComputedRef<string> {
  return computed(() => DOMPurify.sanitize(toValue(html), { /* … */ }));
}
```

`useSanitizedHtml` is file-local to `mt-tooltip.vue` with exactly one call site, so widening the
parameter type is contained. Keeping the named helper (rather than inlining the sanitize call)
follows the usual Vue/VueUse convention for composables that accept reactive input. `toValue`
needs Vue 3.3+; the repo is on 3.5.x.

## Testing?

Two tests added to `mt-tooltip.spec.ts`, both of which fail on `main` and pass with this change:

- `updates the accessible description when the content changes` — covers the cheap path, without
  opening the tooltip.
- `updates the content of an open tooltip when the content changes` — covers the rendered node of
  an already-open tooltip.

From `packages/component-library`:

- `vitest run` — 781 passed, 2 skipped, 55 files.
- `pnpm run lint:types` — clean.
- `pnpm run lint:eslint` — no new errors or warnings on the touched files.

A patch changeset for `@shopware-ag/meteor-component-library` is included.

## Anything Else?

- Origin of the regression: #657.
- Neighbouring report on the same component and the same `helpText` path, different failure mode
  (interaction rather than content): #939.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
